### PR TITLE
docs(changelog): record the 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Versions are derived from git tags (hatch-vcs).
 
+## [0.1.1] - 2026-08-04
+
+### Added
+
+- **Missions install themselves on `run create`** — `xorcise run create` no longer refuses an
+  uninstalled mission; it pulls it first, docker-run style, which is what `POST /runs` already
+  did. The pull renders the same honest progress as `xorcise mission pull`, Ctrl-C still cancels
+  the job server-side, and all of its messaging goes to stderr so `--json` output stays
+  parseable. A failed or externally cancelled pull exits 1 with no run created; a pull still
+  going when the client's poll cap expires exits 3 and continues server-side.
+- **Model refusals are surfaced as evidence** — when a provider blocks a request on policy, the
+  OpenHands and Claude Code adapters now record it as a labelled refusal event instead of
+  discarding the failed call. A refusal is a fact about the run and is graded as one. The
+  console discloses which harnesses support refusal detection, so an unsupported harness reads
+  as "unknown", never as "no refusals".
+
+### Fixed
+
+- **Run replay keeps the agent's own chronology** — events are ordered by the agent's clock
+  rather than by when XORCISE received them, so a delayed OpenTelemetry export can no longer
+  move a prompt behind the response it produced. Ordering stays deterministic when timestamps
+  tie.
+
+### Security
+
+- **Mission slugs can no longer escape the install store** — a slug arriving from a REST path
+  parameter, a request body or a bundle manifest now resolves through a single choke point that
+  rejects anything which is not a direct child of the install root. Previously a slug carrying a
+  path separator, `..` or an absolute path could aim reads, the delete path's `rmtree`, and an
+  install's staging, backup and final writes outside that root. Reads now degrade to "not
+  installed"; installs fail preflight with a named error.
+- **The filesystem browser answers only the local operator** — `GET /api/fs/list` exposes the
+  server host's directory tree, so it is now gated on the peer address: non-loopback clients —
+  LAN peers under an explicit `XORCISE_HOST=0.0.0.0` bind, and agent containers reaching the API
+  over the Docker bridge — get a 403.
+
+### Changed
+
+- **The README quickstart runs as written** — it now follows the CLI's own golden path: set the
+  judge model, register the agent with `--kind`, pull a real library mission, then
+  `run launch-cmd` for the block you paste into the agent's terminal.
+- **The published policies match the shipped software** — the documented default bind is stated
+  as it really is (loopback plus the Docker bridge gateway, widening to the IPv4 wildcard only
+  when you ask for it, or when the gateway cannot be determined at boot), the security
+  response-time commitments that could not yet be honoured are gone, and `ACCEPTABLE_USE.md`
+  now ships inside the wheel, as the policy says it does.
+- **Fifth Domain Pty Ltd is named as the copyright holder**, and a Contributor License Agreement
+  now covers contributions. The licence itself is unchanged: Apache-2.0.
+
 ## [0.1.0] - 2026-08-03
 
 First public release.


### PR DESCRIPTION
Writes the changelog entry for the next release. Eleven commits have landed on `main` since
`v0.1.0`; `release.yml` takes its release-notes body from `CHANGELOG.md`, so this needs to be on
`main` before the tag is pushed.

### What the entry covers

- **Added** — mission auto-pull on `xorcise run create` (including its 0/1/3 exit-code contract),
  and refusal surfacing across the OpenHands and Claude Code adapters.
- **Fixed** — replay chronology now keys on the agent's clock, not receipt time.
- **Security** — mission-slug containment to the install root, and the `/fs` browse loopback gate.
- **Changed** — the README quickstart rewrite, the policy/bind corrections, `ACCEPTABLE_USE.md`
  shipping in the wheel, and the Fifth Domain copyright + CLA.

Deliberately omitted: the CLA signature-store move and the release-notes source change. Both touch
only CI internals and change nothing in the installed package.

### Verification

Release rehearsed locally against a `0.1.1` build (nothing published):

- `uv build` → wheel + sdist, `check_release_metadata.py --tag v0.1.1` ✅, `check_wheel_contents.py` ✅,
  `twine check --strict` ✅, clean-venv install + `xorcise --help` reporting `0.1.1` ✅.
- The release-notes `awk` extraction was dry-run against this entry: 3016 bytes, terminating
  correctly at the `0.1.0` heading.
- Full gate green on `main`: mypy (471 files), ruff, import-linter (4/4 contracts),
  2103 pytest passed / 4 skipped, 675 frontend vitest tests.

Docs-only change — no source, tests or workflows touched.