### PR TITLE
fix(ci): move CLA signatures to the org's private signature store

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,16 +1,21 @@
 # CLA gate — every pull request author must have signed the Contributor License Agreement
-# (CLA.md) before their change can be merged. Signatures are recorded as a JSON file on a
-# dedicated branch of this repository, so the record lives with the project rather than in a
-# third-party service.
+# (CLA.md) before their change can be merged. Signatures are recorded as a JSON file in the
+# ORGANISATION'S PRIVATE SIGNATURE STORE (xorcise-ai/cla-signatures), not in this repository:
+# signer records stay internal, one signature covers every xorcise-ai repository that runs
+# this workflow, and — decisively — this fork-facing job keeps a read-only token. The action
+# writes same-repo signatures with the default GITHUB_TOKEN (the PAT is used only for a
+# remote store), so an in-repo store would force `contents: write` onto a
+# `pull_request_target` workflow.
 #
-# BEFORE ENABLING THIS WORKFLOW:
-#   1. Create the empty branch that stores signatures:
-#        git switch --orphan cla-signatures && git commit --allow-empty -m "chore: cla signature store" && git push -u origin cla-signatures
-#   2. Create a fine-grained PAT with `contents: write` on this repository ONLY, and store it
-#      as the `CLA_SIGNATURE_TOKEN` secret. The default GITHUB_TOKEN cannot be used: it has no
-#      write access on pull requests from forks, which is exactly the case this must handle.
-#   3. Add `ci-ok` gating or a required-status-check rule for this workflow if the CLA is to be
-#      a hard merge gate rather than an advisory comment.
+# OPERATIONAL PREREQUISITES — the check fails on every pull request without them:
+#   1. The private signature repository xorcise-ai/cla-signatures exists (default branch
+#      `main` — the `branch:` input below).
+#   2. A fine-grained PAT with `contents: read & write` on xorcise-ai/cla-signatures ONLY is
+#      stored as the `CLA_SIGNATURE_TOKEN` secret. Scope it to nothing else — this repository
+#      itself needs no PAT access. When the PAT expires the run fails with an empty
+#      PERSONAL_ACCESS_TOKEN in the log, so put the rotation date somewhere visible.
+#   3. (Optional) Add a required-status-check rule for this workflow if the CLA is to be a
+#      hard merge gate rather than an advisory comment.
 
 name: CLA
 
@@ -42,7 +47,7 @@ jobs:
        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
     permissions:
       actions: write # re-run the PR's CLA check once a signature lands
-      contents: read # read the signature file from the signature branch
+      contents: read # this repo stays read-only; signatures live in xorcise-ai/cla-signatures via the PAT
       pull-requests: write # post and update the signing-status comment
       statuses: write # record the CLA result as a commit status
     steps:
@@ -53,12 +58,15 @@ jobs:
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fine-grained PAT, `contents: write` on this repository only.
+          # Fine-grained PAT, `contents: read & write` on xorcise-ai/cla-signatures ONLY.
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURE_TOKEN }}
         with:
           path-to-document: https://github.com/xorcise-ai/xorcise/blob/main/CLA.md
+          # The org's private signature store — see the header for why it is not this repo.
+          remote-organization-name: xorcise-ai
+          remote-repository-name: cla-signatures
           path-to-signatures: signatures/version1/cla.json
-          branch: cla-signatures
+          branch: main
           allowlist: dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: >-
             Thanks for your contribution. Before this can be merged, please read the


### PR DESCRIPTION
## What changed

The CLA assistant now records signatures in the organisation's **private signature store** (`xorcise-ai/cla-signatures`) via the `remote-organization-name` / `remote-repository-name` inputs, instead of on a branch of this repository. The workflow header's operational prerequisites are rewritten to match, and the job's own token stays `contents: read`.

## Why

The CLA check has failed on every pull request since it went live (see the runs on #17). Root cause, verified against the pinned action's source (`src/persistence/persistence.ts` @ `ca4a40a7`): for **same-repo** signature storage the action writes the signature file with the default `GITHUB_TOKEN` — the `PERSONAL_ACCESS_TOKEN` is consulted **only** when a remote store is configured. This workflow deliberately grants its token `contents: read`, so every signature write died with "Resource not accessible by integration", and no signing could ever be recorded.

Two possible fixes: widen this `pull_request_target` job to `contents: write`, or configure the remote store the PAT path was built for. The remote store wins on every axis that matters here:

- the fork-facing workflow keeps a **read-only** token — no standing write grant on the trigger zizmor makes us justify;
- signer records (usernames, IDs, timestamps) stay **internal to Fifth Domain** instead of public in an open repository;
- one signature covers **every xorcise-ai repository** that runs this workflow — the org publishes in parts, and future repos reuse the same store;
- the `CLA_SIGNATURE_TOKEN` PAT narrows to the signature repo **only**; this repository needs no PAT access at all.

## Testing

Workflow-only change; no Python or frontend code is touched, so no test lanes apply. The workflow lint that gates `ci-ok` passes:

```
$ uv run zizmor --pedantic .github/workflows/
No findings to report. Good job! (2 ignored, 1 suppressed)
```

End-to-end verification happens post-merge (the workflow runs from `main` on `pull_request_target`): re-run the sign flow on #17 and confirm the signature lands in `xorcise-ai/cla-signatures`.

## User-facing impact

- [x] No user-visible change (internal refactor, tests, docs only) — contributor-visible only: the CLA check starts actually working.

## Documentation

- [x] No documentation change needed — the workflow header carries its own operational docs, updated in this PR.

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass — not applicable, no Python changes
- [x] `uv run mypy` passes (strict) — not applicable
- [x] `uv run lint-imports` passes (architecture layer rules) — not applicable
- [x] Relevant test lanes pass locally — `zizmor --pedantic` clean (the applicable gate)
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in the diff
- [x] No references to internal-only systems in code or documentation — the signature repo is named intentionally; it is the documented operational dependency of this workflow

## Post-merge steps

1. Re-scope the `CLA_SIGNATURE_TOKEN` PAT from this repository to `xorcise-ai/cla-signatures` (Contents: read & write) — its current scope was for the in-repo store and is useless to the remote one.
2. Re-run the sign flow on #17 (`recheck` or the sign comment) and confirm `signatures/version1/cla.json` appears in the signature repo.
3. Delete the now-unused `cla-signatures` orphan branch of this repository.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA assistant comments below.
