### PR TITLE
feat(cli): auto-pull missions on run create and fix the README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,22 @@ Tested on Ubuntu. Needs **Python 3.12+** and **Docker Engine**.
 
 ```bash
 pip install xorcise
+xorcise doctor                            # checks the host first
 xorcise up                                # boots the stack, prints the console URL
 ```
 
 ```bash
-xorcise agent register --name my-agent
+xorcise config set-model --name <model> --key <key>          # the judge — half the score
+xorcise agent register --name my-agent --kind claude-code
 xorcise mission list
-xorcise run create --agent my-agent --mission demo
-xorcise run prompt <run_id>               # the ready-to-paste connect prompt
+xorcise mission pull aviary-access
+xorcise run create --agent my-agent --mission aviary-access
+xorcise run launch-cmd <run_id>           # paste into your agent's terminal, then run it
 xorcise run status <run_id>               # score, breakdown, evidence
 ```
 
-`xorcise doctor` checks the host first. `xorcise down` stops it all. No Docker on the box?
-`xorcise up --stub` is the self-contained demo. `xorcise --help` has the rest, and
+`xorcise down` stops it all. No Docker on the box? `xorcise up --stub` is the
+self-contained demo. `xorcise --help` has the rest, and
 [docs.xorcise.ai](https://docs.xorcise.ai) walks through a first run end to end.
 
 Prefer to work from source? See [Contributing → Setup](CONTRIBUTING.md#setup).

--- a/src/xorcise/core/cli/_pull.py
+++ b/src/xorcise/core/cli/_pull.py
@@ -1,0 +1,119 @@
+"""Shared mission pull-job orchestration (cli).
+
+`mission pull` and `run create` both install a library mission by starting a
+server-side pull job and watching it to a terminal state. The watch, the Ctrl-C
+cancel contract and the progress render must be identical in both places — one
+progress bar, one interrupt behaviour — so they live here, not in either command
+module. What a terminal state MEANS stays with the caller: 'installed' is the
+goal for `mission pull` but only a step on the way to a run for `run create`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import Any
+
+import typer
+
+from xorcise.core.cli._shared import err_console
+from xorcise.core.cli.rest_client import RestClient
+
+# Pull-job poll cadence + cap: a multi-GB image download can take many minutes; the job
+# keeps running server-side past the cap (exit 3 = still in progress, not failure).
+PULL_POLL_SECONDS = 0.7
+PULL_POLL_CAP_SECONDS = 1800.0
+
+# Pull-job phases → the words a user is waiting on (server phases stay internal).
+PHASE_LABELS = {
+    "resolving": "resolving mission",
+    "pulling_image": "downloading container image",
+    "downloading_bundle": "downloading mission bundle",
+    "installing": "installing",
+    "done": "done",
+}
+
+
+def watch_pull(client: RestClient, job_id: str) -> dict[str, Any]:
+    """Poll a pull job to a terminal state, rendering honest progress on stderr.
+
+    TTY: a live bar fed by the server's real byte counts (indeterminate spinner while
+    totals are unknown — progress is never fabricated). Non-TTY: one line per phase
+    change, no cursor movement. Returns the final job view (may still be 'pulling'
+    when the cap expires — the job continues server-side)."""
+    deadline = time.monotonic() + PULL_POLL_CAP_SECONDS
+
+    def _poll() -> dict[str, Any]:
+        view: dict[str, Any] = client.get(f"/missions/pull-jobs/{job_id}")
+        return view
+
+    if err_console.is_terminal:
+        from rich.progress import (
+            BarColumn,
+            DownloadColumn,
+            Progress,
+            SpinnerColumn,
+            TextColumn,
+            TimeRemainingColumn,
+            TransferSpeedColumn,
+        )
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            console=err_console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task(PHASE_LABELS["resolving"], total=None)
+            while True:
+                view = _poll()
+                total = view.get("bytes_total") or 0
+                progress.update(
+                    task,
+                    description=PHASE_LABELS.get(view.get("phase") or "", "working"),
+                    total=total if total > 0 else None,
+                    completed=view.get("bytes_current") or 0,
+                )
+                if view.get("status") != "pulling" or time.monotonic() >= deadline:
+                    return view
+                time.sleep(PULL_POLL_SECONDS)
+    last_phase = None
+    while True:
+        view = _poll()
+        if view.get("phase") != last_phase:
+            last_phase = view.get("phase")
+            err_console.print(f"{PHASE_LABELS.get(last_phase or '', 'working')}…", markup=False)
+        if view.get("status") != "pulling" or time.monotonic() >= deadline:
+            return view
+        time.sleep(PULL_POLL_SECONDS)
+
+
+def request_cancel(client: RestClient, job_id: str) -> None:
+    """Best-effort server-side cancel of an in-flight pull job (Ctrl-C).
+
+    A failed cancel POST (e.g. the server went away) must NOT mask the interrupt — the exit 130
+    stands regardless — so RestClient's clean-exit (typer.Exit) is swallowed. A SECOND Ctrl-C
+    landing inside this POST is swallowed too: the caller still falls through to `raise Exit(130)`,
+    so an impatient double-interrupt keeps the documented interrupted exit code."""
+    with contextlib.suppress(typer.Exit, KeyboardInterrupt):
+        client.post(f"/missions/pull-jobs/{job_id}/cancel", json={})
+
+
+def pull_to_terminal(client: RestClient, mission_id: str) -> dict[str, Any]:
+    """Start a pull job for *mission_id* and watch it to a terminal view.
+
+    Ctrl-C stops the pull server-side too (not just this client): request the cancel, then
+    exit 130 (interrupted). The worker aborts the download and records the job 'cancelled'.
+    Every other terminal state is returned for the caller to render."""
+    started = client.post(f"/missions/{mission_id}/pull-jobs", json={})
+    job_id = started["job_id"]
+    try:
+        return watch_pull(client, job_id)
+    except KeyboardInterrupt:
+        err_console.print("\ncancelling the pull…")
+        request_cancel(client, job_id)
+        raise typer.Exit(130) from None

--- a/src/xorcise/core/cli/commands/mission.py
+++ b/src/xorcise/core/cli/commands/mission.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import contextlib
-import time
 from pathlib import Path
 from typing import Any
 
 import typer
 
+from xorcise.core.cli._pull import pull_to_terminal
 from xorcise.core.cli._resolve import resolve_mission
 from xorcise.core.cli._shared import app, console, emit_json, err_console
 from xorcise.core.cli._ux import (
@@ -28,11 +27,6 @@ from xorcise.core.cli.rest_client import RestClient
 
 mission_app = typer.Typer(help="Browse, install, and manage missions.", no_args_is_help=True)
 app.add_typer(mission_app, name="mission", rich_help_panel="Evaluate")
-
-# Pull-job poll cadence + cap: a multi-GB image download can take many minutes; the job
-# keeps running server-side past the cap (exit 3 = still in progress, not failure).
-_PULL_POLL_SECONDS = 0.7
-_PULL_POLL_CAP_SECONDS = 1800.0
 
 _MISSION_HELP = "Mission id or name (see: xorcise mission list)."
 
@@ -55,15 +49,6 @@ _ENVIRONMENT_LABELS = {
 # match nothing, and hand back an empty result the caller cannot distinguish from
 # a genuinely empty library.
 _DIFFICULTIES = ("novice", "advance beginner", "competent", "proficient", "expert")
-
-# Pull-job phases → the words a user is waiting on (server phases stay internal).
-_PHASE_LABELS = {
-    "resolving": "resolving mission",
-    "pulling_image": "downloading container image",
-    "downloading_bundle": "downloading mission bundle",
-    "installing": "installing",
-    "done": "done",
-}
 
 # Module-level singleton (B008): a call in an argument default would re-run per import.
 # Optional and unvalidated while `ingest` is disabled — see ingest_cmd for why.
@@ -228,75 +213,6 @@ def show_mission(
         next_step(f"xorcise mission pull {mission_id}")
 
 
-def _watch_pull(client: RestClient, job_id: str) -> dict[str, Any]:
-    """Poll a pull job to a terminal state, rendering honest progress on stderr.
-
-    TTY: a live bar fed by the server's real byte counts (indeterminate spinner while
-    totals are unknown — progress is never fabricated). Non-TTY: one line per phase
-    change, no cursor movement. Returns the final job view (may still be 'pulling'
-    when the cap expires — the job continues server-side)."""
-    deadline = time.monotonic() + _PULL_POLL_CAP_SECONDS
-
-    def _poll() -> dict[str, Any]:
-        view: dict[str, Any] = client.get(f"/missions/pull-jobs/{job_id}")
-        return view
-
-    if err_console.is_terminal:
-        from rich.progress import (
-            BarColumn,
-            DownloadColumn,
-            Progress,
-            SpinnerColumn,
-            TextColumn,
-            TimeRemainingColumn,
-            TransferSpeedColumn,
-        )
-
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("{task.description}"),
-            BarColumn(),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-            TimeRemainingColumn(),
-            console=err_console,
-            transient=True,
-        ) as progress:
-            task = progress.add_task(_PHASE_LABELS["resolving"], total=None)
-            while True:
-                view = _poll()
-                total = view.get("bytes_total") or 0
-                progress.update(
-                    task,
-                    description=_PHASE_LABELS.get(view.get("phase") or "", "working"),
-                    total=total if total > 0 else None,
-                    completed=view.get("bytes_current") or 0,
-                )
-                if view.get("status") != "pulling" or time.monotonic() >= deadline:
-                    return view
-                time.sleep(_PULL_POLL_SECONDS)
-    last_phase = None
-    while True:
-        view = _poll()
-        if view.get("phase") != last_phase:
-            last_phase = view.get("phase")
-            err_console.print(f"{_PHASE_LABELS.get(last_phase or '', 'working')}…", markup=False)
-        if view.get("status") != "pulling" or time.monotonic() >= deadline:
-            return view
-        time.sleep(_PULL_POLL_SECONDS)
-
-
-def _request_cancel(client: RestClient, job_id: str) -> None:
-    """Best-effort server-side cancel of an in-flight pull job (Ctrl-C).
-
-    A failed cancel POST (e.g. the server went away) must NOT mask the interrupt — the exit 130
-    stands regardless — so RestClient's clean-exit (typer.Exit) is swallowed. A SECOND Ctrl-C
-    landing inside this POST is swallowed too: the caller still falls through to `raise Exit(130)`,
-    so an impatient double-interrupt keeps the documented interrupted exit code."""
-    with contextlib.suppress(typer.Exit, KeyboardInterrupt):
-        client.post(f"/missions/pull-jobs/{job_id}/cancel", json={})
-
-
 @mission_app.command("pull")
 def pull_mission_cmd(
     mission_id: str = typer.Argument(..., help=_MISSION_HELP),
@@ -310,16 +226,7 @@ def pull_mission_cmd(
         console.print(f"'{entry.get('name') or mission_id}' is already installed", markup=False)
         next_step(f"xorcise run create --agent <name> --mission {mission_id}")
         return
-    started = client.post(f"/missions/{mission_id}/pull-jobs", json={})
-    job_id = started["job_id"]
-    try:
-        view = _watch_pull(client, job_id)
-    except KeyboardInterrupt:
-        # Ctrl-C stops the pull server-side too (not just this client): request the cancel, then
-        # exit 130 (interrupted). The worker aborts the download and records the job 'cancelled'.
-        err_console.print("\ncancelling the pull…")
-        _request_cancel(client, job_id)
-        raise typer.Exit(130) from None
+    view = pull_to_terminal(client, mission_id)
     if view.get("status") == "installed":
         name = (view.get("entry") or {}).get("name") or entry.get("name") or mission_id
         console.print(f"installed '{name}' ({mission_id})", markup=False)
@@ -339,7 +246,7 @@ def pull_mission_cmd(
         raise typer.Exit(0)
     # Cap expired with the job still running server-side: in progress, not failure.
     console.print(
-        f"still pulling — the download continues in the background (job {job_id}); "
+        f"still pulling — the download continues in the background (job {view.get('job_id')}); "
         "check [value]xorcise mission list[/value]"
     )
     raise typer.Exit(3)

--- a/src/xorcise/core/cli/commands/run.py
+++ b/src/xorcise/core/cli/commands/run.py
@@ -10,6 +10,7 @@ from typing import Any
 import typer
 from rich.markup import escape
 
+from xorcise.core.cli._pull import pull_to_terminal
 from xorcise.core.cli._resolve import (
     agent_names_by_id,
     mission_names_by_id,
@@ -213,6 +214,39 @@ def list_runs(
     print_table(table)
 
 
+def _auto_pull(client: RestClient, entry: dict[str, Any], mission: str) -> None:
+    """Install a not-yet-installed mission before creating its run (docker-run-style,
+    parity with POST /runs which auto-pulls on demand). The CLI runs the pull itself so
+    the wait shows the honest progress bar instead of a silently long create request.
+
+    Everything here renders on stderr: with --json, stdout must carry ONLY the created
+    run. Returns on 'installed'; every other terminal state means no run gets created —
+    'error' and 'cancelled' exit 1 (unlike `mission pull`, where an external cancel is a
+    clean converged stop, exit 0 — here the command's artifact, the run, never appeared),
+    and a poll-cap expiry exits 3 (in progress, retry once installed)."""
+    name = entry.get("name") or mission
+    err_console.print(f"mission '{name}' is not installed — pulling it first", markup=False)
+    view = pull_to_terminal(client, mission)
+    status = view.get("status")
+    if status == "installed":
+        err_console.print(f"installed '{name}' ({mission})", markup=False)
+        return
+    if status == "error":
+        fail(
+            f"pull failed — {view.get('detail') or 'unknown error'}",
+            see=("xorcise doctor",),
+        )
+    if status == "cancelled":
+        fail(f"pull cancelled — '{mission}' was not installed, so no run was created")
+    # Cap expired with the job still running server-side: in progress, not failure.
+    err_console.print(
+        f"still pulling — the download continues in the background (job {view.get('job_id')}); "
+        f"once installed, re-run: xorcise run create --agent <agent> --mission {mission}",
+        markup=False,
+    )
+    raise typer.Exit(3)
+
+
 @run_app.command("create")
 def create_run(
     agent: str = typer.Option(
@@ -221,28 +255,21 @@ def create_run(
     mission: str = typer.Option(
         ...,
         "--mission",
-        help="Installed mission id or name (see: xorcise mission list).",
+        help="Mission id or name (see: xorcise mission list); pulled first if not installed.",
     ),
     budget: int | None = typer.Option(None, "--budget", help="Run budget in seconds."),
     as_json: bool = typer.Option(
         False, "--json", help="Emit the raw created run as JSON (for scripting)."
     ),
 ) -> None:
-    """Create an evaluation run (one agent vs one installed mission)."""
+    """Create an evaluation run (one agent vs one mission; pulls the mission on demand)."""
     client = RestClient()
-    # Validate both inputs up front: the answer to a typo is the matching name and
-    # the answer to a not-installed mission is the pull command — not a 404.
+    # Validate both inputs up front: the answer to a typo is the matching name — not a 404.
     agent = resolve_agent_name(client, agent)
     entry = resolve_mission(client, mission)
     mission = str(entry["mission_id"])
     if not entry.get("installed"):
-        fail(
-            f"mission '{entry.get('name') or mission}' is not installed",
-            example=(
-                f"xorcise mission pull {mission}\n"
-                f"  then: xorcise run create --agent {agent} --mission {mission}"
-            ),
-        )
+        _auto_pull(client, entry, mission)
     body: dict[str, object] = {"agent": agent, "mission": mission}
     if budget is not None:
         body["budget_seconds"] = budget

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,15 +1,16 @@
 import os
 import subprocess
+from collections.abc import Mapping
 
 import httpx
 import pytest
 from typer.testing import CliRunner
 
 import xorcise.core.cli.app  # noqa: F401 — registers commands/callback on shared app
+from xorcise.core.cli import _pull as pull_helpers
 from xorcise.core.cli._diagnostics import Check
 from xorcise.core.cli._shared import app
 from xorcise.core.cli.commands import lifecycle
-from xorcise.core.cli.commands import mission as mission_cmd
 from xorcise.core.cli.rest_client import RestClient
 from xorcise.core.config import REST_PORT
 from xorcise.core.headscale import provision
@@ -133,6 +134,65 @@ def test_run_create_renders(monkeypatch):
     assert "run-001" in result.stdout
 
 
+def _run_create_autopull_fakes(
+    monkeypatch: pytest.MonkeyPatch, terminal_view: Mapping[str, object]
+) -> list[str]:
+    """Wire a not-installed mission whose pull job ends in *terminal_view*; returns the
+    list of POSTed paths so a test can assert what ran (and what never did)."""
+    posts: list[str] = []
+
+    def fake_get(self, path):
+        if path == "/agents":
+            return [{"name": "a"}]
+        if path == "/missions":
+            return [{"source": "library", "mission_id": "c", "name": "C", "installed": False}]
+        assert path == "/missions/pull-jobs/j1"
+        return terminal_view
+
+    def fake_post(self, path, json=None, timeout=None):
+        posts.append(path)
+        if path == "/missions/c/pull-jobs":
+            return {"job_id": "j1"}
+        assert path == "/runs"
+        return {"run_id": "run-001"}
+
+    monkeypatch.setattr(RestClient, "get", fake_get)
+    monkeypatch.setattr(RestClient, "post", fake_post)
+    return posts
+
+
+def test_run_create_autopulls_uninstalled_mission(monkeypatch):
+    # A not-installed mission no longer fails create: it is pulled first (docker-run-style,
+    # parity with POST /runs), then the run is created — one command, honest progress.
+    view = {"status": "installed", "phase": "done", "entry": {"name": "C"}}
+    posts = _run_create_autopull_fakes(monkeypatch, view)
+    result = runner.invoke(app, ["run", "create", "--agent", "a", "--mission", "c"])
+    assert result.exit_code == 0
+    assert posts == ["/missions/c/pull-jobs", "/runs"]  # pulled, then created
+    assert "run-001" in result.stdout
+
+
+def test_run_create_pull_error_exits_1(monkeypatch):
+    # A failed auto-pull is a runtime failure: exit 1, and /runs is never POSTed.
+    view = {"status": "error", "phase": "pulling_image", "detail": "registry unreachable"}
+    posts = _run_create_autopull_fakes(monkeypatch, view)
+    result = runner.invoke(app, ["run", "create", "--agent", "a", "--mission", "c"])
+    assert result.exit_code == 1
+    assert "pull failed" in result.output and "registry unreachable" in result.output
+    assert posts == ["/missions/c/pull-jobs"]  # the create never happened
+
+
+def test_run_create_pull_cancelled_exits_1(monkeypatch):
+    # An externally cancelled auto-pull means no run was created — unlike `mission pull`
+    # (a clean converged stop, exit 0), create's artifact never appeared, so exit 1.
+    view = {"status": "cancelled", "phase": "pulling_image"}
+    posts = _run_create_autopull_fakes(monkeypatch, view)
+    result = runner.invoke(app, ["run", "create", "--agent", "a", "--mission", "c"])
+    assert result.exit_code == 1
+    assert "no run was created" in result.output
+    assert posts == ["/missions/c/pull-jobs"]
+
+
 def test_mission_list_renders(monkeypatch):
     monkeypatch.setattr(
         RestClient,
@@ -199,7 +259,7 @@ def test_mission_pull_ctrl_c_cancels_server_side_and_exits_130(monkeypatch):
 
     monkeypatch.setattr(RestClient, "get", fake_get)
     monkeypatch.setattr(RestClient, "post", fake_post)
-    monkeypatch.setattr(mission_cmd, "_watch_pull", interrupt)
+    monkeypatch.setattr(pull_helpers, "watch_pull", interrupt)
     result = runner.invoke(app, ["mission", "pull", "sqli"])
     assert result.exit_code == 130
     assert "/missions/sqli/pull-jobs" in posts  # the pull was started
@@ -224,7 +284,7 @@ def test_mission_pull_ctrl_c_exits_130_even_if_cancel_post_fails(monkeypatch):
 
     monkeypatch.setattr(RestClient, "get", fake_get)
     monkeypatch.setattr(RestClient, "post", fake_post)
-    monkeypatch.setattr(mission_cmd, "_watch_pull", interrupt)
+    monkeypatch.setattr(pull_helpers, "watch_pull", interrupt)
     result = runner.invoke(app, ["mission", "pull", "sqli"])
     assert result.exit_code == 130
 
@@ -245,7 +305,7 @@ def test_mission_pull_double_ctrl_c_during_cancel_still_exits_130(monkeypatch):
 
     monkeypatch.setattr(RestClient, "get", fake_get)
     monkeypatch.setattr(RestClient, "post", fake_post)
-    monkeypatch.setattr(mission_cmd, "_watch_pull", interrupt)
+    monkeypatch.setattr(pull_helpers, "watch_pull", interrupt)
     result = runner.invoke(app, ["mission", "pull", "sqli"])
     assert result.exit_code == 130
 

--- a/tests/unit/test_cli_ux.py
+++ b/tests/unit/test_cli_ux.py
@@ -602,20 +602,31 @@ def test_agent_resolver_never_suggests_registering_a_command_word(monkeypatch, c
     assert "register --name list" not in err  # never steer a typo toward a mutation
 
 
-def test_run_create_not_installed_hint_has_single_label(monkeypatch):
+def test_run_create_not_installed_pulls_and_says_so_on_stderr(monkeypatch):
+    # A not-installed mission is no longer an error with a hint — create pulls it itself.
+    # The UX contract flips with it: announce the pull on stderr (stdout stays clean for
+    # --json), and never instruct the user to run a command the CLI just ran for them.
     from xorcise.core.cli.rest_client import RestClient
 
     def fake_get(self, path):
         if path == "/agents":
             return [{"id": "a1", "name": "demo"}]
-        return [{"mission_id": "aviary-access", "name": "Aviary Access", "installed": False}]
+        if path == "/missions":
+            return [{"mission_id": "aviary-access", "name": "Aviary Access", "installed": False}]
+        return {"status": "installed", "phase": "done"}
+
+    def fake_post(self, path, json=None, timeout=None):
+        if path.endswith("/pull-jobs"):
+            return {"job_id": "j1"}
+        return {"run_id": "run-777"}
 
     monkeypatch.setattr(RestClient, "get", fake_get)
+    monkeypatch.setattr(RestClient, "post", fake_post)
     result = runner.invoke(app, ["run", "create", "--agent", "demo", "--mission", "aviary-access"])
-    assert result.exit_code == 1
-    assert "xorcise mission pull aviary-access" in result.stderr
-    assert "then: xorcise run create --agent demo --mission aviary-access" in result.stderr
-    assert "see: then:" not in result.stderr  # regression: the two labels once doubled up
+    assert result.exit_code == 0
+    assert "'Aviary Access' is not installed — pulling it first" in result.stderr
+    assert "then: xorcise run create" not in result.stderr  # the old hint must not linger
+    assert "run-777" in result.stdout
 
 
 def test_narrow_terminal_never_truncates_ids_or_scores():


### PR DESCRIPTION
## What changed

`xorcise run create` now pulls a not-yet-installed mission itself instead of failing with a "run `mission pull` first" error. The pull renders the same live progress bar as `xorcise mission pull` (real byte counts, spinner while totals are unknown, phase lines when piped) — the watch/cancel machinery both commands share moved to `cli/_pull.py`. The README quickstart is rewritten around the CLI's own golden path: real mission ids, the judge model, `--kind` on registration, and `run launch-cmd` in place of `run prompt`.

## Why

Two problems, one seam:

- **The README quickstart could not produce a graded run.** It used a mission id that does not exist (`demo`), skipped `mission pull` and the judge model entirely, registered the agent without `--kind` (which flips the connect prompt to container addressing), and handed the agent `run prompt` instead of `run launch-cmd` — so even a run that started would export no telemetry to grade. The new sequence is the one the CLI's own `--help` and next-step hints walk you through.
- **The CLI was the only surface that refused an uninstalled mission.** `POST /runs` already auto-pulls on demand, docker-run-style; the CLI's client-side guard predates that and turned a one-command flow into three. Now the CLI converges with the server, and does it with an honest progress render instead of a silently long create request.

Behaviour a user could not rely on before and can now: `xorcise run create --agent a --mission <uninstalled-id>` installs the mission and creates the run in one command. The auto-pull leg keeps the established exit-code contract: Ctrl-C cancels the job server-side and exits 130; a pull error or an external cancel exits 1 (no run was created); a poll-cap expiry exits 3 (still in progress). All auto-pull messaging goes to stderr, so `--json` output on stdout stays parseable.

This is a backwards-compatible behaviour addition to a public CLI command (a previously failing invocation now succeeds), so per the versioning table it belongs in the next minor bump.

## Testing

```
$ uv run pytest -m unit -q
1925 passed, 1 skipped (host-environment loopback), 181 deselected

$ uv run pytest -m "adapters or topology" -q
144 passed, 1963 deselected

$ uv run mypy
Success: no issues found in 471 source files

$ uv run ruff check .          # All checks passed!
$ uv run ruff format --check . # 477 files already formatted
$ uv run lint-imports          # Contracts: 4 kept, 0 broken
```

New coverage: auto-pull happy path (pull job → installed → run created, with the POST order asserted), pull error (exit 1, `/runs` never POSTed), external cancel (exit 1 — unlike `mission pull`, where an external cancel is a clean exit-0 stop, `create`'s artifact never appeared). The old UX test asserting the removed error hint now guards the inverse contract: announce the pull on stderr and never instruct the user to run a command the CLI just ran for them.

**Test lanes affected:**

- [x] `unit` — no Docker, fast
- [ ] `adapters` — port/adapter contracts
- [x] `topology` — manifest / compose / import / extras parity (new `cli/_pull.py` module; lane run locally, green)
- [ ] `integration` — needs Docker or a live server process
- [ ] `e2e` — full `xorcise up` + scripted agent
- [ ] `frontend` — Next.js typecheck / vitest

## User-facing impact

- [x] Backwards-compatible addition (new command, new optional flag, new field) — `run create` gains install-on-demand; no existing invocation changes meaning, and the explicit `mission pull` flow is untouched.

## Documentation

- [x] Documentation updated in this PR (`README.md` quickstart)

The docs-site CLI reference still describes the explicit `mission pull` flow, which remains correct; a line noting the on-demand pull can follow when the site is next updated.

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in the diff
- [x] No references to internal-only systems in code or documentation

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA assistant comments below.
