### PR TITLE
fix(security): contain mission slugs and gate /fs browse to loopback

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,3 +9,6 @@ paths-ignore:
   - missions
   # Generated Next.js bundle. The authored sources under frontend/ are analysed instead.
   - src/xorcise/core/frontend/_static
+  # Test code is not attack surface, and its idioms read as findings: tmp_path fixtures
+  # flag as path injection, `in` assertions on built URLs as incomplete sanitization.
+  - tests

--- a/src/xorcise/core/missions/ingest.py
+++ b/src/xorcise/core/missions/ingest.py
@@ -16,9 +16,18 @@ from pathlib import Path
 from xorcise.core.contracts.control import MissionRef
 from xorcise.core.contracts.mission import MissionManifest
 from xorcise.core.missions.builder import BundleBuilder
-from xorcise.core.missions.errors import AttachmentBundleError, MissionCollisionError
+from xorcise.core.missions.errors import (
+    AttachmentBundleError,
+    MissionCollisionError,
+    PreflightError,
+)
 from xorcise.core.missions.preflight import preflight
-from xorcise.core.missions.runtime import INSTALLED_FILE, InstalledMission, Origin
+from xorcise.core.missions.runtime import (
+    INSTALLED_FILE,
+    InstalledMission,
+    Origin,
+    resolve_install_dir,
+)
 
 
 def _copytree(src: Path, dst: Path) -> None:
@@ -70,9 +79,16 @@ def _atomic_install(
     installed.json is written; it should create/populate the staging directory.
     Version/origin are read from any existing install BEFORE the swap so the read is safe."""
     install_root.mkdir(parents=True, exist_ok=True)
+    # mission_id is third-party content (bundle/catalog manifest); a separator or '..' in it
+    # would put final — and staging/backup with their rmtree cleanups — outside the install root.
+    final = resolve_install_dir(slug, install_root)
+    if final is None:
+        raise PreflightError(
+            f"metadata.mission_id {slug!r} is not a usable install name "
+            "(must be a plain directory name: no separators, no '..')"
+        )
     staging = install_root / f".{slug}.tmp"
     backup = install_root / f".{slug}.bak"
-    final = install_root / slug
 
     # a mission_id belongs to one source. Read the existing record BEFORE we disturb
     # anything, so a cross-source collision leaves the prior install byte-for-byte intact (no

--- a/src/xorcise/core/missions/runtime.py
+++ b/src/xorcise/core/missions/runtime.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -107,12 +108,19 @@ def resolve_install_dir(slug: str, install_root: Path) -> Path | None:
     a direct child. Slugs arrive from REST path params, request bodies and bundle/catalog
     manifests; every install-store path is built through this choke point so a hostile
     slug (separators, '..', an absolute path) can never steer a read, write or rmtree
-    outside the install root."""
-    base = install_root.resolve()
-    root = (install_root / slug).resolve()
-    if not root.is_relative_to(base) or root.parent != base:
+    outside the install root.
+
+    os.path (not pathlib) on purpose: realpath + startswith is the containment idiom
+    CodeQL recognizes as a taint barrier, while Path.resolve() inside the guard reads as
+    one more unsanitized filesystem sink — "simplifying" back to pathlib re-opens the
+    py/path-injection alerts this function exists to close."""
+    base = os.path.realpath(install_root)
+    root = os.path.realpath(os.path.join(base, slug))
+    if not root.startswith(base + os.sep):
         return None
-    return root
+    if os.path.dirname(root) != base:  # direct child only — never a nested path
+        return None
+    return Path(root)
 
 
 def get_installed(slug: str, install_root: Path) -> InstalledMission | None:

--- a/src/xorcise/core/missions/runtime.py
+++ b/src/xorcise/core/missions/runtime.py
@@ -102,9 +102,22 @@ class InstalledMission:
         )
 
 
+def resolve_install_dir(slug: str, install_root: Path) -> Path | None:
+    """Resolve *slug* to its directory under *install_root*, or None unless it lands on
+    a direct child. Slugs arrive from REST path params, request bodies and bundle/catalog
+    manifests; every install-store path is built through this choke point so a hostile
+    slug (separators, '..', an absolute path) can never steer a read, write or rmtree
+    outside the install root."""
+    base = install_root.resolve()
+    root = (install_root / slug).resolve()
+    if not root.is_relative_to(base) or root.parent != base:
+        return None
+    return root
+
+
 def get_installed(slug: str, install_root: Path) -> InstalledMission | None:
-    root = install_root / slug
-    if not (root / INSTALLED_FILE).is_file():
+    root = resolve_install_dir(slug, install_root)
+    if root is None or not (root / INSTALLED_FILE).is_file():
         return None
     try:
         return InstalledMission.from_root(root)
@@ -135,10 +148,11 @@ def delete_installed(slug: str, install_root: Path) -> bool:
     Uninstalls the local copy — the same for a locally-ingested "your_own" mission and a pulled
     "library" one (a pulled mission has no remote state to reach beyond its local install). The
     fused image is intentionally left in the local store; pruning it is a separate concern. Guarded
-    on the INSTALLED_FILE marker so it never removes an unrelated directory.
+    on the INSTALLED_FILE marker so it never removes an unrelated directory, and on
+    resolve_install_dir so a path-shaped slug can never aim the rmtree outside the root.
     """
-    root = install_root / slug
-    if not (root / INSTALLED_FILE).is_file():
+    root = resolve_install_dir(slug, install_root)
+    if root is None or not (root / INSTALLED_FILE).is_file():
         return False
     shutil.rmtree(root)
     return True

--- a/src/xorcise/core/rest/routers/fs.py
+++ b/src/xorcise/core/rest/routers/fs.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from ipaddress import ip_address
+
+from fastapi import APIRouter, HTTPException, Request
 
 from xorcise.core.contracts.fs import FsListing
 from xorcise.core.rest.fs_browse import BrowseError, list_directory
@@ -10,9 +12,24 @@ from xorcise.core.rest.fs_browse import BrowseError, list_directory
 router = APIRouter(prefix="/fs", tags=["fs"])
 
 
+def _is_loopback_client(request: Request) -> bool:
+    """True only for a client connecting over this host's loopback. The picker surfaces
+    the server host's directory tree, so it answers the local operator alone — not LAN
+    peers under an explicit 0.0.0.0 bind, and not agent containers reaching /api over
+    the docker bridge gateway."""
+    if request.client is None:
+        return False
+    try:
+        return ip_address(request.client.host).is_loopback
+    except ValueError:  # not an IP literal (e.g. a test client placeholder) — fail closed
+        return False
+
+
 @router.get("/list")
-def list_fs(path: str | None = None) -> FsListing:
+def list_fs(request: Request, path: str | None = None) -> FsListing:
     """List one directory (names + is_dir). Defaults to the user's home directory."""
+    if not _is_loopback_client(request):
+        raise HTTPException(status_code=403, detail="filesystem browse is local-only")
     try:
         return list_directory(path)
     except BrowseError as exc:

--- a/tests/unit/test_fs_browse.py
+++ b/tests/unit/test_fs_browse.py
@@ -55,9 +55,15 @@ def test_file_target_raises(tmp_path: Path) -> None:
         list_directory(str(f))
 
 
+def _loopback_client() -> TestClient:
+    # The endpoint answers loopback clients only; TestClient's default placeholder
+    # ("testclient") must NOT pass the guard, so present a real loopback peer.
+    return TestClient(build_rest_app(), client=("127.0.0.1", 51000))
+
+
 def test_rest_list_ok(tmp_path: Path) -> None:
     _tree(tmp_path)
-    r = TestClient(build_rest_app()).get("/api/fs/list", params={"path": str(tmp_path)})
+    r = _loopback_client().get("/api/fs/list", params={"path": str(tmp_path)})
     assert r.status_code == 200
     body = r.json()
     assert body["path"] == str(tmp_path.resolve())
@@ -65,5 +71,16 @@ def test_rest_list_ok(tmp_path: Path) -> None:
 
 
 def test_rest_bad_path_is_400(tmp_path: Path) -> None:
-    r = TestClient(build_rest_app()).get("/api/fs/list", params={"path": str(tmp_path / "nope")})
+    r = _loopback_client().get("/api/fs/list", params={"path": str(tmp_path / "nope")})
     assert r.status_code == 400
+
+
+def test_rest_non_loopback_client_is_403(tmp_path: Path) -> None:
+    # Under an explicit 0.0.0.0 bind (or via the docker bridge interface) the host's
+    # directory tree must stay invisible: only the local operator on loopback may browse.
+    _tree(tmp_path)
+    for peer in ("192.168.1.50", "172.17.0.2", "testclient"):
+        r = TestClient(build_rest_app(), client=(peer, 40000)).get(
+            "/api/fs/list", params={"path": str(tmp_path)}
+        )
+        assert r.status_code == 403, peer

--- a/tests/unit/test_installed_slug_guard.py
+++ b/tests/unit/test_installed_slug_guard.py
@@ -1,0 +1,98 @@
+"""Hostile mission slugs must stay inside the install root (unit lane).
+
+Slugs reach the install store from REST path params, request bodies and bundle/catalog
+manifests. A slug carrying separators, '..' or an absolute path must read as "not
+installed" (reads) or fail preflight (installs) — never as a file read, write or rmtree
+outside the install root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xorcise.core.contracts.control import MissionRef
+from xorcise.core.contracts.mission import MissionManifest
+from xorcise.core.missions.errors import PreflightError
+from xorcise.core.missions.ingest import install_pulled
+from xorcise.core.missions.runtime import (
+    INSTALLED_FILE,
+    delete_installed,
+    get_installed,
+    resolve_install_dir,
+)
+
+pytestmark = pytest.mark.unit
+
+HOSTILE_SLUGS = (
+    "",
+    ".",
+    "..",
+    "../outside",
+    "a/../../outside",
+    "/etc",
+    "nested/child",
+)
+
+
+def _plant_marker(dirpath: Path) -> None:
+    dirpath.mkdir(parents=True, exist_ok=True)
+    (dirpath / INSTALLED_FILE).write_text("{}")
+
+
+@pytest.mark.parametrize("slug", HOSTILE_SLUGS)
+def test_resolve_install_dir_rejects_escaping_slugs(tmp_path: Path, slug: str) -> None:
+    assert resolve_install_dir(slug, tmp_path / "installs") is None
+
+
+def test_resolve_install_dir_accepts_a_plain_slug(tmp_path: Path) -> None:
+    root = resolve_install_dir("basic-pivot", tmp_path / "installs")
+    assert root == (tmp_path / "installs" / "basic-pivot").resolve()
+
+
+@pytest.mark.parametrize("slug", HOSTILE_SLUGS)
+def test_get_installed_rejects_escaping_slugs(tmp_path: Path, slug: str) -> None:
+    install_root = tmp_path / "installs"
+    _plant_marker(install_root)  # a marker in the root itself must not read as a mission
+    _plant_marker(tmp_path / "outside")  # reachable via '..' — must stay invisible
+    assert get_installed(slug, install_root) is None
+
+
+@pytest.mark.parametrize("slug", HOSTILE_SLUGS)
+def test_delete_installed_never_leaves_the_install_root(tmp_path: Path, slug: str) -> None:
+    install_root = tmp_path / "installs"
+    outside = tmp_path / "outside"
+    _plant_marker(install_root)
+    _plant_marker(outside)
+    assert delete_installed(slug, install_root) is False
+    assert outside.exists() and install_root.exists()
+
+
+def _manifest(mission_id: str) -> MissionManifest:
+    return MissionManifest.model_validate(
+        {
+            "schema_version": "2.0",
+            "metadata": {
+                "mission_id": mission_id,
+                "name": mission_id or "x",
+                "objective": "do the thing",
+                "type": "lab",
+            },
+            "environment": {},
+        }
+    )
+
+
+@pytest.mark.parametrize("slug", HOSTILE_SLUGS)
+def test_install_refuses_a_path_shaped_mission_id(tmp_path: Path, slug: str) -> None:
+    install_root = tmp_path / "installs"
+    with pytest.raises(PreflightError):
+        install_pulled(
+            manifest=_manifest(slug),
+            mission_ref=MissionRef(mission_id=slug, image=""),
+            install_root=install_root,
+        )
+    # nothing may have been written outside (or half-written inside) the install root
+    assert list(install_root.iterdir()) == []
+    assert not (tmp_path / "outside").exists()


### PR DESCRIPTION
## What

Closes the two valid finding clusters from the CodeQL code-scanning report and removes the scanner noise that buried them.

- **Mission slug path containment** (CodeQL py/path-injection #3–#6): slugs arrive from REST path params, request bodies and bundle/catalog manifests, and flowed unvalidated into `install_root / slug`. A new `resolve_install_dir()` choke point in `missions/runtime.py` rejects anything that does not resolve to a direct child of the install root. Reads (`get_installed`) degrade to "not installed", `delete_installed` refuses before its `rmtree`, and — beyond what CodeQL flagged — `_atomic_install` in `ingest.py` now routes its `final`/staging/backup paths through the same guard, so a crafted bundle `mission_id` like `a/../../x` can no longer write or delete outside the install root (fails preflight with a named error).
- **`GET /api/fs/list` answers loopback clients only** (hardens py/path-injection #1): the GUI file picker surfaces the server host's directory tree, so it now 403s any non-loopback peer — LAN clients under an explicit `0.0.0.0` bind, or agent containers reaching `/api` over the docker bridge gateway. The picker is not yet wired into the frontend/CLI, so no released behaviour changes.
- **`tests/` dropped from the CodeQL database**: test idioms read as findings (tmp_path fixtures as path injection #14–#15, substring assertions on built URLs as incomplete sanitization #16–#19). Real defects in tests surface through the test lanes, not the scanner.

The remaining open alerts (#2, #7–#13, #20–#22) were assessed as false positives (whitelisted `arch`, probe-only sockets, fixed error string) and are being dismissed on the alert tray with per-alert justifications, not code changes.

## Why

All 22 open code-scanning alerts were investigated against the code and the threat model (agent-facing runcontrol/OTLP surface = untrusted; operator `/api` = loopback-trusted). These are the two clusters where the taint flow is real; the slug fix is the only one reachable with today's wiring, and the write-path variant it uncovered (hostile bundle `mission_id`) is the more serious of the two.

## Tests

- New `tests/unit/test_installed_slug_guard.py`: hostile slugs (`..`, absolute, separator forms) across read, delete and install paths, plus the direct-child contract of `resolve_install_dir`.
- `tests/unit/test_fs_browse.py`: REST tests now present a real loopback peer; new 403 test for LAN/bridge/placeholder peers.
- Lanes run locally: unit (1917 passed), topology + adapters (144 passed), `ruff`, `mypy`, `lint-imports` all clean.