### PR TITLE
Refusal surfacing and trace chronology

### DIFF
--- a/frontend/src/features/agents/harness-profile.tsx
+++ b/frontend/src/features/agents/harness-profile.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/components/ui/cn";
 import {
   groupLevel,
+  groupNote,
   type GroupLevel,
   type DisplayGroup,
 } from "@/features/capabilities/capability-groups";
@@ -28,7 +29,8 @@ const REGISTRATION_GROUPS: readonly DisplayGroup[] = [
   { id: "files", label: "File edits", kinds: ["file_edit", "file_read"] },
   { id: "tools", label: "Tool calls", kinds: ["tool_call", "tool_result"] },
   { id: "mcp", label: "MCP", kinds: ["mcp_call", "mcp_result"] },
-  { id: "health", label: "Status / errors / metrics", kinds: ["status", "error", "metric"] },
+  { id: "refusals", label: "Model refusals", kinds: ["error"] },
+  { id: "health", label: "Status / metrics", kinds: ["status", "metric"] },
 ] as const;
 
 function registrationLevel(
@@ -131,25 +133,34 @@ export function HarnessProfile({
           {REGISTRATION_GROUPS.map((group) => {
             const level = registrationLevel(descriptor.capabilities, group);
             const supported = level !== "unsupported";
+            const note =
+              group.id === "refusals"
+                ? groupNote(descriptor.capabilities, group)
+                : undefined;
             return (
-              <li key={group.id} className="flex items-center gap-2 text-dense text-text-secondary">
+              <li key={group.id} className="flex items-start gap-2 text-dense text-text-secondary">
                 {isGeneric ? (
                   <CircleHelp
-                    className="size-4 shrink-0 text-primary"
+                    className="mt-0.5 size-4 shrink-0 text-primary"
                     aria-label={`${group.label}: unknown`}
                   />
                 ) : supported ? (
                   <CheckCircle2
-                    className="size-4 shrink-0 text-ok"
+                    className="mt-0.5 size-4 shrink-0 text-ok"
                     aria-label={`${group.label}: supported`}
                   />
                 ) : (
                   <XCircle
-                    className="size-4 shrink-0 text-err"
+                    className="mt-0.5 size-4 shrink-0 text-err"
                     aria-label={`${group.label}: not supported`}
                   />
                 )}
-                <span>{group.label}</span>
+                <span>
+                  {group.label}
+                  {!isGeneric && level !== "supported" && note && (
+                    <span className="block text-caption text-text-tertiary">{note}</span>
+                  )}
+                </span>
               </li>
             );
           })}

--- a/frontend/src/features/agents/register-agent-page.test.tsx
+++ b/frontend/src/features/agents/register-agent-page.test.tsx
@@ -133,7 +133,28 @@ describe("RegisterAgentPage — register mode", () => {
 
     expect(screen.getByLabelText(/user messages: supported/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/agent messages: not supported/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/model refusals: not supported/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("Model refusal details are not exported."),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/review visibility limitations/i)).not.toBeInTheDocument();
+  });
+
+  it("advertises refusal support for Claude Code and OpenHands", async () => {
+    renderWithProviders(<RegisterAgentPage editName={null} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /claude code/i }));
+    await waitFor(() =>
+      expect(screen.getByLabelText(/model refusals: supported/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("Model refusal details are not exported."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: /openhands/i }));
+    await waitFor(() =>
+      expect(screen.getByLabelText(/model refusals: supported/i)).toBeInTheDocument(),
+    );
   });
 
   it("shows custom harness export capabilities as unknown, not supported", async () => {
@@ -141,7 +162,7 @@ describe("RegisterAgentPage — register mode", () => {
     fireEvent.click(screen.getByRole("radio", { name: /custom/i }));
 
     await waitFor(() =>
-      expect(screen.getByText("8 unknown")).toBeInTheDocument(),
+      expect(screen.getByText("9 unknown")).toBeInTheDocument(),
     );
     expect(screen.getByLabelText(/user messages: unknown/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/agent messages: unknown/i)).toBeInTheDocument();
@@ -154,13 +175,17 @@ describe("RegisterAgentPage — register mode", () => {
 
     await waitFor(() => expect(screen.getByText("claude-opus-4-8")).toBeInTheDocument());
     fireEvent.click(screen.getByText("claude-opus-4-8"));
-    expect(screen.getByLabelText(/^model/i)).toHaveValue("claude-opus-4-8");
+    expect(screen.getByRole("combobox", { name: /^model/i })).toHaveValue(
+      "claude-opus-4-8",
+    );
 
     // Suggestions are shortcuts, not validation — arbitrary disclosed IDs remain accepted.
-    fireEvent.change(screen.getByLabelText(/^model/i), {
+    fireEvent.change(screen.getByRole("combobox", { name: /^model/i }), {
       target: { value: "my-provider/custom-model" },
     });
-    expect(screen.getByLabelText(/^model/i)).toHaveValue("my-provider/custom-model");
+    expect(screen.getByRole("combobox", { name: /^model/i })).toHaveValue(
+      "my-provider/custom-model",
+    );
   });
 
   it("adds the selected model to the Codex launch preview", async () => {
@@ -168,7 +193,7 @@ describe("RegisterAgentPage — register mode", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: /codex/i }));
     await screen.findByText(/codex exec/i);
-    fireEvent.change(screen.getByLabelText(/^model/i), {
+    fireEvent.change(screen.getByRole("combobox", { name: /^model/i }), {
       target: { value: "gpt-5.6-terra" },
     });
     await waitFor(() =>
@@ -184,7 +209,7 @@ describe("RegisterAgentPage — register mode", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: /claude code/i }));
     await screen.findByText(/claude --permission-mode/i);
-    fireEvent.change(screen.getByLabelText(/^model/i), {
+    fireEvent.change(screen.getByRole("combobox", { name: /^model/i }), {
       target: { value: "claude-sonnet-5" },
     });
     await waitFor(() =>
@@ -312,7 +337,7 @@ describe("RegisterAgentPage — edit mode", () => {
     );
     expect(screen.getByDisplayValue("claude-opus-4-8")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/^model/i), {
+    fireEvent.change(screen.getByRole("combobox", { name: /^model/i }), {
       target: { value: "claude-haiku" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
@@ -521,7 +546,7 @@ describe("RegisterAgentPage — edit mode", () => {
       expect(screen.getByDisplayValue("claude-opus-4-8")).toBeInTheDocument(),
     );
 
-    fireEvent.change(screen.getByLabelText(/^model/i), {
+    fireEvent.change(screen.getByRole("combobox", { name: /^model/i }), {
       target: { value: "typing-in-progress" },
     });
 

--- a/frontend/src/features/capabilities/capabilities.test.tsx
+++ b/frontend/src/features/capabilities/capabilities.test.tsx
@@ -52,7 +52,8 @@ describe("capability display groups", () => {
       "Tool calls",
       "MCP",
       "Findings & flags",
-      "Status / errors / metrics",
+      "Model refusals",
+      "Status / metrics",
     ]);
   });
 

--- a/frontend/src/features/capabilities/capability-gap-notes.test.tsx
+++ b/frontend/src/features/capabilities/capability-gap-notes.test.tsx
@@ -17,6 +17,7 @@ describe("CapabilityGapNotes", () => {
     expect(screen.getByText(/Agent messages/)).toBeInTheDocument();
     expect(screen.getByText(/partial/i)).toBeInTheDocument();
     expect(screen.getByText(/Codex CLI does not export thinking traces\./)).toBeInTheDocument();
+    expect(screen.getByText(/Model refusal details are not exported\./)).toBeInTheDocument();
   });
 
   it("omits un-noted structural gaps (they stay matrix-only)", async () => {

--- a/frontend/src/features/capabilities/capability-groups.ts
+++ b/frontend/src/features/capabilities/capability-groups.ts
@@ -1,6 +1,6 @@
 // Display grouping over AgentEventKind (XOR harness capability matrix). The wire profile is
 // TOTAL over every kind (see HarnessCapabilityProfile), but a per-kind matrix is too dense to
-// read at a glance — these 9 groups are the unit the capability matrix renders one row/dot per.
+// read at a glance — these groups are the unit the capability matrix renders one row/dot per.
 // `unknown` is deliberately excluded: it is the adapter's escape hatch, not a declared capability,
 // so it never earns its own row.
 import type { HarnessCapabilityProfile } from "@/lib/api/types";
@@ -30,10 +30,11 @@ export const DISPLAY_GROUPS: readonly DisplayGroup[] = [
   { id: "tools", label: "Tool calls", kinds: ["tool_call", "tool_result"] },
   { id: "mcp", label: "MCP", kinds: ["mcp_call", "mcp_result"] },
   { id: "findings", label: "Findings & flags", kinds: ["finding", "flag"] },
+  { id: "errors", label: "Model refusals", kinds: ["error"] },
   {
     id: "health",
-    label: "Status / errors / metrics",
-    kinds: ["status", "error", "metric"],
+    label: "Status / metrics",
+    kinds: ["status", "metric"],
   },
 ] as const;
 

--- a/frontend/src/features/capabilities/capability-matrix.test.tsx
+++ b/frontend/src/features/capabilities/capability-matrix.test.tsx
@@ -20,6 +20,19 @@ describe("CapabilityMatrix", () => {
     expect(screen.getAllByText(/not supported/).length).toBeGreaterThan(0);
   });
 
+  it("shows refusal support separately from general status and metrics", async () => {
+    renderWithProviders(<CapabilityMatrix selectedKind="codex" />);
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    expect(screen.getByRole("rowheader", { name: "Model refusals" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Model refusals: not supported, Model refusal details are not exported\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Model refusals: supported/)).toHaveLength(3);
+  });
+
   it("marks the Custom column unverified", async () => {
     renderWithProviders(<CapabilityMatrix selectedKind="codex" />);
     await waitFor(() => expect(screen.getByText(/unverified/i)).toBeInTheDocument());

--- a/frontend/src/features/capabilities/capability-matrix.tsx
+++ b/frontend/src/features/capabilities/capability-matrix.tsx
@@ -21,7 +21,7 @@ interface MatrixColumn {
 
 /**
  * The harness capability dot-matrix shown beneath the harness picker at agent
- * creation: rows = the 9 display groups, columns = every built-in harness + Custom, so a user
+ * creation: rows = the display groups, columns = every built-in harness + Custom, so a user
  * can see — before registering an agent — what telemetry that harness's adapter actually
  * declares, honestly (gaps show as an unsupported/partial dot with the adapter's own note,
  * never hidden). `selectedKind` highlights the chosen column with the amber selection token —

--- a/frontend/src/features/replay/replay-order.test.ts
+++ b/frontend/src/features/replay/replay-order.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { mergeAgentAndInfra } from "./replay-order";
+
+interface Agent {
+  id: string;
+  receipt: string | null;
+}
+
+interface Infra {
+  id: string;
+  ts: string | null;
+  seq: number;
+}
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+function ids(agents: Agent[], infra: Infra[]): string[] {
+  return mergeAgentAndInfra(agents, infra, {
+    agentReceipt: (agent) => agent.receipt,
+    infraTime: (row) => row.ts,
+    infraSequence: (row) => row.seq,
+  }).map((entry) => (entry.kind === "agent" ? entry.agent.id : entry.infra.id));
+}
+
+describe("mergeAgentAndInfra", () => {
+  it("keeps ordinary receipt-bracketed infrastructure interleaving", () => {
+    expect(
+      ids(
+        [
+          { id: "agent-before", receipt: iso(1000) },
+          { id: "agent-after", receipt: iso(3000) },
+        ],
+        [{ id: "infra", ts: iso(2000), seq: 0 }],
+      ),
+    ).toEqual(["agent-before", "infra", "agent-after"]);
+  });
+
+  it("uses receipt only one-way and never inverts the fixed agent chronology", () => {
+    expect(
+      ids(
+        [
+          { id: "delayed-prompt", receipt: iso(4000) },
+          { id: "response", receipt: iso(1000) },
+        ],
+        [{ id: "infra", ts: iso(2000), seq: 0 }],
+      ),
+    ).toEqual(["delayed-prompt", "response", "infra"]);
+  });
+
+  it("keeps infra first on an exact receipt tie", () => {
+    expect(
+      ids(
+        [{ id: "agent", receipt: iso(2000) }],
+        [{ id: "infra", ts: iso(2000), seq: 0 }],
+      ),
+    ).toEqual(["infra", "agent"]);
+  });
+
+  it("orders anchorless infra last", () => {
+    expect(
+      ids(
+        [{ id: "agent", receipt: iso(2000) }],
+        [{ id: "infra", ts: null, seq: 0 }],
+      ),
+    ).toEqual(["agent", "infra"]);
+  });
+});

--- a/frontend/src/features/replay/replay-order.ts
+++ b/frontend/src/features/replay/replay-order.ts
@@ -1,0 +1,96 @@
+import type { AgentEvent } from "@/lib/api/types";
+
+const parseFiniteTime = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/** Deterministic chronology within the agent's own clock domain.
+ *
+ * `received_at` is deliberately absent: receipt proves when XORCISE learned about an event, not
+ * when the event happened. A delayed export must not move a prompt behind its response.
+ */
+export function compareAgentEvents(a: AgentEvent, b: AgentEvent): number {
+  const aTs = parseFiniteTime(a.ts);
+  const bTs = parseFiniteTime(b.ts);
+  if (aTs !== bTs) {
+    if (aTs == null) return 1;
+    if (bTs == null) return -1;
+    return aTs - bTs;
+  }
+  const signal = (a.raw_ref.signal ?? "trace").localeCompare(b.raw_ref.signal ?? "trace");
+  if (signal !== 0) return signal;
+  if (a.raw_ref.raw_seq !== b.raw_ref.raw_seq) {
+    return a.raw_ref.raw_seq - b.raw_ref.raw_seq;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+export function sortAgentEvents(events: readonly AgentEvent[]): AgentEvent[] {
+  return [...events].sort(compareAgentEvents);
+}
+
+export type ReplayMergeEntry<A, I> =
+  | { kind: "agent"; agent: A }
+  | { kind: "infra"; infra: I };
+
+/**
+ * Merge two clock domains without treating export latency as occurrence time.
+ *
+ * Agent items must already be in producer/causal order. Infra items are ordered here on the
+ * server clock. Receipt time is safe only as one-way evidence:
+ *
+ *   agent.received_at < infra.ts  =>  the agent event happened before the infra activity
+ *   agent.received_at > infra.ts  =>  unknown (the export may simply have been delayed)
+ *
+ * Therefore an infra activity is inserted after the latest agent item that the server had
+ * already received. Because that insertion is a boundary in the fixed agent sequence, an older
+ * delayed prompt can never be separated from and placed behind its later response. Exact ties
+ * keep the existing infra-first prerequisite rule. Anchorless infra activities sort last.
+ */
+export function mergeAgentAndInfra<A, I>(
+  agents: readonly A[],
+  infra: readonly I[],
+  options: {
+    agentReceipt: (agent: A) => string | null | undefined;
+    infraTime: (infra: I) => string | null | undefined;
+    infraSequence: (infra: I) => number;
+  },
+): ReplayMergeEntry<A, I>[] {
+  const orderedInfra = [...infra].sort((a, b) => {
+    const aTs = parseFiniteTime(options.infraTime(a));
+    const bTs = parseFiniteTime(options.infraTime(b));
+    if (aTs !== bTs) {
+      if (aTs == null) return 1;
+      if (bTs == null) return -1;
+      return aTs - bTs;
+    }
+    return options.infraSequence(a) - options.infraSequence(b);
+  });
+
+  const buckets: I[][] = Array.from({ length: agents.length + 1 }, () => []);
+  for (const systemItem of orderedInfra) {
+    const systemTs = parseFiniteTime(options.infraTime(systemItem));
+    if (systemTs == null) {
+      buckets[agents.length].push(systemItem);
+      continue;
+    }
+    let boundary = 0;
+    for (let index = 0; index < agents.length; index += 1) {
+      const receipt = parseFiniteTime(options.agentReceipt(agents[index]));
+      // Strict comparison preserves infra-first behavior on an exact server-time tie.
+      if (receipt != null && receipt < systemTs) boundary = index + 1;
+    }
+    buckets[boundary].push(systemItem);
+  }
+
+  const merged: ReplayMergeEntry<A, I>[] = [];
+  for (let boundary = 0; boundary <= agents.length; boundary += 1) {
+    merged.push(...buckets[boundary].map((item) => ({ kind: "infra" as const, infra: item })));
+    if (boundary < agents.length) {
+      merged.push({ kind: "agent", agent: agents[boundary] });
+    }
+  }
+  return merged;
+}

--- a/frontend/src/features/replay/replay-timeline.test.tsx
+++ b/frontend/src/features/replay/replay-timeline.test.tsx
@@ -595,7 +595,7 @@ describe("ReplayTimeline infra rows", () => {
   });
 
   it("interleaves an infra row between agent turns by receipt-time", () => {
-    // Agent producer clocks disagree, but receipt times at 1000ms and 3000ms bracket infra at 2000.
+    // Receipt times at 1000ms and 3000ms bracket infra at 2000ms.
     // Message titles are display-mapped ("Agent CoT"), so the distinguishing text rides in body.
     const first = agentEvent({ id: "first", kind: "message", body: "first-msg" });
     const second = agentEvent({ id: "second", kind: "message", body: "second-msg" });
@@ -605,12 +605,12 @@ describe("ReplayTimeline infra rows", () => {
         events={[
           {
             ...first,
-            ts: new Date(9000).toISOString(),
+            ts: new Date(500).toISOString(),
             received_at: new Date(1000).toISOString(),
           },
           {
             ...second,
-            ts: new Date(500).toISOString(),
+            ts: new Date(9000).toISOString(),
             received_at: new Date(3000).toISOString(),
           },
         ]}
@@ -623,6 +623,42 @@ describe("ReplayTimeline infra rows", () => {
     expect(text[0]).toContain("first-msg");
     expect(text[1]).toContain("Fetched the run brief");
     expect(text[2]).toContain("second-msg");
+  });
+
+  it("does not let a delayed prompt move behind its already-received response or intervening infra", () => {
+    render(
+      <ReplayTimeline
+        runId="r1"
+        events={[
+          agentEvent({
+            id: "response",
+            kind: "message",
+            body: "assistant-response",
+            ts: new Date(2000).toISOString(),
+            received_at: new Date(1000).toISOString(),
+          }),
+          agentEvent({
+            id: "prompt",
+            kind: "message",
+            role: "user",
+            body: "delayed-user-prompt",
+            ts: new Date(1000).toISOString(),
+            received_at: new Date(4000).toISOString(),
+          }),
+        ]}
+        infraRows={[
+          infra({
+            ts: new Date(1500).toISOString(),
+            label: "System activity",
+          }),
+        ]}
+      />,
+    );
+
+    const rows = screen.getAllByTestId(/replay-turn|infra-turn/);
+    expect(rows[0]).toHaveTextContent("delayed-user-prompt");
+    expect(rows[1]).toHaveTextContent("assistant-response");
+    expect(rows[2]).toHaveTextContent("System activity");
   });
 
   it("lets infra split a long same-group Claude segment", () => {
@@ -661,7 +697,7 @@ describe("ReplayTimeline infra rows", () => {
     expect(rows[2]).toHaveTextContent("after-infra");
   });
 
-  it("places a delayed older producer event by receipt time", () => {
+  it("keeps infra first when a lone delayed event has no cross-clock ordering evidence", () => {
     render(
       <ReplayTimeline
         runId="r1"

--- a/frontend/src/features/replay/replay-timeline.tsx
+++ b/frontend/src/features/replay/replay-timeline.tsx
@@ -10,6 +10,7 @@ import type { RunEventsMeta } from "./use-run-events";
 import { KIND_META, displayLabel, formatEventTime } from "./kind-meta";
 import { EventCard, EventTime, StatusDot, TerminalCard, type AttributionSpanStatus } from "./event-card";
 import { RawDrillDownModal } from "./raw-drilldown-modal";
+import { mergeAgentAndInfra } from "./replay-order";
 
 /** The icon for an infra row, by its representative target id (Headscale / run-control / OTel
  *  collector / agent). Display-only. */
@@ -292,65 +293,51 @@ export function ReplayTimeline({
         : events.filter((e) => (KIND_META[e.kind] ?? KIND_META.unknown).group !== "debug"),
     [events, debug],
   );
-  // Merge atomic agent cards and infra activities on the server receipt clock BEFORE visual turn
-  // grouping. This is important for Claude: many consecutive tool spans share one whole-session
-  // group_id, and grouping first makes an infra event incapable of landing inside that long group.
+  // Fix the agent narrative in producer order, then merge infra using receipt as one-way evidence.
+  // This preserves infra's server-clock interleaving without mistaking a delayed export for a late
+  // event. Merge before visual grouping so infra can still split Claude's whole-session group.
   type Entry =
     | { kind: "turn"; ts: number; turn: Turn }
     | { kind: "infra"; ts: number; row: InfraRowData };
   const entries = useMemo<Entry[]>(() => {
-    type Atomic =
-      | { kind: "agent"; card: AgentCard }
-      | { kind: "infra"; row: InfraRowData; receivedTs: number };
-    const atomic: Atomic[] = [
-      ...agentCards(visible).map((card): Atomic => ({ kind: "agent", card })),
-      ...(infraRows ?? []).map(
-        (row): Atomic => ({
-          kind: "infra",
-          row,
-          receivedTs: finiteOr(parseTime(row.ts), Number.NEGATIVE_INFINITY),
-        }),
-      ),
-    ];
-    atomic.sort((a, b) => {
-      const aReceived = a.kind === "infra" ? a.receivedTs : a.card.receivedTs;
-      const bReceived = b.kind === "infra" ? b.receivedTs : b.card.receivedTs;
-      if (aReceived !== bReceived) return aReceived - bReceived;
-      // Infra wins an exact receipt-time tie so setup/lifecycle state is visible before the agent
-      // action it enabled. Remaining keys make same-export ordering deterministic.
-      if (a.kind !== b.kind) return a.kind === "infra" ? -1 : 1;
-      if (a.kind === "infra" && b.kind === "infra") return a.row.seq - b.row.seq;
-      if (a.kind === "agent" && b.kind === "agent") {
-        if (a.card.producerTs !== b.card.producerTs) {
-          return a.card.producerTs - b.card.producerTs;
-        }
-        const signal = a.card.signal.localeCompare(b.card.signal);
-        if (signal !== 0) return signal;
-        if (a.card.rawSeq !== b.card.rawSeq) return a.card.rawSeq - b.card.rawSeq;
-        return a.card.key.localeCompare(b.card.key);
-      }
-      return 0;
+    const cards = agentCards(visible).sort((a, b) => {
+      if (a.producerTs !== b.producerTs) return a.producerTs - b.producerTs;
+      const signal = a.signal.localeCompare(b.signal);
+      if (signal !== 0) return signal;
+      if (a.rawSeq !== b.rawSeq) return a.rawSeq - b.rawSeq;
+      return a.key.localeCompare(b.key);
+    });
+    const atomic = mergeAgentAndInfra(cards, infraRows ?? [], {
+      agentReceipt: (card) => card.events[0]?.received_at,
+      infraTime: (row) => row.ts,
+      infraSequence: (row) => row.seq,
     });
 
     const merged: Entry[] = [];
     let previousGroup: string | null = null;
     for (const item of atomic) {
       if (item.kind === "infra") {
-        merged.push({ kind: "infra", ts: item.receivedTs, row: item.row });
+        const row = item.infra;
+        merged.push({
+          kind: "infra",
+          ts: finiteOr(parseTime(row.ts), Number.POSITIVE_INFINITY),
+          row,
+        });
         previousGroup = null; // infra deliberately splits a long visual agent turn
         continue;
       }
+      const card = item.agent;
       const previous = merged.at(-1);
-      if (previous?.kind === "turn" && previousGroup === item.card.groupKey) {
-        previous.turn.events.push(...item.card.events);
+      if (previous?.kind === "turn" && previousGroup === card.groupKey) {
+        previous.turn.events.push(...card.events);
       } else {
         merged.push({
           kind: "turn",
-          ts: item.card.receivedTs,
-          turn: { key: item.card.key, events: [...item.card.events] },
+          ts: card.receivedTs,
+          turn: { key: card.key, events: [...card.events] },
         });
       }
-      previousGroup = item.card.groupKey;
+      previousGroup = card.groupKey;
     }
     return merged;
   }, [visible, infraRows]);

--- a/frontend/src/features/replay/use-run-events.test.tsx
+++ b/frontend/src/features/replay/use-run-events.test.tsx
@@ -146,7 +146,10 @@ describe("useRunEvents", () => {
     await waitFor(() => expect(result.current.events).toHaveLength(2), {
       timeout: 4000,
     });
-    expect(result.current.events.map((event) => event.id)).toEqual(["evt-0", "log-0"]);
+    expect(result.current.events.map((event) => event.id)).toHaveLength(2);
+    expect(result.current.events.map((event) => event.id)).toEqual(
+      expect.arrayContaining(["evt-0", "log-0"]),
+    );
   });
 
   it("seeds the stall clock from the backlog's newest receipt time, clamped to now", async () => {
@@ -206,5 +209,53 @@ describe("useRunEvents", () => {
     // The second batch really did just arrive — client stamp, so the old server receipt
     // time can't hold the stall clock in the past while telemetry is visibly flowing.
     expect(result.current.lastEventAt).toBeGreaterThanOrEqual(testStart);
+  });
+
+  it("reorders a delayed older event into producer chronology across polling pages", async () => {
+    let poll = 0;
+    server.use(
+      http.get("*/api/runs/r7/events", () => {
+        poll += 1;
+        if (poll === 1) {
+          return HttpResponse.json(
+            eventsView(
+              "r7",
+              [
+                {
+                  ...agentEvent(0, "r7"),
+                  id: "response",
+                  ts: new Date(2000).toISOString(),
+                },
+              ],
+              0,
+            ),
+          );
+        }
+        return HttpResponse.json(
+          eventsView(
+            "r7",
+            [
+              {
+                ...agentEvent(1, "r7"),
+                id: "delayed-prompt",
+                ts: new Date(1000).toISOString(),
+              },
+            ],
+            1,
+          ),
+        );
+      }),
+    );
+    const { result } = renderHook(() => useRunEvents("r7", true), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.events).toHaveLength(2), {
+      timeout: 4000,
+    });
+    expect(result.current.events.map((event) => event.id)).toEqual([
+      "delayed-prompt",
+      "response",
+    ]);
   });
 });

--- a/frontend/src/features/replay/use-run-events.ts
+++ b/frontend/src/features/replay/use-run-events.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import type { AgentEvent, RunEventsView } from "@/lib/api/types";
+import { sortAgentEvents } from "./replay-order";
 
 export interface RunEventsMeta {
   sourceAgent: string;
@@ -79,7 +80,9 @@ export function useRunEvents(runId: string, active: boolean) {
       setLastEventAt(Date.now());
     }
     fresh.forEach((e) => seenRef.current.add(e.id));
-    setEvents((prev) => [...prev, ...fresh]);
+    // A later export can contain an older producer event. Rebuild the agent chronology after each
+    // page instead of treating page arrival as occurrence order.
+    setEvents((prev) => sortAgentEvents([...prev, ...fresh]));
   }, [query.data]);
 
   return {

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -46,10 +46,10 @@ function capabilityProfile(
 const CAPABILITY_PROFILES: HarnessCapabilityProfile[] = [
   capabilityProfile(
     "claude-code",
-    "7",
+    "8",
     [
       "message", "terminal_command", "terminal_output", "file_edit", "file_read",
-      "tool_call", "tool_result", "status", "metric", "unknown",
+      "tool_call", "tool_result", "error", "status", "metric", "unknown",
     ],
     [],
     {
@@ -59,7 +59,7 @@ const CAPABILITY_PROFILES: HarnessCapabilityProfile[] = [
   ),
   capabilityProfile(
     "codex",
-    "1",
+    "2",
     [
       "terminal_command", "terminal_output", "file_edit", "tool_call", "tool_result",
       "mcp_call", "mcp_result", "status", "metric", "unknown",
@@ -69,6 +69,7 @@ const CAPABILITY_PROFILES: HarnessCapabilityProfile[] = [
       message:
         "User prompts only — Codex CLI does not export agent-authored chat messages.",
       thinking: "Codex CLI does not export thinking traces.",
+      error: "Model refusal details are not exported.",
     },
   ),
   capabilityProfile(
@@ -81,10 +82,10 @@ const CAPABILITY_PROFILES: HarnessCapabilityProfile[] = [
   ),
   capabilityProfile(
     "openhands",
-    "1",
+    "2",
     [
       "message", "thinking", "terminal_command", "terminal_output", "file_edit",
-      "file_read", "tool_call", "metric", "unknown",
+      "file_read", "tool_call", "error", "metric", "unknown",
     ],
     [],
     { tool_result: "OpenHands reports tool calls without separate result events." },

--- a/src/xorcise/core/harness_adapters/claude_code/otel.py
+++ b/src/xorcise/core/harness_adapters/claude_code/otel.py
@@ -15,6 +15,7 @@ Rides AgentTraceAdapter; self-registers at import; the core framework never impo
                                      (v4); a separate result event only for an orphan execution
   claude_code.tool.blocked_on_user-> status, but ONLY for a meaningful decision (reject/approve/…);
                                      a decision=unknown gate is auto-handled noise and is dropped
+  claude_code.api_refusal (LOG)   -> error/model_refusal, with model + policy category metadata
   <anything else claude_code.*>   -> unknown (never crash)
 
 DISPATCH ORDER MATTERS: claude_code.tool / tool.execution carry ``gen_ai.tool.call.id`` (a
@@ -26,9 +27,8 @@ CONTENT NOTE: tool OUTPUT — file content for Write/Edit/Read (``content``) and
 Bash (``output``, with the command in ``bash_command``) — rides the ``tool.output`` span EVENT
 (surfaced by flatten()), and this adapter maps it. What is STILL not
 in the spans is the assistant's response FREE-TEXT: ``claude_code.llm_request`` carries only
-tokens/model/stop_reason (no message body), so assistant prose needs OTLP *log records*
-(``OTEL_LOG_RAW_API_BODIES`` + a log-ingestion path) — a documented follow-up. Pure + total:
-malformed/missing keys -> fewer events, never an exception.
+tokens/model/stop_reason (no message body), so assistant prose and explicit refusal signals come
+from OTLP *log records*. Pure + total: malformed/missing keys -> fewer events, never an exception.
 """
 
 from __future__ import annotations
@@ -56,11 +56,12 @@ _TOKEN_KEYS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_crea
 
 class ClaudeCodeAdapter(AgentTraceAdapter):
     name = "claude-code"
+    # v8: surface the explicit claude_code.api_refusal log as a model_refusal error.
     # v7: map the user_prompt LOG → user message (headless runs drop the interaction
     #   span that carried it), deduped against the span copy by the merge.
     # v6: _group_id falls back to the topmost ancestor when the interaction root was
     #   never exported (headless), so tool spans still group into turns instead of group_id=None.
-    version = "7"
+    version = "8"
     _genai = GenAiSemconvExtractor()
 
     @property
@@ -76,6 +77,7 @@ class ClaudeCodeAdapter(AgentTraceAdapter):
                 AgentEventKind.file_read,
                 AgentEventKind.tool_call,
                 AgentEventKind.tool_result,
+                AgentEventKind.error,
                 AgentEventKind.status,
                 AgentEventKind.metric,
                 AgentEventKind.unknown,
@@ -116,13 +118,62 @@ class ClaudeCodeAdapter(AgentTraceAdapter):
 
     def normalize_logs(self, logs: list[FlatLogRecord], ctx: AdapterContext) -> list[AgentEvent]:
         """Map Claude Code's OTLP LOG events (scope com.anthropic.claude_code.events) to
-        AgentEvents: the assistant's response TEXT
+        AgentEvents: explicit model refusals (`claude_code.api_refusal` → error), the assistant's
+        response TEXT
         (`claude_code.assistant_response.response` → agent `message`) and the user's prompt
         (`claude_code.user_prompt.prompt` → user `message`). The user prompt normally rides the
         interaction span, but headless runs don't export it; the merge dedups the two sources by
         body so it never shows twice. Pure + total."""
         out: list[AgentEvent] = []
         for i, rec in enumerate(logs):
+            if rec.event_name == "claude_code.api_refusal":
+                model = str(rec.attrs.get("model") or "Claude")
+                category = str(rec.attrs.get("category") or "")
+                explanation = str(
+                    rec.attrs.get("explanation")
+                    or rec.attrs.get("reason")
+                    or rec.attrs.get("message")
+                    or ""
+                )
+                if explanation and explanation != "<REDACTED>":
+                    body = explanation
+                else:
+                    body = f"{model} refused the request"
+                    if category:
+                        body += f" (category: {category})"
+                    body += "."
+                data_keys = (
+                    "model",
+                    "category",
+                    "request_id",
+                    "attempt",
+                    "effort",
+                    "query_source",
+                    "has_explanation",
+                )
+                out.append(
+                    AgentEvent(
+                        run_id=ctx.run_id,
+                        id=f"log:{rec.raw_seq}:{i}:refusal",
+                        ts=self._log_ts(rec, ctx),
+                        source_agent=ctx.source_agent,
+                        kind=AgentEventKind.error,
+                        subkind="model_refusal",
+                        role="agent",
+                        title="model refusal",
+                        body=body,
+                        data={k: rec.attrs[k] for k in data_keys if rec.attrs.get(k)},
+                        status="error",
+                        severity="error",
+                        raw_ref=RawTraceRef(
+                            run_id=ctx.run_id,
+                            raw_seq=rec.raw_seq,
+                            span_id="",
+                            signal="log",
+                        ),
+                    )
+                )
+                continue
             # The user's prompt: normally the claude_code.interaction span carries it, but headless
             # runs never export that span, so the user_prompt LOG is the only source — map it (the
             # merge dedups against a span-provided copy so it never shows twice).

--- a/src/xorcise/core/harness_adapters/codex/otel.py
+++ b/src/xorcise/core/harness_adapters/codex/otel.py
@@ -75,7 +75,8 @@ _AUTO_DECISIONS = {"approved", "approve", "auto", "allow", "allowed"}
 
 class CodexAdapter(AgentTraceAdapter):
     name = "codex"
-    version = "1"
+    # v2: disclose that the Codex OTel export does not expose model refusal details.
+    version = "2"
 
     @property
     def capabilities(self) -> HarnessCapabilityProfile:
@@ -103,6 +104,7 @@ class CodexAdapter(AgentTraceAdapter):
                 "message": "User prompts only — Codex CLI does not export "
                 "agent-authored chat messages.",
                 "thinking": "Codex CLI does not export thinking traces.",
+                "error": "Model refusal details are not exported.",
             },
         )
 

--- a/src/xorcise/core/harness_adapters/openhands/otel.py
+++ b/src/xorcise/core/harness_adapters/openhands/otel.py
@@ -17,6 +17,8 @@ import. Maps OpenHands-SDK / Laminar (lmnr.tracer) spans to AgentEvents:
                                 high-risk action OpenHands runs without a TerminalAction span) is
                                 SURFACED, so no real agent action is invisible. The
                                 assistant text + usage metric are always kept (as Claude Code does).
+                                Failed LLM spans also surface their OTel exception as one clean
+                                error event; policy blocks are labelled as model refusals.
   <anything else>            -> unknown (never crash)
 
 Pure + total: malformed lmnr blobs / missing keys yield fewer events, never an exception.
@@ -72,7 +74,9 @@ def _dict(v: Any) -> dict[str, Any]:
 
 class OpenHandsAdapter(AgentTraceAdapter):
     name = "openhands"
-    version = "1"
+    # v2: surface failed LLM exceptions, including provider policy refusals, instead of leaving
+    #     only an empty-body model metric in the replay.
+    version = "2"
     _genai = GenAiSemconvExtractor()
     # Span names that ARE the canonical execution of a tool call (they carry `action.command`).
     _ACTION_SPANS = ("TerminalAction", "TaskTrackerAction", "FileEditorAction")
@@ -90,6 +94,7 @@ class OpenHandsAdapter(AgentTraceAdapter):
                 AgentEventKind.file_edit,
                 AgentEventKind.file_read,
                 AgentEventKind.tool_call,
+                AgentEventKind.error,
                 AgentEventKind.metric,
                 AgentEventKind.unknown,
             ),
@@ -141,6 +146,93 @@ class OpenHandsAdapter(AgentTraceAdapter):
             cur = anc.parent_span_id
         return None
 
+    @staticmethod
+    def _llm_error_details(span: FlatSpan) -> tuple[str, str, dict[str, str]] | None:
+        """Extract one display-safe failure from repeated Laminar exception events."""
+        if span.status_code != 2:
+            return None
+        raw = ""
+        exception_type = ""
+        for event in span.events:
+            if event.name != "exception":
+                continue
+            raw = event.attrs.get("exception.message") or raw
+            exception_type = event.attrs.get("exception.type") or exception_type
+        if not raw:
+            return None
+
+        # LiteLLM prefixes the provider JSON with its exception class. Prefer the provider's
+        # concise error message over exposing that wrapper (or its stack trace) in the replay.
+        message = raw.strip()
+        error_code = ""
+        error_type = ""
+        brace = message.find("{")
+        if brace >= 0:
+            parsed = _loads(message[brace:])
+            error = _dict(_dict(parsed).get("error"))
+            provider_message = error.get("message")
+            if isinstance(provider_message, str) and provider_message.strip():
+                message = provider_message.strip()
+            error_code = str(error.get("code") or "")
+            error_type = str(error.get("type") or "")
+
+        refusal_markers = (
+            "cyber_policy",
+            "content_filter",
+            "content_policy",
+            "policy_violation",
+            "moderation",
+            "safety",
+        )
+        refusal_text = f"{error_code} {error_type} {message}".lower()
+        is_refusal = any(marker in refusal_text for marker in refusal_markers) or (
+            "content was flagged" in refusal_text
+        )
+        data = {"body": message}
+        if error_code:
+            data["error.code"] = error_code
+        if error_type:
+            data["error.type"] = error_type
+        if exception_type:
+            data["exception.type"] = exception_type
+        return (
+            "model refusal" if is_refusal else "model request failed",
+            "model_refusal" if is_refusal else "model_error",
+            data,
+        )
+
+    def _llm_error_event(
+        self, span: FlatSpan, ctx: AdapterContext, group_id: str | None
+    ) -> AgentEvent | None:
+        details = self._llm_error_details(span)
+        if details is None:
+            return None
+        title, subkind, details_data = details
+        body = details_data.pop("body")
+        base = span.span_id or f"{span.raw_seq}:{span.name}:{span.start_ns}"
+        return AgentEvent(
+            run_id=ctx.run_id,
+            id=f"{base}:error",
+            ts=self._ts(span, ctx),
+            source_agent=ctx.source_agent,
+            kind=AgentEventKind.error,
+            subkind=subkind,
+            role="agent",
+            title=title,
+            body=body,
+            data=details_data,
+            group_id=group_id,
+            parent_id=span.parent_span_id or None,
+            status="error",
+            severity="error",
+            raw_ref=RawTraceRef(
+                run_id=ctx.run_id,
+                raw_seq=span.raw_seq,
+                span_id=span.span_id,
+                trace_id=span.trace_id or None,
+            ),
+        )
+
     def _ts(self, span: FlatSpan, ctx: AdapterContext) -> datetime:
         if span.start_ns > 0:
             try:
@@ -171,6 +263,9 @@ class OpenHandsAdapter(AgentTraceAdapter):
                 if is_tc and not self._is_orphan_tool_call(e, actioned):
                     continue  # duplicates a dedicated action span → the action layer is canonical
                 kept.append(e.model_copy(update={"group_id": gid or e.group_id}))
+            failure = self._llm_error_event(span, ctx, gid)
+            if failure is not None:
+                kept.append(failure)
             return kept
 
         # agent.step is a structural group boundary — no event.

--- a/src/xorcise/core/otel/adapters/__init__.py
+++ b/src/xorcise/core/otel/adapters/__init__.py
@@ -21,6 +21,15 @@ from xorcise.core.otel.adapters.base import AdapterContext
 from xorcise.core.otel.adapters.registry import select
 from xorcise.core.otel.flatten import FlatLogRecord, FlatSpan, flatten, flatten_logs
 
+# Normalization is a versioned projection independently of each harness adapter's mapping version.
+# Including it in RunEventsView.adapter_version makes persisted caches rebuild when shared assembly
+# semantics (such as cross-batch ordering) change, even if the selected adapter itself did not.
+NORMALIZER_VERSION = "2"
+
+
+def projection_version(adapter_version: str) -> str:
+    return f"{adapter_version}+normalizer.{NORMALIZER_VERSION}"
+
 
 def _extract_record(
     record: TraceRecord | Mapping[str, Any],
@@ -147,13 +156,12 @@ def normalize_run(
     events = [with_receipt(event) for event in events]
     log_events = [with_receipt(event) for event in log_events]
 
-    def order_key(event: AgentEvent) -> tuple[float, float, str, int, str]:
-        # Receipt time is the only clock shared by RAW telemetry and infra records. Producer time
-        # remains the deterministic intra-export ordering key. Legacy/in-memory records without a
-        # receipt stamp fall back to producer time and retain their historical behavior.
-        received = event.received_at or event.ts
+    def order_key(event: AgentEvent) -> tuple[float, str, int, str]:
+        # This view is the agent narrative, so its own clock is authoritative for chronology.
+        # Receipt time says when XORCISE learned about an event, not when it happened: a delayed
+        # export must not move a prompt behind its response. The presentation layer retains
+        # received_at and uses it only as one-way evidence when interleaving server-clock infra.
         return (
-            received.timestamp(),
             event.ts.timestamp(),
             event.raw_ref.signal,
             event.raw_ref.raw_seq,
@@ -198,7 +206,7 @@ def normalize_run(
         run_id=ctx.run_id,
         source_agent=ctx.source_agent,
         adapter_name=adapter.name,
-        adapter_version=adapter.version,
+        adapter_version=projection_version(adapter.version),
         fallback=fallback,
         next_since=next_since,
         next_cursor=next_cursor,

--- a/src/xorcise/core/otel/distill.py
+++ b/src/xorcise/core/otel/distill.py
@@ -167,6 +167,16 @@ def _render_log(rec: FlatLogRecord) -> str | None:
 
     Seeded with the event name so a record whose `event.name` attr repeats it does not say it
     twice — `event.name` is itself content-bearing (segment "name"), unlike a span's name."""
+    if rec.event_name == "claude_code.api_refusal":
+        # A refusal is an agent outcome, not transport noise. Claude Code emits a purpose-built
+        # log but no response body: preserve the semantic outcome and its policy classification
+        # for the raw-derived judge transcript without globally admitting model/request metadata.
+        parts = ["outcome=refusal"]
+        for key in ("model", "category", "attempt", "has_explanation"):
+            value = rec.attrs.get(key)
+            if value:
+                parts.append(f"{key}={value}")
+        return " | ".join([rec.event_name, " · ".join(parts)])
     seen: set[str] = {rec.event_name}
     parts = _render(rec.attrs, seen)
     if not parts:

--- a/src/xorcise/core/otel/flatten.py
+++ b/src/xorcise/core/otel/flatten.py
@@ -53,6 +53,19 @@ def _to_int(v: Any) -> int:
         return 0
 
 
+def _status_code(v: Any) -> int:
+    """OTLP status enum accepts both protobuf-JSON names and their integer values."""
+    if isinstance(v, str):
+        named = {
+            "STATUS_CODE_UNSET": 0,
+            "STATUS_CODE_OK": 1,
+            "STATUS_CODE_ERROR": 2,
+        }
+        if v in named:
+            return named[v]
+    return _to_int(v)
+
+
 def _scalar(value: Any) -> str | None:
     """An OTLP attribute value -> scalar string; complex values preserved as JSON; else None."""
     if not isinstance(value, dict):
@@ -193,7 +206,7 @@ def flatten(payload: Any, *, raw_seq: int = 0) -> list[FlatSpan]:
                         name=str(sp.get("name", "")),
                         start_ns=_to_int(sp.get("startTimeUnixNano")),
                         end_ns=_to_int(sp.get("endTimeUnixNano")),
-                        status_code=_to_int(status.get("code")),
+                        status_code=_status_code(status.get("code")),
                         attrs=_flatten_attrs(sp.get("attributes")),
                         scope=scope,
                         resource=resource,

--- a/src/xorcise/core/rest/events_view.py
+++ b/src/xorcise/core/rest/events_view.py
@@ -32,7 +32,7 @@ from xorcise.core.contracts.telemetry import TraceRecord
 # the imports, to stay E402-clean). Still lazy: events_view is itself lazy-imported by the route
 # handler, so this stays off role:control's boot path (plane-isolation invariant).
 from xorcise.core.harness_adapters import load_adapters
-from xorcise.core.otel.adapters import normalize_run
+from xorcise.core.otel.adapters import normalize_run, projection_version
 from xorcise.core.otel.adapters.base import AdapterContext
 from xorcise.core.otel.adapters.registry import select
 from xorcise.core.otel.flatten import FlatSpan, flatten
@@ -92,7 +92,12 @@ def _ensure_fresh(run_id: str) -> None:
     ctx = _ctx_for(run_id)
     adapter, _ = select(ctx.source_agent, _flatten_records(records))
     store = SqliteAgentEventStore()
-    if store.get_staleness(run_id) == (adapter.name, adapter.version, max_seq, log_max_seq):
+    if store.get_staleness(run_id) == (
+        adapter.name,
+        projection_version(adapter.version),
+        max_seq,
+        log_max_seq,
+    ):
         return
     store.put(run_id, normalize_run(records, ctx, log_records=logs), max_seq, log_max_seq)
 

--- a/tests/unit/test_agent_events_cache.py
+++ b/tests/unit/test_agent_events_cache.py
@@ -115,6 +115,28 @@ def test_adapter_version_bump_invalidates(migrated_home):
     assert rebuilt is not None and rebuilt[1] == current_version
 
 
+def test_shared_normalizer_version_invalidates_legacy_projection(migrated_home):
+    """A shared ordering change must rebuild old completed-run caches even when the harness
+    adapter and RAW max sequences themselves have not changed."""
+    from xorcise.core.db import session_scope
+    from xorcise.core.otel.store.agent_events import SqliteAgentEventStore
+    from xorcise.core.otel.store.models import AgentEventRunRow
+    from xorcise.core.rest import events_view
+
+    _seed("r-normalizer", [(0, "s0", "shell.exec")])
+    events_view.events_since("r-normalizer", -1)
+    with session_scope() as s:
+        header = s.get(AgentEventRunRow, "r-normalizer")
+        assert header is not None
+        header.adapter_version = "1"  # pre-normalizer-version cache
+
+    events_view.events_since("r-normalizer", -1)
+
+    rebuilt = SqliteAgentEventStore().get_staleness("r-normalizer")
+    assert rebuilt is not None
+    assert rebuilt[1].endswith("+normalizer.2")
+
+
 def test_regenerate_from_raw_equals_served(migrated_home):
     """Canonical-safety guard: the cached (served) view == a fresh normalize-from-RAW view."""
     from xorcise.core.otel.adapters import normalize_run

--- a/tests/unit/test_capability_profiles_adapters.py
+++ b/tests/unit/test_capability_profiles_adapters.py
@@ -176,3 +176,5 @@ def test_claude_code_declares_no_thinking_and_codex_partial_messages() -> None:
     cx = CodexAdapter().capabilities
     assert cx.kinds["message"].value == "partial"
     assert "message" in cx.notes
+    assert cx.kinds["error"].value == "unsupported"
+    assert cx.notes["error"] == "Model refusal details are not exported."

--- a/tests/unit/test_claude_code_adapter.py
+++ b/tests/unit/test_claude_code_adapter.py
@@ -424,6 +424,58 @@ def test_normalize_logs_maps_assistant_response_to_agent_message():
     assert ev.data.get("model") == "claude-opus-4-8"
 
 
+def test_normalize_logs_maps_api_refusal_to_clean_error():
+    rec = FlatLogRecord(
+        event_name="claude_code.api_refusal",
+        time_ns=1_700_000_000_000_000_000,
+        attrs={
+            "model": "claude-opus-4-8",
+            "category": "cyber",
+            "request_id": "req_refused",
+            "attempt": "1",
+            "has_explanation": "True",
+            "user.email": "operator@example.com",
+        },
+        body="claude_code.api_refusal",
+        raw_seq=3,
+    )
+
+    (event,) = ClaudeCodeAdapter().normalize_logs([rec], _CTX)
+
+    assert event.kind is AgentEventKind.error
+    assert event.subkind == "model_refusal"
+    assert event.title == "model refusal"
+    assert event.body == "claude-opus-4-8 refused the request (category: cyber)."
+    assert event.status == "error"
+    assert event.severity == "error"
+    assert event.data == {
+        "model": "claude-opus-4-8",
+        "category": "cyber",
+        "request_id": "req_refused",
+        "attempt": "1",
+        "has_explanation": "True",
+    }
+    assert event.raw_ref.signal == "log" and event.raw_ref.raw_seq == 3
+
+
+def test_normalize_logs_prefers_exported_refusal_explanation():
+    rec = FlatLogRecord(
+        event_name="claude_code.api_refusal",
+        time_ns=0,
+        attrs={
+            "model": "claude-opus",
+            "category": "policy",
+            "explanation": "I cannot assist with that request.",
+        },
+        body="claude_code.api_refusal",
+        raw_seq=0,
+    )
+
+    (event,) = ClaudeCodeAdapter().normalize_logs([rec], _CTX)
+
+    assert event.body == "I cannot assist with that request."
+
+
 def test_normalize_logs_skips_redacted_and_non_response_events():
     from xorcise.core.otel.flatten import FlatLogRecord
 

--- a/tests/unit/test_distill_transcript.py
+++ b/tests/unit/test_distill_transcript.py
@@ -159,6 +159,31 @@ def test_distils_the_logs_signal_not_only_spans():
     assert "someone@example.com" not in lines[0] and "duration_ms" not in lines[0]
 
 
+def test_distils_claude_code_refusal_for_the_judge():
+    logs = _logs_payload(
+        _log(
+            event_name="claude_code.api_refusal",
+            attrs={
+                "model": "claude-opus-4-8",
+                "category": "cyber",
+                "attempt": "1",
+                "has_explanation": "true",
+                "request_id": "req_refused",
+                "user.email": "operator@example.com",
+            },
+        )
+    )
+
+    (line,) = distill_transcript([], [_rec(0, logs)])
+
+    assert line == (
+        "claude_code.api_refusal | outcome=refusal · model=claude-opus-4-8 "
+        "· category=cyber · attempt=1 · has_explanation=true"
+    )
+    assert "req_refused" not in line
+    assert "operator@example.com" not in line
+
+
 def test_interleaves_spans_and_logs_in_time_order():
     """A judge reasons about a sequence of actions, so a span-recorded action and a log-recorded
     one must appear in the order they happened, not grouped by which signal carried them."""

--- a/tests/unit/test_flatten.py
+++ b/tests/unit/test_flatten.py
@@ -68,6 +68,27 @@ def test_missing_span_fields_do_not_raise():
     assert out[0].name == "" and dict(out[0].attrs) == {} and out[0].start_ns == 0
 
 
+def test_symbolic_otlp_error_status_is_normalized_to_enum_value():
+    payload = {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "name": "failed",
+                                "status": {"code": "STATUS_CODE_ERROR"},
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert flatten(payload)[0].status_code == 2
+
+
 def test_attr_scalar_types_and_lossless_complex():
     payload = {
         "resourceSpans": [

--- a/tests/unit/test_openhands_adapter.py
+++ b/tests/unit/test_openhands_adapter.py
@@ -11,7 +11,7 @@ from xorcise.core.harness_adapters.openhands.otel import OpenHandsAdapter
 from xorcise.core.otel.adapters.base import AdapterContext
 from xorcise.core.otel.adapters.genai import GenAiSemconvExtractor
 from xorcise.core.otel.adapters.registry import select
-from xorcise.core.otel.flatten import FlatSpan, flatten
+from xorcise.core.otel.flatten import FlatSpan, FlatSpanEvent, flatten
 
 _FIX = Path(__file__).resolve().parents[1] / "fixtures/otlp/openhands_real_run.json"
 _GOLDEN = Path(__file__).resolve().parents[1] / "fixtures/otlp/openhands_events_golden.json"
@@ -86,7 +86,14 @@ def test_llm_spans_are_delegated_to_the_shared_extractor():
     assert [(e.id, e.kind) for e in got_non_tool] == [(e.id, e.kind) for e in kept]
 
 
-def _flatspan(name: str, attrs: dict[str, str], *, span_id: str = "s1") -> FlatSpan:
+def _flatspan(
+    name: str,
+    attrs: dict[str, str],
+    *,
+    span_id: str = "s1",
+    status_code: int = 0,
+    events: tuple[FlatSpanEvent, ...] = (),
+) -> FlatSpan:
     return FlatSpan(
         span_id=span_id,
         parent_span_id="",
@@ -94,12 +101,65 @@ def _flatspan(name: str, attrs: dict[str, str], *, span_id: str = "s1") -> FlatS
         name=name,
         start_ns=1_700_000_000_000_000_000,
         end_ns=0,
-        status_code=0,
+        status_code=status_code,
         attrs=attrs,
         scope="lmnr.tracer",
         resource={},
         raw_seq=0,
+        events=events,
     )
+
+
+def test_failed_llm_policy_exception_surfaces_one_clean_refusal_event():
+    provider_message = (
+        "This content was flagged for possible cybersecurity risk. "
+        "If this seems wrong, try rephrasing your request."
+    )
+    exception = FlatSpanEvent(
+        name="exception",
+        time_ns=1_700_000_001_000_000_000,
+        attrs={
+            "exception.type": "litellm.exceptions.BadRequestError",
+            "exception.message": (
+                "litellm.BadRequestError: OpenAIException - "
+                + json.dumps(
+                    {
+                        "error": {
+                            "message": provider_message,
+                            "type": "invalid_request",
+                            "code": "cyber_policy",
+                        }
+                    }
+                )
+            ),
+        },
+    )
+    span = _flatspan(
+        "litellm.responses",
+        {
+            "lmnr.span.type": "LLM",
+            "gen_ai.request.model": "openai/gpt-5.5",
+        },
+        status_code=2,
+        # The reported Laminar span repeats this exception; render one card, not two.
+        events=(exception, exception),
+    )
+
+    events = OpenHandsAdapter().normalize([span], _CTX)
+    errors = [event for event in events if event.kind is AgentEventKind.error]
+
+    assert len(errors) == 1
+    assert errors[0].title == "model refusal"
+    assert errors[0].subkind == "model_refusal"
+    assert errors[0].body == provider_message
+    assert errors[0].status == "error"
+    assert errors[0].severity == "error"
+    assert errors[0].data == {
+        "error.code": "cyber_policy",
+        "error.type": "invalid_request",
+        "exception.type": "litellm.exceptions.BadRequestError",
+    }
+    assert any(event.kind is AgentEventKind.metric for event in events)
 
 
 def test_send_message_with_dict_content_maps_to_user_message():

--- a/tests/unit/test_otel_adapters.py
+++ b/tests/unit/test_otel_adapters.py
@@ -376,9 +376,9 @@ def test_normalize_run_skips_structurally_broken_record() -> None:
     assert view.events[0].title == "ok"
 
 
-def test_normalize_run_orders_by_receipt_time_not_delayed_producer_time() -> None:
-    """A late export may contain an older producer timestamp; it still belongs after infra/events
-    already received by the server."""
+def test_normalize_run_keeps_delayed_older_event_in_producer_chronology() -> None:
+    """Receipt is an observation time, not an occurrence time: a late export containing an older
+    producer event must not move that event behind a response exported earlier."""
     early_receipt = datetime(2026, 7, 25, 1, 0, 1, tzinfo=UTC)
     late_receipt = datetime(2026, 7, 25, 1, 0, 10, tzinfo=UTC)
     records: list[Mapping[str, Any]] = [
@@ -392,8 +392,8 @@ def test_normalize_run_orders_by_receipt_time_not_delayed_producer_time() -> Non
                             {
                                 "spans": [
                                     {
-                                        "spanId": "received-first",
-                                        "name": "first",
+                                        "spanId": "response-received-first",
+                                        "name": "response",
                                         "startTimeUnixNano": "2000000000",
                                     }
                                 ]
@@ -413,8 +413,8 @@ def test_normalize_run_orders_by_receipt_time_not_delayed_producer_time() -> Non
                             {
                                 "spans": [
                                     {
-                                        "spanId": "producer-older",
-                                        "name": "late",
+                                        "spanId": "delayed-prompt",
+                                        "name": "prompt",
                                         "startTimeUnixNano": "1000000000",
                                     }
                                 ]
@@ -428,8 +428,8 @@ def test_normalize_run_orders_by_receipt_time_not_delayed_producer_time() -> Non
 
     view = normalize_run(records, _ctx(source_agent="generic"))
 
-    assert [event.id for event in view.events] == ["received-first", "producer-older"]
-    assert [event.received_at for event in view.events] == [early_receipt, late_receipt]
+    assert [event.id for event in view.events] == ["delayed-prompt", "response-received-first"]
+    assert [event.received_at for event in view.events] == [late_receipt, early_receipt]
 
 
 def test_normalize_run_uses_producer_time_within_one_receipt_batch() -> None:


### PR DESCRIPTION
Replays the four commits that landed on the internal GitLab `main` after the public snapshot was cut (`e43879d2` + curated files), closing the code drift between the two remotes:

- `fix(otel): surface OpenHands model refusals`
- `fix(otel): surface Claude Code refusals`
- `feat(ui): disclose harness refusal support`
- `fix(trace): preserve agent chronology across delayed exports`

All four touch only `src/`, `frontend/`, and `tests/` — no curated public files (README, CHANGELOG, workflows) are affected. After this merge the only intentional code delta vs GitLab main is the public-CI block in `tests/conftest.py`.

Verification:
- `uv run pytest -m unit -n auto` — 1892 passed, 1 environment skip
- `vitest run src/features/replay src/features/capabilities` — 118 passed