### PR TITLE
chore(legal): name Fifth Domain as copyright holder and add a CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -82,9 +82,13 @@ run by hand. Delete any section that genuinely does not apply, and say why.
 
 ---
 
+- [ ] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA
+      assistant comments below. If I am contributing in the course of employment, my employer
+      has signed the Corporate CLA.
+
 By opening this pull request you agree that your contribution is licensed under the
-[Apache License 2.0](../LICENSE), and that you have read the
-[Code of Conduct](../CODE_OF_CONDUCT.md).
+[Apache License 2.0](../LICENSE) and on the terms of the [CLA](../CLA.md), and that you have read
+the [Code of Conduct](../CODE_OF_CONDUCT.md).
 
 **Found a security vulnerability?** Do not open a pull request or a public issue — follow
 [SECURITY.md](../SECURITY.md) instead.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,70 @@
+# CLA gate — every pull request author must have signed the Contributor License Agreement
+# (CLA.md) before their change can be merged. Signatures are recorded as a JSON file on a
+# dedicated branch of this repository, so the record lives with the project rather than in a
+# third-party service.
+#
+# BEFORE ENABLING THIS WORKFLOW:
+#   1. Create the empty branch that stores signatures:
+#        git switch --orphan cla-signatures && git commit --allow-empty -m "chore: cla signature store" && git push -u origin cla-signatures
+#   2. Create a fine-grained PAT with `contents: write` on this repository ONLY, and store it
+#      as the `CLA_SIGNATURE_TOKEN` secret. The default GITHUB_TOKEN cannot be used: it has no
+#      write access on pull requests from forks, which is exactly the case this must handle.
+#   3. Add `ci-ok` gating or a required-status-check rule for this workflow if the CLA is to be
+#      a hard merge gate rather than an advisory comment.
+
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  # `pull_request_target` is required: the CLA assistant must comment and set a status on pull
+  # requests from forks, which the default token of a plain `pull_request` run cannot do. The
+  # usual danger of the trigger does not apply — no step checks out or executes PR code.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  # One run per PR at a time — a sign-comment and a synchronize event racing could drop a
+  # write to the signature file. Never cancel a run that may be mid-write.
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    name: Check the Contributor License Agreement
+    runs-on: ubuntu-latest
+    # Run on pull requests, and on the comment a contributor leaves to record their assent.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    permissions:
+      actions: write # re-run the PR's CLA check once a signature lands
+      contents: read # read the signature file from the signature branch
+      pull-requests: write # post and update the signing-status comment
+      statuses: write # record the CLA result as a commit status
+    steps:
+      - name: CLA assistant # zizmor: ignore[archived-uses]
+        # Upstream archived this repository in March 2026; v2.6.1 is the final release, pinned
+        # to its commit — an archived action is frozen, which a SHA pin makes safe to keep
+        # running. Revisit if a maintained successor to the CLA assistant emerges.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained PAT, `contents: write` on this repository only.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURE_TOKEN }}
+        with:
+          path-to-document: https://github.com/xorcise-ai/xorcise/blob/main/CLA.md
+          path-to-signatures: signatures/version1/cla.json
+          branch: cla-signatures
+          allowlist: dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: >-
+            Thanks for your contribution. Before this can be merged, please read the
+            [Contributor License Agreement](https://github.com/xorcise-ai/xorcise/blob/main/CLA.md)
+            and sign it by posting the comment below. You sign once; it covers all your future
+            contributions. If you are contributing in the course of employment, your employer
+            needs to sign the Corporate CLA instead — email legal@xorcise.ai.
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA."

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,116 @@
+# XORCISE Contributor License Agreement
+
+Thank you for your interest in contributing to XORCISE, a project of **Fifth Domain Pty Ltd
+(ACN 606 251 585)** ("Fifth Domain", "we", "us").
+
+This agreement clarifies the intellectual property licence granted with Contributions from any
+person or entity. It protects You as a Contributor as well as Fifth Domain and its users; it
+does **not** change your right to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms for Your present and future Contributions submitted
+to Fifth Domain. Except for the licences granted here to Fifth Domain and recipients of software
+distributed by Fifth Domain, **You reserve all right, title and interest in and to Your
+Contributions.**
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner, or the legal entity authorised by the
+copyright owner, entering into this agreement with Fifth Domain. For legal entities, the entity
+making a Contribution and all other entities that control, are controlled by, or are under common
+control with that entity are considered a single Contributor.
+
+**"Contribution"** means any original work of authorship, including any modifications or additions
+to an existing work, that is intentionally submitted by You to Fifth Domain for inclusion in, or
+documentation of, any of the products owned or managed by Fifth Domain (the **"Work"**).
+"Submitted" means any form of electronic, verbal or written communication sent to Fifth Domain or
+its representatives, including but not limited to communication on electronic mailing lists, source
+code control systems and issue tracking systems that are managed by, or on behalf of, Fifth Domain
+for the purpose of discussing and improving the Work — excluding communication that is
+conspicuously marked or otherwise designated in writing by You as "Not a Contribution".
+
+## 2. Grant of copyright licence
+
+Subject to the terms and conditions of this agreement, You hereby grant to Fifth Domain and to
+recipients of software distributed by Fifth Domain a **perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright licence** to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense and distribute Your Contributions and such
+derivative works.
+
+**2.1 Relicensing.** You further grant Fifth Domain the right to license Your Contributions, and
+derivative works of them, **under any licence terms Fifth Domain selects**, including proprietary
+terms and including terms different from those under which the Work is distributed at the time of
+Your Contribution. This right is granted so that Fifth Domain may relicense the Work as a whole
+without needing to obtain further consent from each Contributor. For the avoidance of doubt, this
+does not permit Fifth Domain to alter the terms under which any previously published release was
+made available.
+
+## 3. Grant of patent licence
+
+Subject to the terms and conditions of this agreement, You hereby grant to Fifth Domain and to
+recipients of software distributed by Fifth Domain a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent licence to make,
+have made, use, offer to sell, sell, import and otherwise transfer the Work — where such licence
+applies only to those patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the Work to which it was submitted.
+
+If any entity institutes patent litigation against You or any other entity (including a cross-claim
+or counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which You have
+contributed, constitutes direct or contributory patent infringement, then any patent licences
+granted to that entity under this agreement for that Contribution or Work terminate as of the date
+such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+**4.1** You are legally entitled to grant the above licences. If Your employer has rights to
+intellectual property that You create, that includes Your Contributions, You represent that You
+have received permission to make Contributions on behalf of that employer, that Your employer has
+waived such rights for Your Contributions to Fifth Domain, **or** that Your employer has executed a
+Corporate CLA with Fifth Domain (see section 8).
+
+**4.2** Each of Your Contributions is Your original creation. You represent that Your Contribution
+submissions include complete details of any third-party licence or other restriction (including
+related patents and trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
+
+**4.3** You are not expected to provide support for Your Contributions, except to the extent You
+desire to provide support. Unless required by applicable law or agreed to in writing, You provide
+Your Contributions on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**, either
+express or implied, including without limitation any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 5. Third-party works
+
+Should You wish to submit work that is not Your original creation, You may submit it to Fifth
+Domain separately from any Contribution, identifying the complete details of its source and of any
+licence or other restriction (including related patents, trademarks and licence agreements) of
+which You are personally aware, and conspicuously marking the work as
+`Submitted on behalf of a third party: [named here]`.
+
+## 6. Notification
+
+You agree to notify Fifth Domain of any facts or circumstances of which You become aware that would
+make these representations inaccurate in any respect.
+
+## 7. Governing law
+
+This agreement is governed by the laws of the **Australian Capital Territory**, Australia, and You
+submit to the non-exclusive jurisdiction of the courts of that place.
+
+## 8. Corporate contributors
+
+If You are making Contributions in the course of employment, or otherwise on behalf of an entity
+that holds rights in Your work, that entity must execute a **Corporate CLA** rather than relying on
+this individual agreement. Contact <legal@xorcise.ai> for the corporate form, which additionally
+requires a schedule of authorised employee contributors and a nominated point of contact.
+
+---
+
+## How to sign
+
+Contributions are gated on a signed CLA. When you open your first pull request, the CLA assistant
+will comment with a link and record your assent against your GitHub account. You sign once; it
+covers all your future contributions.
+
+If you prefer to sign out of band, email a completed copy to <legal@xorcise.ai>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,19 @@ generated release notes your change lands in:
 
 ---
 
-By contributing, you agree that your contributions will be licensed under the
-[Apache License 2.0](LICENSE), and that you have read the
+## Contributor License Agreement
+
+XORCISE is published by **Fifth Domain Pty Ltd (ACN 606 251 585)**, which owns the project and
+holds the rights needed to license it as a whole.
+
+Before your first pull request can be merged, you need to sign the
+[Contributor License Agreement](CLA.md). The CLA assistant will comment on your pull request with
+a link; signing takes a minute and covers all your future contributions. You keep the copyright in
+your own work — the CLA grants Fifth Domain the licence it needs to distribute and, if it ever
+chooses to, relicense the project.
+
+If you are contributing in the course of employment, or your employer otherwise holds rights in
+your work, your employer needs to sign the Corporate CLA instead. Email <legal@xorcise.ai>.
+
+By contributing, you also confirm that you have read the
 [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -181,7 +181,7 @@
       embedded in the machine-readable metadata on source packages,
       where applicable.
 
-   Copyright 2026 The XORCISE Authors
+   Copyright 2026 Fifth Domain Pty Ltd (ACN 606 251 585)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+XORCISE
+Copyright 2026 Fifth Domain Pty Ltd (ACN 606 251 585)
+
+This product is developed and maintained by Fifth Domain Pty Ltd, an Australian
+company trading as XORCISE.AI.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Portions of this software may be contributed by third parties under the terms of
+the XORCISE Contributor License Agreement (see CLA.md). Such contributions remain
+the copyright of their respective authors and are licensed to Fifth Domain Pty Ltd
+under that agreement.
+
+XORCISE and XORCISE.AI, the associated logos and wordmarks, and the xorcise.ai
+domain are trademarks of Fifth Domain Pty Ltd. The Apache License does not grant
+permission to use them; see https://xorcise.ai/policies/trademark/.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ mission are the content.
 
 ## License
 
-[Apache-2.0](LICENSE) © The XORCISE Authors
+[Apache-2.0](LICENSE) © 2026 Fifth Domain Pty Ltd (ACN 606 251 585)
+
+XORCISE.AI is a business name of Fifth Domain Pty Ltd. Contributions are accepted under the
+[Contributor License Agreement](CLA.md). "XORCISE" and "XORCISE.AI", the associated logos and
+wordmarks, and the `xorcise.ai` domain are trademarks — see the
+[trademark policy](https://xorcise.ai/policies/trademark/) and [`NOTICE`](NOTICE).
 
 ---
 


### PR DESCRIPTION
## What changed

Names **Fifth Domain Pty Ltd (ACN 606 251 585)** as the copyright holder in `LICENSE`, the new `NOTICE`, and the README; adds the **Contributor License Agreement** (`CLA.md`) together with a CLA-assistant workflow that records signatures on a dedicated branch; and points `CONTRIBUTING.md` and the pull-request template at the CLA.

## Why

XORCISE is published by Fifth Domain Pty Ltd, but the legal attribution didn't say so: `LICENSE` and the README credited "The XORCISE Authors", there was no `NOTICE` file, and nothing recorded the licence the company needs from contributors in order to distribute the project as a whole. This aligns the legal attribution with reality and gates future contributions on a signed CLA.

The CLA workflow ships **dormant**: it is SHA-pinned and lint-clean, but enabling it still requires the `cla-signatures` branch, the `CLA_SIGNATURE_TOKEN` secret, and a status-check rule — the steps are documented in the workflow header.

## Testing

Legal documents plus one workflow file — no Python or frontend code is touched, so no test lanes apply. The workflow lint that gates `ci-ok` passes:

```
$ uv run zizmor --pedantic .github/workflows/
No findings to report. Good job! (2 ignored, 1 suppressed)
```

## User-facing impact

- [x] No user-visible change (internal refactor, tests, docs only) — contributor-visible only: future PRs will be asked to sign the CLA once the workflow is enabled.

## Documentation

- [x] Documentation updated in this PR (`CONTRIBUTING.md`, `README.md`, PR template)

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .`, `uv run mypy`, `uv run lint-imports` — not applicable, no Python changes
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in the diff
- [x] No references to internal-only systems in code or documentation

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA assistant comments below.
