### PR TITLE
feat(missions): draw the actual terrain map on the mission detail page

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4850,6 +4850,49 @@
         ]
       }
     },
+    "/api/missions/{mission_id}/terrain": {
+      "get": {
+        "description": "The mission's projected v2 terrain \u2014 the same base graph a run of it starts from.\n\nRuns the run-scoped projector over the manifest (installed copy, else the library) with\nno run attached: infra scaffold + authored/static-ips mission plane, every element in its\nbase state, no updates. This is what the mission detail page draws so the ACTUAL terrain\nmap \u2014 not a simplification \u2014 is visible before a run (or a pull). Unknown id \u2192 404.",
+        "operationId": "mission_terrain_api_missions__mission_id__terrain_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mission_id",
+            "required": true,
+            "schema": {
+              "title": "Mission Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedTerrainV2"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mission Terrain",
+        "tags": [
+          "missions"
+        ]
+      }
+    },
     "/api/runs": {
       "get": {
         "description": "List runs, each stamped with `last_telemetry_at` \u2014 the newest OTLP receipt across the\ntrace + log signals. A cross-module join the delivery layer owns (like /result's intel count):\nthe runs module stays telemetry-blind, and the RAW stores stay canonical. Lazy import keeps\nthe otel plane off the module-import path (plane-isolation invariant).",

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -6,6 +6,7 @@ import { foldIndexForEvent, foldTerrain, probingPathEdgeIds, pulseIdsForIndex, t
 import { layoutTerrainV2, type LaidOutEdge, type LaidOutGroup, type LaidOutNode } from "./terrain-layout";
 import { edgeColor, groupStyle, nodeColor, otelActive, T } from "./terrain-colors";
 import { useRunTerrain } from "./use-run-terrain";
+import type { ResolvedTerrainV2 } from "@/lib/api/types";
 
 /**
  * Terrain map v2 — a spatial map rendered as hand-rolled inline SVG (no graph library), drawing the
@@ -477,6 +478,9 @@ function Legend() {
   );
 }
 
+/** The run-scoped terrain map: fetches the run's resolved v2 terrain and renders it.
+ *  All drawing lives in `TerrainMapView` below, which is presentational/query-free — the
+ *  mission detail page feeds it a MISSION-scoped projection (no run) through its own query. */
 export function TerrainMap({
   runId,
   active = false,
@@ -488,6 +492,45 @@ export function TerrainMap({
   runId: string;
   active?: boolean;
   selectedEventId?: string | null;
+  onReturnToLive?: () => void;
+  attributionOff?: boolean;
+  onHoverEvents?: (eventIds: string[]) => void;
+}) {
+  const { terrain, isError } = useRunTerrain(runId, active);
+  return (
+    <TerrainMapView
+      terrain={terrain}
+      isError={isError}
+      resetKey={runId}
+      active={active}
+      selectedEventId={selectedEventId}
+      attributionOff={attributionOff}
+      onHoverEvents={onHoverEvents}
+      onReturnToLive={onReturnToLive}
+    />
+  );
+}
+
+export function TerrainMapView({
+  terrain,
+  isError = false,
+  resetKey = "",
+  active = false,
+  selectedEventId = null,
+  attributionOff = false,
+  caption,
+  onHoverEvents,
+  onReturnToLive,
+}: {
+  /** The resolved v2 terrain to draw (null while loading/absent). Run-scoped (with updates)
+   *  or mission-scoped (base graph only) — the fold below is a no-op on an empty updates array. */
+  terrain: ResolvedTerrainV2 | null;
+  isError?: boolean;
+  /** Identity of the drawn subject (run id / mission id) — a new key restarts auto-fit
+   *  following from scratch, exactly as a new run used to. */
+  resetKey?: string;
+  active?: boolean;
+  selectedEventId?: string | null;
   /** Return-to-live escape from time-travel: when a span is selected the map is frozen at that
    *  fold, so a control asks RunLive (which owns the selection) to clear it. Without this the only
    *  way back to the live/latest view was a page refresh. */
@@ -496,11 +539,13 @@ export function TerrainMap({
    *  configured — RunLive derives this from `useConfig().terrain.configured` so TerrainMap
    *  stays presentational/query-free. */
   attributionOff?: boolean;
+  /** Footer caption override — the default speaks run-language (amber ring / trace events);
+   *  the mission preview passes its own. */
+  caption?: string;
   /** Reverse hover link: hovering a node reports the event ids of the updates
    *  that targeted it, so RunLive can highlight them in the Trace. */
   onHoverEvents?: (eventIds: string[]) => void;
 }) {
-  const { terrain, isError } = useRunTerrain(runId, active);
 
   // TIME-TRAVEL wiring: `k` is the array index to fold to. Selection is prop-driven (owned by
   // RunLive) — it derives from `selectedEventId` every render, so a poll that advances "latest"
@@ -686,10 +731,10 @@ export function TerrainMap({
     // container (re)mounts: it only renders once layout exists, so the first mount is never missed.
   }, [layout, showWheelTip]);
   useEffect(() => {
-    // A new run starts following again from scratch.
+    // A new subject (run / mission) starts following again from scratch.
     fittedDims.current = null;
     userControlled.current = false;
-  }, [runId]);
+  }, [resetKey]);
   useEffect(() => {
     // Fit on the FIRST render, and re-fit whenever the graph's drawn size changes (live nodes
     // appear) — unless the user has taken manual control. Keyed on the actual dimensions so a poll
@@ -949,7 +994,7 @@ export function TerrainMap({
           hover interaction. The colour→state mapping lives in the legend, so it's dropped here to
           keep this caption short enough to wrap cleanly inside the card. */}
       <p className="shrink-0 border-t border-border px-4 py-2 text-caption text-text-tertiary">
-        Amber ring = what just changed · hover a node to highlight its trace events.
+        {caption ?? "Amber ring = what just changed · hover a node to highlight its trace events."}
       </p>
       {attributionOff && hasMissionGroup && (
         <p className="shrink-0 border-t border-border px-4 py-2 text-caption italic text-text-tertiary">

--- a/frontend/src/features/missions/mission-detail.test.tsx
+++ b/frontend/src/features/missions/mission-detail.test.tsx
@@ -105,6 +105,77 @@ describe("MissionDetail skills before pull", () => {
   });
 });
 
+describe("MissionDetail terrain", () => {
+  it("renders the ACTUAL terrain map (SVG renderer) for a manifest with a terrain block", async () => {
+    server.use(
+      http.get("*/api/missions", () => HttpResponse.json([INSTALLED])),
+      http.get("*/api/missions/idor/manifest", () =>
+        HttpResponse.json({
+          schema_version: "2.0",
+          metadata: {
+            mission_id: "idor",
+            name: "IDOR",
+            objective: "o",
+            type: "lab",
+            skills: [],
+            technologies: [],
+          },
+          environment: {},
+          rubric: [],
+          checks: [],
+          artifacts: [],
+          attachments: [],
+          intel: [],
+          terrain: {
+            summary: "Reach the vault.",
+            groups: [{ id: "dmz", label: "DMZ" }],
+            nodes: [
+              { id: "web", parent: "dmz", label: "web" },
+              { id: "vault", parent: "dmz", label: "vault", objective: true },
+            ],
+            edges: [],
+          },
+        }),
+      ),
+      // The detail page draws the server-side projection — the SAME graph a run starts from.
+      http.get("*/api/missions/idor/terrain", () =>
+        HttpResponse.json({
+          run_id: "",
+          mission_id: "idor",
+          summary: "Reach the vault.",
+          groups: [
+            { id: "dmz", label: "DMZ", description: null, kind: "segment", order: 2, hidden: false, discovered: false },
+          ],
+          nodes: [
+            { id: "web", label: "web", group: "dmz", type: "service", objective: false,
+              description: null, discovery_condition: null, completion_condition: null, state: "defined" },
+            { id: "vault", label: "vault", group: "dmz", type: "service", objective: true,
+              description: null, discovery_condition: null, completion_condition: null, state: "defined" },
+          ],
+          edges: [],
+          updates: [],
+          attribution: null,
+          objective_id: "vault",
+        }),
+      ),
+    );
+
+    const { container } = renderWithProviders(<MissionDetail id="idor" />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "IDOR" })).toBeInTheDocument(),
+    );
+    // The real SVG renderer, not the old linear flow simplification.
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="terrain-svg"]')).toBeInTheDocument(),
+    );
+    expect(container.querySelectorAll("[data-node-id]").length).toBe(2);
+    // The objective keeps its ⊗ grammar on the preview too.
+    expect(container.querySelector('[data-node-objective="true"]')).toBeInTheDocument();
+    // The authored summary rides in the map's header strip.
+    expect(screen.getByText("Reach the vault.")).toBeInTheDocument();
+  });
+});
+
 describe("MissionDetail deterministic check prerequisites", () => {
   it("shows which check must pass before a dependent check earns credit", async () => {
     server.use(

--- a/frontend/src/features/missions/mission-detail.tsx
+++ b/frontend/src/features/missions/mission-detail.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
-  ArrowRight,
-  Bot,
   Boxes,
   Cpu,
   Crosshair,
   Download,
   FileText,
   FlaskConical,
-  Flag,
   Lightbulb,
   Loader2,
   ListChecks,
@@ -34,6 +31,7 @@ import { Reveal } from "@/components/ui/reveal";
 import { NotFoundState } from "@/components/layout/not-found-state";
 import type { CatalogEntry, MissionManifest } from "@/lib/api/types";
 import { PullProgressBlock } from "./mission-card";
+import { MissionTerrain } from "./mission-terrain";
 import {
   useMission,
   useMissionManifest,
@@ -615,171 +613,18 @@ function ManifestSections({
       )}
 
       {m.terrain && (
-        <Section icon={MapIcon} title="Terrain">
-          <TerrainPreview terrain={m.terrain} />
+        <Section
+          icon={MapIcon}
+          title="Terrain"
+          helpText="The actual mission map — exactly what the live run view draws, before any run exists."
+        >
+          {/* The real renderer, not the old linear Agent → Service flow: the server projects
+              the authored terrain through the same projector a run uses, so layout, legend
+              and hover popovers match the live map one-for-one. */}
+          <MissionTerrain missionId={m.metadata.mission_id} />
         </Section>
       )}
     </>
-  );
-}
-
-/* ── Terrain preview ── */
-
-type FlowStep = {
-  id: string;
-  label: string;
-  sub: string;
-  objective: boolean;
-  isAgent: boolean;
-  edgeFull?: string;
-  edgeCaption?: string;
-};
-
-const str = (x: unknown): string => (typeof x === "string" ? x : "");
-
-/** A short "PROTO :port" caption pulled from a free-text edge label (ports aren't structured). */
-function edgeCaption(label: string): string {
-  const port = label.match(/:\d{2,5}\b/)?.[0] ?? "";
-  const proto =
-    label.match(
-      /\b(HTTPS?|SSH|FTP|SMB|RDP|DNS|TCP|UDP|SSRF|SQLi?|LDAP|SMTP|gRPC|WS|API)\b/i,
-    )?.[0] ?? "";
-  return [proto, port].filter(Boolean).join(" ");
-}
-
-/**
- * Best-effort linear flow (Agent → Service → …) from the loosely-typed terrain graph.
- * Returns null when there aren't enough connected edges to draw one — the caller then
- * falls back to the summary text.
- */
-function buildFlow(terrain: NonNullable<MissionManifest["terrain"]>): FlowStep[] | null {
-  const nodes = new Map<string, { label: string; sub: string; objective: boolean }>();
-  for (const n of terrain.nodes ?? []) {
-    const id = str((n as Record<string, unknown>).id);
-    if (!id) continue;
-    const type = str((n as Record<string, unknown>).type);
-    nodes.set(id, {
-      label: type ? titleCase(type) : titleCase(id),
-      sub: id,
-      objective: (n as Record<string, unknown>).objective === true,
-    });
-  }
-
-  const edges = (terrain.edges ?? [])
-    .map((e) => {
-      const r = e as Record<string, unknown>;
-      return { src: str(r.src), dst: str(r.dst), label: str(r.label) };
-    })
-    .filter((e) => e.src && e.dst);
-  if (edges.length === 0) return null;
-
-  const out = new Map<string, { dst: string; label: string }[]>();
-  const incoming = new Set<string>();
-  for (const e of edges) {
-    if (!out.has(e.src)) out.set(e.src, []);
-    out.get(e.src)!.push({ dst: e.dst, label: e.label });
-    incoming.add(e.dst);
-  }
-
-  const start =
-    (out.has("agent") && "agent") ||
-    [...out.keys()].find((k) => !incoming.has(k)) ||
-    edges[0].src;
-
-  const steps: FlowStep[] = [];
-  const seen = new Set<string>();
-  let cur: string | undefined = start;
-  let edgeFull: string | undefined;
-  while (cur && !seen.has(cur)) {
-    seen.add(cur);
-    const meta = nodes.get(cur);
-    const isAgent = cur === "agent";
-    steps.push({
-      id: cur,
-      label: meta?.label ?? (isAgent ? "Agent" : titleCase(cur)),
-      sub: meta?.sub ?? cur,
-      objective: meta?.objective ?? false,
-      isAgent,
-      edgeFull,
-      edgeCaption: edgeFull ? edgeCaption(edgeFull) : undefined,
-    });
-    const nexts = out.get(cur);
-    if (!nexts || nexts.length === 0) break;
-    const nxt = nexts.find((n) => !seen.has(n.dst)) ?? nexts[0];
-    edgeFull = nxt.label || undefined;
-    cur = nxt.dst;
-  }
-
-  return steps.length >= 2 ? steps : null;
-}
-
-function TerrainPreview({
-  terrain,
-}: {
-  terrain: NonNullable<MissionManifest["terrain"]>;
-}) {
-  const flow = buildFlow(terrain);
-  const summary = terrain.summary?.trim();
-
-  if (!flow && !summary) {
-    return (
-      <p className="text-dense text-text-tertiary">
-        No terrain map available for this mission.
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      {flow && (
-        <div className="flex flex-wrap items-stretch gap-2 rounded-lg border border-border bg-background/60 p-3">
-          {flow.map((s, i) => (
-            <Fragment key={s.id}>
-              {i > 0 && (
-                <div
-                  className="flex flex-col items-center justify-center gap-1 self-center"
-                  title={s.edgeFull}
-                >
-                  <ArrowRight className="size-4 text-text-tertiary" />
-                  {s.edgeCaption && (
-                    <span className="font-mono text-caption text-text-tertiary">
-                      {s.edgeCaption}
-                    </span>
-                  )}
-                </div>
-              )}
-              <div
-                className={cn(
-                  "flex min-w-[92px] flex-col items-center gap-1 rounded-lg border px-3 py-2 text-center",
-                  s.objective
-                    ? "border-primary/40 bg-primary/[0.08]"
-                    : s.isAgent
-                      ? "border-tool/40 bg-tool/[0.08]"
-                      : "border-border bg-raised",
-                )}
-              >
-                {s.isAgent ? (
-                  <Bot className="size-4 text-tool" />
-                ) : s.objective ? (
-                  <Flag className="size-4 text-primary" />
-                ) : (
-                  <Server className="size-4 text-text-secondary" />
-                )}
-                <span className="text-dense text-heading">{s.label}</span>
-                {s.sub && s.sub.toLowerCase() !== s.label.toLowerCase() && (
-                  <span className="font-mono text-caption text-text-tertiary">
-                    {s.sub}
-                  </span>
-                )}
-              </div>
-            </Fragment>
-          ))}
-        </div>
-      )}
-      {summary && (
-        <p className="max-w-full break-words text-body text-text-secondary">{summary}</p>
-      )}
-    </div>
   );
 }
 

--- a/frontend/src/features/missions/mission-terrain.tsx
+++ b/frontend/src/features/missions/mission-terrain.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { TerrainMapView } from "@/features/live-trace/terrain-map";
+import { useMissionTerrain } from "./queries";
+
+/**
+ * The ACTUAL terrain map for a mission — the same renderer the live run view draws, fed the
+ * mission-scoped projection (infra scaffold + authored mission plane, every element in its
+ * base state, no updates). Replaces the old linear Agent → Service flow simplification on
+ * the detail page: same layout, legend, pan/zoom and hover popovers as a run's map, so what
+ * you study here is exactly what you watch there.
+ */
+export function MissionTerrain({ missionId }: { missionId: string }) {
+  const terrain = useMissionTerrain(missionId);
+  return (
+    // The map renderer fills its container (the viewport keeps its own 360px floor); a fixed
+    // height here keeps the detail page's reading flow — the map is one section, not the page.
+    <div className="h-[480px] min-h-0">
+      <TerrainMapView
+        terrain={terrain.data ?? null}
+        isError={terrain.isError}
+        resetKey={missionId}
+        caption="The map an agent explores during a run — mission nodes start unknown (grey) and color in live · hover a node for details."
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/missions/queries.ts
+++ b/frontend/src/features/missions/queries.ts
@@ -9,6 +9,7 @@ import type {
   IngestStarted,
   PullJobStarted,
   PullJobView,
+  ResolvedTerrainV2,
 } from "@/lib/api/types";
 
 export function useMissions() {
@@ -226,6 +227,20 @@ export function useDeleteMission() {
     mutationFn: (id: string) =>
       api.del(`/missions/${encodeURIComponent(id)}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["missions"] }),
+  });
+}
+
+/** The mission's projected v2 terrain — the same base graph a run of it starts from
+ * (infra scaffold + authored mission plane, no run, no updates). Static per mission
+ * version, so no polling. */
+export function useMissionTerrain(id: string) {
+  return useQuery({
+    queryKey: ["missions", id, "terrain"],
+    queryFn: () =>
+      api.get<ResolvedTerrainV2>(
+        `/missions/${encodeURIComponent(id)}/terrain`,
+      ),
+    enabled: !!id,
   });
 }
 

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -529,6 +529,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/missions/{mission_id}/terrain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Mission Terrain
+         * @description The mission's projected v2 terrain — the same base graph a run of it starts from.
+         *
+         *     Runs the run-scoped projector over the manifest (installed copy, else the library) with
+         *     no run attached: infra scaffold + authored/static-ips mission plane, every element in its
+         *     base state, no updates. This is what the mission detail page draws so the ACTUAL terrain
+         *     map — not a simplification — is visible before a run (or a pull). Unknown id → 404.
+         */
+        get: operations["mission_terrain_api_missions__mission_id__terrain_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs": {
         parameters: {
             query?: never;
@@ -3563,6 +3588,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PullJobStarted"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mission_terrain_api_missions__mission_id__terrain_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                mission_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResolvedTerrainV2"];
                 };
             };
             /** @description Validation Error */

--- a/src/xorcise/core/rest/routers/missions.py
+++ b/src/xorcise/core/rest/routers/missions.py
@@ -14,6 +14,7 @@ from xorcise.core.config import get_settings
 from xorcise.core.contracts.catalog import CatalogEntry
 from xorcise.core.contracts.errors import NotFoundError
 from xorcise.core.contracts.mission import MissionManifest, MissionMetadata
+from xorcise.core.contracts.terrain import ResolvedTerrainV2
 from xorcise.core.missions.errors import MissionCollisionError
 from xorcise.core.rest.catalog_view import build_catalog_view_deps, fetch_manifest, list_catalog
 from xorcise.core.rest.ingest import ingest_bundle
@@ -345,3 +346,23 @@ def mission_manifest(mission_id: str) -> MissionManifest:
         return fetch_manifest(mission_id, build_catalog_view_deps(get_settings()))
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=f"no mission '{mission_id}'") from exc
+
+
+@router.get("/{mission_id}/terrain", response_model=ResolvedTerrainV2)
+def mission_terrain(mission_id: str) -> ResolvedTerrainV2:
+    """The mission's projected v2 terrain — the same base graph a run of it starts from.
+
+    Runs the run-scoped projector over the manifest (installed copy, else the library) with
+    no run attached: infra scaffold + authored/static-ips mission plane, every element in its
+    base state, no updates. This is what the mission detail page draws so the ACTUAL terrain
+    map — not a simplification — is visible before a run (or a pull). Unknown id → 404."""
+    # Lazy: same plane-isolation rule as runs.py's terrain endpoint — keep the runs module off
+    # this router's import path at boot (the projector itself is pure, contracts-only).
+    from xorcise.core.runs.terrain_v2 import project_terrain_v2
+
+    try:
+        manifest = fetch_manifest(mission_id, build_catalog_view_deps(get_settings()))
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"no mission '{mission_id}'") from exc
+    # run_id "" — mission-scoped, there is no run; the graph is identical to a fresh run's.
+    return project_terrain_v2("", mission_id, manifest)

--- a/tests/unit/test_mission_terrain_rest.py
+++ b/tests/unit/test_mission_terrain_rest.py
@@ -1,0 +1,90 @@
+"""GET /api/missions/{id}/terrain — the mission's projected v2 base terrain.
+
+The endpoint runs the run-scoped projector over the manifest with no run attached, so the
+mission detail page can draw the ACTUAL terrain map (infra scaffold + authored mission
+plane) before a run — or a pull — exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from xorcise.core.contracts.control import MissionRef
+from xorcise.core.contracts.mission import (
+    EnvironmentSpec,
+    MissionManifest,
+    MissionMetadata,
+    TerrainSpec,
+)
+from xorcise.core.missions.runtime import INSTALLED_FILE, InstalledMission
+from xorcise.core.roles.boot.role_all import build_rest_app
+
+pytestmark = pytest.mark.unit
+
+
+def _client() -> TestClient:
+    return TestClient(build_rest_app())
+
+
+def _install_with_terrain(home: Path, slug: str = "terr") -> None:
+    """An installed mission whose manifest authors a two-node terrain with an objective."""
+    root = Path(home) / "missions" / slug
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = MissionManifest(
+        schema_version="2.0",
+        metadata=MissionMetadata(mission_id=slug, name=slug, objective="Solve it.", type="lab"),
+        environment=EnvironmentSpec(),
+        terrain=TerrainSpec(
+            summary="Reach the vault.",
+            groups=({"id": "dmz", "label": "DMZ"},),
+            nodes=(
+                {"id": "web", "parent": "dmz", "label": "web"},
+                {"id": "vault", "parent": "dmz", "label": "vault", "objective": True},
+            ),
+            edges=({"id": "e-agent-web", "src": "agent", "dst": "web"},),
+        ),
+    )
+    ref = MissionRef(mission_id=slug, image=f"xorcise/mission-{slug}:0")
+    (root / INSTALLED_FILE).write_text(InstalledMission(slug, root, manifest, ref).to_record())
+
+
+def test_terrain_projects_scaffold_plus_authored_graph(migrated_home):
+    _install_with_terrain(migrated_home)
+    r = _client().get("/api/missions/terr/terrain")
+    assert r.status_code == 200
+    body = r.json()
+    node_ids = {n["id"] for n in body["nodes"]}
+    # The fixed infra scaffold AND the authored mission plane — the same graph a run starts from.
+    assert {"agent", "collector", "web", "vault"} <= node_ids
+    assert body["objective_id"] == "vault"
+    assert body["summary"] == "Reach the vault."
+    assert body["mission_id"] == "terr"
+    # Mission-scoped: no run, nothing folded.
+    assert body["run_id"] == ""
+    assert body["updates"] == []
+    assert {e["id"] for e in body["edges"]} >= {"e-agent-web"}
+
+
+def test_terrain_for_library_mission_when_connected(migrated_home, monkeypatch):
+    # Hermetic: the fixture library resolves the manifest, no live remote (mirrors the
+    # manifest endpoint's test).
+    from xorcise.core.catalog import StubCatalogSource
+    from xorcise.core.rest import catalog_view
+
+    monkeypatch.setattr(
+        catalog_view, "build_catalog_source", lambda settings: StubCatalogSource(enabled=True)
+    )
+    r = _client().get("/api/missions/sqli-login/terrain")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mission_id"] == "sqli-login"
+    # Even with no authored terrain the projector degrades to the infra scaffold, never 500s.
+    assert {"agent", "collector"} <= {n["id"] for n in body["nodes"]}
+
+
+def test_terrain_unknown_is_404(migrated_home):
+    r = _client().get("/api/missions/does-not-exist/terrain")
+    assert r.status_code == 404


### PR DESCRIPTION
## What changed

The mission detail page now draws the ACTUAL terrain map — the same SVG renderer the live
run view uses — instead of the hand-rolled linear Agent → Service flow. A new
`GET /missions/{id}/terrain` endpoint runs the run-scoped v2 projector over the manifest
(installed copy, else the library) with no run attached: infra scaffold + authored mission
plane, every element in its base state, no updates. `TerrainMap` splits into a query-free
`TerrainMapView` plus the existing run-scoped fetch wrapper; the mission page feeds the view
its own mission-scoped query. The linear-flow code is deleted.

## Why

The old preview was a simplification: it flattened the authored graph to one linear chain,
dropping groups, branches, and the map grammar (objective ⊗, legend, descriptions, routes).
An operator studying a mission before running it now sees exactly the graph a run of it
starts from — same layout, legend, pan/zoom, and hover popovers as the live map.

## Testing

```
$ uv run pytest -m "unit or adapters or topology" -q
2072 passed, 1 skipped, 37 deselected in 44.05s

$ uv run mypy
Success: no issues found in 472 source files

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
478 files already formatted

$ uv run lint-imports
Contracts: 4 kept, 0 broken.

$ cd frontend && npm run typecheck && npm test
tsc --noEmit: clean
Tests  676 passed (676)
```

New coverage: `tests/unit/test_mission_terrain_rest.py` (scaffold + authored projection,
library fallback, 404) and a `MissionDetail terrain` case asserting the real SVG renderer
(not the flow boxes) draws the server projection.

**Test lanes affected**:

- [x] `unit` — no Docker, fast
- [ ] `adapters` — port/adapter contracts
- [x] `topology` — manifest / compose / import / extras parity
- [ ] `integration` — needs Docker or a live server process
- [ ] `e2e` — full `xorcise up` + scripted agent
- [x] `frontend` — Next.js typecheck / vitest

## User-facing impact

- [ ] No user-visible change (internal refactor, tests, docs only)
- [x] Backwards-compatible addition (new command, new optional flag, new field)
- [ ] **Breaking change** — describe the break and the migration path below

New REST endpoint `GET /missions/{id}/terrain`; the mission detail page's Terrain section
changes appearance (real map replaces the simplified flow). No existing contract changes.

## Documentation

- [x] No documentation change needed
- [ ] Documentation updated in this PR
- [ ] Documentation needed and tracked in a follow-up issue (link it)

## Dependencies

- [x] No dependency changes
- [ ] Dependencies changed **and** the lockfile is committed

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in
      the diff — including in test fixtures, logs and comments
- [x] No references to internal-only systems (private trackers, internal URLs, internal
      process names) in code or documentation

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA
      assistant comments below. If I am contributing in the course of employment, my employer
      has signed the Corporate CLA.
