### PR TITLE
feat(runs): fullscreen toggle for the live run's terrain map

### DIFF
--- a/frontend/src/features/live-trace/run-live.tsx
+++ b/frontend/src/features/live-trace/run-live.tsx
@@ -494,6 +494,9 @@ export function RunLive({ runId }: { runId: string | null }) {
               active={!terminal}
               selectedEventId={selectedEventId}
               attributionOff={attributionOff}
+              // fullscreen toggle — the split pane is fine for glancing, not for reading a
+              // large graph; expanded, the same map instance fills the viewport.
+              expandable
               onHoverEvents={setHoveredEventIds}
               onReturnToLive={() => setSelectedEventId(null)}
             />

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -1056,4 +1056,62 @@ describe("TerrainMap", () => {
     });
   });
 
+  describe("fullscreen toggle (expandable)", () => {
+    const graph = terrain({
+      groups: [{ id: "g", label: "Group", description: null, kind: "segment", order: 0, hidden: false, discovered: true }],
+      nodes: [
+        { id: "web", label: "web", group: "g", type: "service", objective: false, description: null,
+          discovery_condition: null, completion_condition: null, state: "defined" },
+      ] as ResolvedTerrainV2["nodes"],
+    });
+
+    test("no fullscreen control unless expandable is passed", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" />);
+      await screen.findByText("web");
+      expect(screen.queryByRole("button", { name: "fullscreen" })).toBeNull();
+    });
+
+    test("expands into a modal overlay, and the toggle collapses it again", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" expandable />);
+      await screen.findByText("web");
+      expect(screen.queryByRole("dialog")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
+      const overlay = screen.getByRole("dialog");
+      expect(overlay).toBeInTheDocument();
+      expect(overlay.className).toContain("fixed");
+      // SAME instance re-homed, not a second map: still exactly one SVG.
+      expect(screen.getAllByTestId("terrain-svg")).toHaveLength(1);
+
+      fireEvent.click(screen.getByRole("button", { name: "exit fullscreen" }));
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    test("Escape closes the expanded overlay", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" expandable />);
+      await screen.findByText("web");
+      fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      // the map itself is still there, back in its pane
+      expect(screen.getByTestId("terrain-svg")).toBeInTheDocument();
+    });
+
+    test("clicking the backdrop closes; clicking inside the card does not", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" expandable />);
+      await screen.findByText("web");
+      fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
+      const overlay = screen.getByRole("dialog");
+      fireEvent.click(screen.getByTestId("terrain-viewport")); // inside the card
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      fireEvent.click(overlay); // the backdrop itself
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
 });

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -1101,6 +1101,41 @@ describe("TerrainMap", () => {
       expect(screen.getByTestId("terrain-svg")).toBeInTheDocument();
     });
 
+    test("the expanded overlay portals to document.body, escaping transformed ancestors", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" expandable />);
+      await screen.findByText("web");
+      fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
+      // REGRESSION: the narrow layout mounts the map under an ancestor that animates
+      // `transform` (TabsContent's fade-up entrance) — `fixed` positions against such an
+      // ancestor, not the viewport, so anything short of a body-level portal pins the
+      // "fullscreen" overlay inside the Terrain pane.
+      expect(screen.getByRole("dialog").parentElement).toBe(document.body);
+    });
+
+    test("wheel zoom still works after a fullscreen round-trip (re-created viewport re-binds)", async () => {
+      server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
+      renderWithProviders(<TerrainMap runId="r1" expandable />);
+      await screen.findByText("web");
+      fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
+      fireEvent.click(screen.getByRole("button", { name: "exit fullscreen" }));
+      // The portal toggle re-creates the viewport ELEMENT; the native wheel listener must
+      // re-attach to it (for a terminal run `layout` never changes to re-run the attach).
+      const viewport = screen.getByTestId("terrain-viewport");
+      const scale = () => {
+        const layer = screen.getByTestId("terrain-svg").parentElement as HTMLElement;
+        const m = /scale\(([\d.]+)\)/.exec(layer.style.transform || "");
+        return m ? parseFloat(m[1]) : 1;
+      };
+      const before = scale();
+      act(() => {
+        viewport.dispatchEvent(
+          new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -100, ctrlKey: true }),
+        );
+      });
+      expect(scale()).toBeGreaterThan(before);
+    });
+
     test("clicking the backdrop closes; clicking inside the card does not", async () => {
       server.use(http.get("*/runs/r1/terrain2", () => HttpResponse.json(graph)));
       renderWithProviders(<TerrainMap runId="r1" expandable />);

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
-import { Minus, Plus, Radio } from "lucide-react";
+import { Maximize2, Minimize2, Minus, Plus, Radio } from "lucide-react";
 import { foldIndexForEvent, foldTerrain, probingPathEdgeIds, pulseIdsForIndex, type FoldedNode } from "./terrain-fold";
 import { layoutTerrainV2, type LaidOutEdge, type LaidOutGroup, type LaidOutNode } from "./terrain-layout";
 import { edgeColor, groupStyle, nodeColor, otelActive, T } from "./terrain-colors";
@@ -486,6 +486,7 @@ export function TerrainMap({
   active = false,
   selectedEventId = null,
   attributionOff = false,
+  expandable = false,
   onHoverEvents,
   onReturnToLive,
 }: {
@@ -494,6 +495,7 @@ export function TerrainMap({
   selectedEventId?: string | null;
   onReturnToLive?: () => void;
   attributionOff?: boolean;
+  expandable?: boolean;
   onHoverEvents?: (eventIds: string[]) => void;
 }) {
   const { terrain, isError } = useRunTerrain(runId, active);
@@ -505,6 +507,7 @@ export function TerrainMap({
       active={active}
       selectedEventId={selectedEventId}
       attributionOff={attributionOff}
+      expandable={expandable}
       onHoverEvents={onHoverEvents}
       onReturnToLive={onReturnToLive}
     />
@@ -518,6 +521,7 @@ export function TerrainMapView({
   active = false,
   selectedEventId = null,
   attributionOff = false,
+  expandable = false,
   caption,
   onHoverEvents,
   onReturnToLive,
@@ -539,6 +543,9 @@ export function TerrainMapView({
    *  configured — RunLive derives this from `useConfig().terrain.configured` so TerrainMap
    *  stays presentational/query-free. */
   attributionOff?: boolean;
+  /** Offer the fullscreen toggle (bottom-right cluster): expanded, the card re-homes into a
+   *  fixed full-viewport overlay — Escape, the backdrop, or the toggle collapse it. */
+  expandable?: boolean;
   /** Footer caption override — the default speaks run-language (amber ring / trace events);
    *  the mission preview passes its own. */
   caption?: string;
@@ -622,6 +629,18 @@ export function TerrainMapView({
 
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  // Fullscreen toggle (expandable only): the SAME component instance re-homes into a fixed
+  // overlay — no second map, no remount — so pan/zoom and the shared terrain query carry
+  // over, and the ResizeObserver's auto-fit refits the graph to the larger viewport.
+  const [expanded, setExpanded] = useState(false);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
   // Hover state for the node popover (description + collapsed routes, Change 2). An edge's
   // route-used note (Change 3) is rendered persistently at the edge midpoint instead — no hover
   // state needed for it.
@@ -798,7 +817,20 @@ export function TerrainMapView({
   const hasMissionGroup = (terrain.groups ?? []).some((g) => g.kind === "segment");
 
   return (
-    <div className="flex h-full flex-col rounded-md border border-border bg-card">
+    // Collapsed, the wrapper is layout-transparent (`contents`) so the card sits in the page
+    // exactly as before; expanded, it becomes the fixed backdrop the card fills. One element
+    // whose class flips — not two subtrees — so React never remounts the map mid-toggle.
+    <div
+      className={expanded ? "fixed inset-0 z-50 flex bg-black/60 p-3 sm:p-6" : "contents"}
+      role={expanded ? "dialog" : undefined}
+      aria-modal={expanded || undefined}
+      aria-label={expanded ? "Terrain map — fullscreen" : undefined}
+      onClick={expanded ? () => setExpanded(false) : undefined}
+    >
+      <div
+        className="flex h-full w-full flex-col rounded-md border border-border bg-card"
+        onClick={expanded ? (e) => e.stopPropagation() : undefined}
+      >
       {terrain.summary && (
         // The authored summary, in full. It used to be ONE `truncate`d line with the rest
         // revealed on hover, which cut every shipped mission's summary mid-sentence — they
@@ -960,6 +992,21 @@ export function TerrainMapView({
           className="absolute bottom-2 right-2 flex items-center gap-1 text-text-secondary"
           onPointerDown={(e) => e.stopPropagation()}
         >
+          {expandable && (
+            <button
+              type="button"
+              aria-label={expanded ? "exit fullscreen" : "fullscreen"}
+              title={expanded ? "Exit fullscreen (Esc)" : "Fullscreen"}
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center self-stretch rounded border border-border bg-card px-2 hover:text-foreground"
+            >
+              {expanded ? (
+                <Minimize2 className="size-3" aria-hidden />
+              ) : (
+                <Maximize2 className="size-3" aria-hidden />
+              )}
+            </button>
+          )}
           <button
             type="button"
             aria-label="zoom out"
@@ -1001,6 +1048,7 @@ export function TerrainMapView({
           target attribution off — set a model in Settings
         </p>
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import { Maximize2, Minimize2, Minus, Plus, Radio } from "lucide-react";
 import { foldIndexForEvent, foldTerrain, probingPathEdgeIds, pulseIdsForIndex, type FoldedNode } from "./terrain-fold";
 import { layoutTerrainV2, type LaidOutEdge, type LaidOutGroup, type LaidOutNode } from "./terrain-layout";
@@ -748,7 +749,10 @@ export function TerrainMapView({
     return () => el.removeEventListener("wheel", onWheel);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `layout` re-runs the attach when the
     // container (re)mounts: it only renders once layout exists, so the first mount is never missed.
-  }, [layout, showWheelTip]);
+    // `expanded` is load-bearing too: the fullscreen portal toggle re-creates the viewport
+    // ELEMENT, so without it this native listener stays bound to the detached old node and
+    // wheel zoom dies after a toggle (for a terminal run `layout` never changes to re-run it).
+  }, [layout, showWheelTip, expanded]);
   useEffect(() => {
     // A new subject (run / mission) starts following again from scratch.
     fittedDims.current = null;
@@ -781,7 +785,10 @@ export function TerrainMapView({
     });
     ro.observe(el);
     return () => ro.disconnect();
-  }, [fitToView, hasLayout]);
+    // `expanded` re-attaches the observer to the element the fullscreen portal toggle just
+    // re-created — observe() fires once on attach, which is also what refits the graph to the
+    // new viewport size on both expand and collapse (unless the user has taken control).
+  }, [fitToView, hasLayout, expanded]);
 
   if (isError)
     return (
@@ -816,10 +823,14 @@ export function TerrainMapView({
   // No-model degradation notice: only meaningful once there's a mission (segment) group.
   const hasMissionGroup = (terrain.groups ?? []).some((g) => g.kind === "segment");
 
-  return (
+  const body = (
     // Collapsed, the wrapper is layout-transparent (`contents`) so the card sits in the page
-    // exactly as before; expanded, it becomes the fixed backdrop the card fills. One element
-    // whose class flips — not two subtrees — so React never remounts the map mid-toggle.
+    // exactly as before; expanded, it becomes the fixed backdrop the card fills — rendered
+    // through a body-level portal (see the return below), because `fixed` positions against
+    // the nearest TRANSFORMED ancestor, not the viewport: the narrow layout's TabsContent
+    // animates `transform` (animate-fade-up), which trapped the overlay inside the Terrain
+    // pane. The component instance (zoom/pan/queries) survives the toggle; only the DOM
+    // subtree re-homes, and the element-bound effects above re-attach off `expanded`.
     <div
       className={expanded ? "fixed inset-0 z-50 flex bg-black/60 p-3 sm:p-6" : "contents"}
       role={expanded ? "dialog" : undefined}
@@ -1051,4 +1062,9 @@ export function TerrainMapView({
       </div>
     </div>
   );
+  // Fullscreen must escape every ancestor: a transformed/filtered/overflow-clipping parent
+  // (the tabs' entrance animation, a pane's overflow-hidden) becomes `fixed`'s containing
+  // block and pins the overlay inside the pane. Portaling to <body> is the standard escape.
+  // `expanded` only flips on a user click, so this never runs during SSR/prerender.
+  return expanded ? createPortal(body, document.body) : body;
 }


### PR DESCRIPTION
> Was stacked on #20, which has merged — now rebased onto `main`; the diff is the single
> fullscreen commit.

## What changed

The Terrain pane on the live run view gains a fullscreen toggle in the map's control
cluster: expanded, the SAME map instance re-homes into a fixed full-viewport overlay — no
remount, so pan/zoom state and the shared terrain query carry over, and the auto-fit refits
the graph to the larger viewport. Escape, a backdrop click, or the toggle collapse it back
into the split pane. Opt-in per surface (`expandable`): only the live run view enables it;
the results and mission views are unchanged.

The expanded overlay renders through a **body-level portal**: on non-wide screens the map
lives inside `TabsContent`, whose fade-up entrance animates `transform`, and `position:
fixed` positions against the nearest transformed ancestor — without the portal the
"fullscreen" overlay pinned itself inside the Terrain pane instead of covering the screen.
The portal toggle re-creates the viewport element, so the native wheel listener and the
auto-fit ResizeObserver re-attach off `expanded` (the observer's attach-fire also refits the
graph to the new viewport size in both directions).

## Why

The Terrain|Trace split pane is fine for glancing but too small for reading a large graph —
labels, edge notes, and group structure need more than half a screen. Operators previously
had no way to enlarge the map beyond dragging the divider.

## Testing

```
$ cd frontend && npm run typecheck && npm test
tsc --noEmit: clean
Tests  682 passed (682)   # full suite
```

New coverage in `terrain-map.test.tsx`: no control unless `expandable`; expand → dialog
overlay with the same single SVG instance; toggle, Escape, and backdrop-click all collapse
it; clicks inside the card do not; the overlay portals to `document.body` (regression for
the narrow-layout transformed-ancestor trap); wheel zoom still works after a fullscreen
round-trip (re-created viewport re-binds its native listener).

**Test lanes affected**:

- [ ] `unit` — no Docker, fast
- [ ] `adapters` — port/adapter contracts
- [ ] `topology` — manifest / compose / import / extras parity
- [ ] `integration` — needs Docker or a live server process
- [ ] `e2e` — full `xorcise up` + scripted agent
- [x] `frontend` — Next.js typecheck / vitest

## User-facing impact

- [ ] No user-visible change (internal refactor, tests, docs only)
- [x] Backwards-compatible addition (new command, new optional flag, new field)
- [ ] **Breaking change** — describe the break and the migration path below

## Documentation

- [x] No documentation change needed
- [ ] Documentation updated in this PR
- [ ] Documentation needed and tracked in a follow-up issue (link it)

## Dependencies

- [x] No dependency changes
- [ ] Dependencies changed **and** the lockfile is committed

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in
      the diff — including in test fixtures, logs and comments
- [x] No references to internal-only systems (private trackers, internal URLs, internal
      process names) in code or documentation

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA
      assistant comments below. If I am contributing in the course of employment, my employer
      has signed the Corporate CLA.
