### PR TITLE
feat(missions): show mission download size before pulling

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -729,6 +729,28 @@
       "CatalogEntry": {
         "additionalProperties": false,
         "properties": {
+          "attachments_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attachments Size Bytes"
+          },
+          "download_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Size Bytes"
+          },
           "image": {
             "anyOf": [
               {
@@ -739,6 +761,17 @@
               }
             ],
             "title": "Image"
+          },
+          "image_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Bytes"
           },
           "installed": {
             "default": false,

--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -44,6 +44,41 @@ function EnvironmentBadge({ type }: { type: string }) {
 }
 
 /**
+ * What this mission will cost to download, shown while it is still a decision.
+ *
+ * "up to" is load-bearing, not hedging: this is the mission's full compressed size, but
+ * missions share base layers, so a pull that reuses layers already on disk transfers
+ * strictly less. Quoting it as an exact figure would make a correct pull look broken —
+ * the same confusion that made cached-layer pulls read as "stuck at 0 bytes".
+ *
+ * Renders nothing when the size is unknown (an installed mission, or a catalog that
+ * predates the field) rather than a confident "0 B".
+ */
+function DownloadSize({ mission: c }: { mission: CatalogEntry }) {
+  if (c.download_size_bytes == null) return null;
+  const parts = [
+    c.image_size_bytes != null ? `Image ${formatBytes(c.image_size_bytes)}` : null,
+    c.attachments_size_bytes != null
+      ? `Attachments ${formatBytes(c.attachments_size_bytes)}`
+      : null,
+  ].filter(Boolean);
+  return (
+    <span
+      data-testid="mission-download-size"
+      title={
+        parts.length > 0
+          ? `${parts.join(" · ")}. Shared layers already on disk are not re-downloaded.`
+          : undefined
+      }
+      className="inline-flex items-center gap-1 whitespace-nowrap text-caption text-text-tertiary"
+    >
+      <Download className="size-3" aria-hidden />
+      up to {formatBytes(c.download_size_bytes)}
+    </span>
+  );
+}
+
+/**
  * Determinate-when-sized progress + phase/bytes/ETA caption for an in-flight pull.
  * Shared by the catalog card and the detail page so both render the same live job.
  * Falls back to an indeterminate bar while docker hasn't sized the download yet
@@ -188,10 +223,15 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
               <PullProgressBlock pull={pull} />
             </div>
           ) : (
-            <Button size="sm" onClick={() => pull.start()}>
-              <Download className="size-3.5" />
-              Pull
-            </Button>
+            // Size sits beside the button, not up with the badges: it is the last thing
+            // read before committing, so it belongs at the point of commitment.
+            <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1">
+              <Button size="sm" onClick={() => pull.start()}>
+                <Download className="size-3.5" />
+                Pull
+              </Button>
+              <DownloadSize mission={c} />
+            </div>
           )}
           {pull.isSuccess && (
             <span className="text-caption text-ok">Installed — ready to run.</span>
@@ -252,6 +292,11 @@ export function MissionRow({ mission: c }: { mission: CatalogEntry }) {
           {c.proficiency && <DifficultyBadge proficiency={c.proficiency} />}
           {c.type && <EnvironmentBadge type={c.type} />}
         </div>
+        {!installed && !pull.isPulling && (
+          <span className="hidden shrink-0 lg:inline-flex">
+            <DownloadSize mission={c} />
+          </span>
+        )}
         <Badge variant={installed ? "ok" : "muted"} className="hidden shrink-0 sm:inline-flex">
           {installed ? "installed" : "available"}
         </Badge>

--- a/frontend/src/features/missions/mission-size.test.tsx
+++ b/frontend/src/features/missions/mission-size.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { renderWithProviders } from "@/test/render";
+import { MissionCard, MissionRow } from "./mission-card";
+import type { CatalogEntry } from "@/lib/api/types";
+
+/**
+ * The download size is a decision input BEFORE a pull, so it has to reach the card
+ * while the mission is still "available". It is deliberately absent once installed —
+ * the bytes are already on disk — and absent from a catalog that predates the field,
+ * which must degrade to no badge rather than a confident "0 B".
+ */
+
+const AVAILABLE: CatalogEntry = {
+  source: "library",
+  mission_id: "chrono-canary",
+  name: "Chrono Canary",
+  summary: "Own the time service",
+  installed: false,
+  skills: [],
+  technologies: [],
+  image_size_bytes: 260306509,
+  attachments_size_bytes: 384284,
+  download_size_bytes: 260690793,
+};
+
+beforeEach(() => {
+  server.use(http.get("*/api/missions/pull-jobs", () => HttpResponse.json(null)));
+});
+
+describe("MissionCard download size", () => {
+  it("quotes the download size while the mission is still available", async () => {
+    renderWithProviders(<MissionCard mission={AVAILABLE} />);
+
+    expect(await screen.findByText(/260\.7 MB/)).toBeInTheDocument();
+  });
+
+  it("frames the size as an upper bound, since shared layers transfer less", async () => {
+    renderWithProviders(<MissionCard mission={AVAILABLE} />);
+
+    const size = await screen.findByTestId("mission-download-size");
+    expect(size.textContent).toMatch(/up to/i);
+  });
+
+  it("renders no size for an installed mission — the download already happened", () => {
+    renderWithProviders(
+      <MissionCard mission={{ ...AVAILABLE, installed: true, download_size_bytes: null }} />,
+    );
+
+    expect(screen.queryByTestId("mission-download-size")).not.toBeInTheDocument();
+  });
+
+  it("renders no size when the catalog serves none, rather than 0 B", () => {
+    renderWithProviders(
+      <MissionCard mission={{ ...AVAILABLE, download_size_bytes: null }} />,
+    );
+
+    expect(screen.queryByTestId("mission-download-size")).not.toBeInTheDocument();
+    expect(screen.queryByText(/0 B/)).not.toBeInTheDocument();
+  });
+
+  it("breaks the total down into image and attachments for the curious", async () => {
+    renderWithProviders(<MissionCard mission={AVAILABLE} />);
+
+    const size = await screen.findByTestId("mission-download-size");
+    expect(size.getAttribute("title")).toMatch(/260\.3 MB/); // image
+    expect(size.getAttribute("title")).toMatch(/384\.3 KB/); // attachments
+  });
+});
+
+describe("MissionRow download size", () => {
+  it("quotes the size in the compact row too", async () => {
+    renderWithProviders(
+      <ul>
+        <MissionRow mission={AVAILABLE} />
+      </ul>,
+    );
+
+    expect(await screen.findByText(/260\.7 MB/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -1393,8 +1393,14 @@ export interface components {
         };
         /** CatalogEntry */
         CatalogEntry: {
+            /** Attachments Size Bytes */
+            attachments_size_bytes?: number | null;
+            /** Download Size Bytes */
+            download_size_bytes?: number | null;
             /** Image */
             image?: string | null;
+            /** Image Size Bytes */
+            image_size_bytes?: number | null;
             /**
              * Installed
              * @default false

--- a/src/xorcise/core/catalog/http.py
+++ b/src/xorcise/core/catalog/http.py
@@ -106,6 +106,12 @@ def _to_item(row: dict[str, object]) -> LibraryItem:
         # skills listed"), so an older catalog still degrades cleanly.
         type=_opt_str(row.get("type")),
         skills=_str_tuple(row.get("skills")),
+        # Pull cost, so the card can quote the download before the user commits. Absent on
+        # a catalog deployed before these fields existed -> None ("size unknown"), so an
+        # older remote still browses cleanly.
+        image_size_bytes=_opt_int(row.get("image_size_bytes")),
+        attachments_size_bytes=_opt_int(row.get("attachments_size_bytes")),
+        download_size_bytes=_opt_int(row.get("download_size_bytes")),
     )
 
 
@@ -115,3 +121,16 @@ def _str_tuple(value: object) -> tuple[str, ...]:
 
 def _opt_str(value: object) -> str | None:
     return None if value is None else str(value)
+
+
+def _opt_int(value: object) -> int | None:
+    """A byte count from the wire, or None if absent/unusable.
+
+    Browse must survive a malformed row: a non-numeric size degrades this one field to
+    "unknown" rather than raising and taking the whole catalog view down."""
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/xorcise/core/catalog/source.py
+++ b/src/xorcise/core/catalog/source.py
@@ -30,6 +30,11 @@ class LibraryItem:
     skills: tuple[str, ...] = ()
     technologies: tuple[str, ...] = ()
     image: str | None = None
+    # Pull cost, quoted by the catalog before anything is downloaded. See
+    # contracts.catalog.CatalogEntry for the full semantics; None means unknown, not zero.
+    image_size_bytes: int | None = None
+    attachments_size_bytes: int | None = None
+    download_size_bytes: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/xorcise/core/cli/_ux.py
+++ b/src/xorcise/core/cli/_ux.py
@@ -161,6 +161,29 @@ def difficulty_label(proficiency: str | None) -> str:
     return proficiency.title() if proficiency else DASH
 
 
+def size_label(size_bytes: int | None) -> str:
+    """Byte count → the download size a person reads, or a dash when it is unknown.
+
+    Decimal units, mirroring the GUI's formatBytes (frontend missions/queries.ts) so the
+    CLI and the console quote the same mission with the same number — the parity rule
+    run_state_label follows for run outcomes.
+
+    None means UNKNOWN, not zero: an installed mission carries no size (it is already
+    downloaded) and a catalog predating the size fields serves none. Rendering "0 B"
+    there would state a falsehood, so it reads as a dash.
+    """
+    if size_bytes is None:
+        return DASH
+    n = float(size_bytes)
+    if n >= 1e9:
+        return f"{n / 1e9:.1f} GB"
+    if n >= 1e6:
+        return f"{n / 1e6:.1f} MB"
+    if n >= 1e3:
+        return f"{n / 1e3:.1f} KB"
+    return f"{max(0, round(n))} B"
+
+
 def run_state_label(state: str | None, trigger: str | None = None) -> str:
     """Server-side run state (+ terminal trigger) → the user-facing result word.
 

--- a/src/xorcise/core/cli/commands/mission.py
+++ b/src/xorcise/core/cli/commands/mission.py
@@ -20,6 +20,7 @@ from xorcise.core.cli._ux import (
     next_step,
     print_table,
     prose,
+    size_label,
     source_label,
     ux_table,
 )
@@ -123,7 +124,10 @@ def list_missions(
                 markup=False,
             )
         return
-    table = ux_table("Source", "Id", "Name", "Difficulty", "State", title="Missions")
+    # Size sits beside State because the two answer one question together: an Available
+    # mission is a download you have not made yet, and this is what it will cost. An
+    # installed row has no size to quote (already on disk) and reads as a dash.
+    table = ux_table("Source", "Id", "Name", "Difficulty", "State", "Size", title="Missions")
     ordered = sorted(
         missions,
         key=lambda c: (not c.get("installed"), str(c.get("name") or "").lower()),
@@ -135,6 +139,7 @@ def list_missions(
             str(c.get("name") or DASH),
             difficulty_label(c.get("proficiency")),
             "Installed" if c.get("installed") else "Available",
+            size_label(c.get("download_size_bytes")),
         )
     print_table(table)
 

--- a/src/xorcise/core/contracts/catalog.py
+++ b/src/xorcise/core/contracts/catalog.py
@@ -28,6 +28,20 @@ class CatalogEntry(_Frozen):
     technologies: tuple[str, ...] = ()
     installed: bool = False
     image: str | None = None
+    # What pulling this mission COSTS, so the browse card can say so before the user
+    # commits. Two independent parts — the OCI image the runner pulls and the attachment
+    # bundle fetched out-of-band — either of which may be absent (a static mission has no
+    # image; a lab may declare no attachments). `download_size_bytes` is their sum.
+    #
+    # None means UNKNOWN, never zero: an installed row carries no size (the download is
+    # already done) and a catalog that predates these fields serves none, so the UI must
+    # render "size unknown" rather than a confident "0 B".
+    #
+    # These are COMPRESSED transfer bytes, not extracted disk footprint, and shared base
+    # layers mean a real pull often transfers less — present them as "up to".
+    image_size_bytes: int | None = None
+    attachments_size_bytes: int | None = None
+    download_size_bytes: int | None = None
 
 
 class CatalogStatus(_Frozen):

--- a/src/xorcise/core/rest/catalog_view.py
+++ b/src/xorcise/core/rest/catalog_view.py
@@ -98,6 +98,13 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 technologies=item.technologies,
                 installed=False,
                 image=item.image,
+                # Only the library rows carry a size: these are the ones still facing a
+                # download, which is the decision the number informs. An installed row
+                # leaves them None — its bytes are already on disk, so quoting a download
+                # there would answer a question nobody is asking.
+                image_size_bytes=item.image_size_bytes,
+                attachments_size_bytes=item.attachments_size_bytes,
+                download_size_bytes=item.download_size_bytes,
             )
         )
 

--- a/tests/unit/test_catalog_package_size.py
+++ b/tests/unit/test_catalog_package_size.py
@@ -1,0 +1,209 @@
+"""Package size travels the catalog chain: catalog API → LibraryItem → CatalogEntry.
+
+The browse card has to answer "what will this cost me?" BEFORE the user commits to a
+pull, so the size has to survive every hop between the remote catalog and the UI. Each
+field is independently nullable — a STATIC mission has no image, a LAB may declare no
+attachments, and an older catalog serves none of them — so absent degrades to None
+(render "size unknown") rather than 0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+import xorcise.core.cli.app  # noqa: F401 — registers commands on the shared app
+from xorcise.core.catalog.http import HttpCatalogSource
+from xorcise.core.catalog.source import CatalogSource, LibraryItem
+from xorcise.core.cli._shared import app
+from xorcise.core.cli._ux import DASH, size_label
+from xorcise.core.cli.rest_client import RestClient
+from xorcise.core.contracts.catalog import CatalogStatus
+from xorcise.core.contracts.mission import MissionManifest
+from xorcise.core.rest.catalog_view import CatalogViewDeps, list_catalog
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+_IMAGE = "registry.example.com/xorcise/mis-chrono-canary:abc-base1"
+
+
+def _catalog(**extra: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": "chrono-canary",
+        "name": "Chrono Canary",
+        "objective": "Own the time service.",
+        "difficulty": "Expert",
+        "competencies": ["Penetration"],
+        "technologies": ["c"],
+        "image": _IMAGE,
+    }
+    row.update(extra)
+    return {"catalog": [row]}
+
+
+def _source(payload: dict[str, Any]) -> HttpCatalogSource:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    return HttpCatalogSource(
+        "https://api.example.com", client=httpx.Client(transport=httpx.MockTransport(handler))
+    )
+
+
+def test_library_item_carries_the_sizes_the_catalog_serves():
+    source = _source(
+        _catalog(
+            image_size_bytes=260306509,
+            attachments_size_bytes=384284,
+            download_size_bytes=260690793,
+        )
+    )
+
+    item = source.list_library()[0]
+
+    assert item.image_size_bytes == 260306509
+    assert item.attachments_size_bytes == 384284
+    assert item.download_size_bytes == 260690793
+
+
+def test_catalog_without_size_fields_degrades_to_unknown():
+    """An older catalog deployment serves no size keys; the client must still parse."""
+    item = _source(_catalog()).list_library()[0]
+
+    assert item.image_size_bytes is None
+    assert item.attachments_size_bytes is None
+    assert item.download_size_bytes is None
+
+
+def test_static_mission_carries_only_an_attachment_size():
+    source = _source(
+        _catalog(
+            image=None,
+            attachments_size_bytes=41300000,
+            download_size_bytes=41300000,
+        )
+    )
+
+    item = source.list_library()[0]
+
+    assert item.image_size_bytes is None
+    assert item.attachments_size_bytes == 41300000
+    assert item.download_size_bytes == 41300000
+
+
+def test_non_numeric_size_is_ignored_rather_than_crashing_browse():
+    """A malformed catalog row must not take the whole browse view down with it."""
+    item = _source(_catalog(download_size_bytes="lots")).list_library()[0]
+
+    assert item.download_size_bytes is None
+
+
+class _FakeSource(CatalogSource):
+    def __init__(self, items: tuple[LibraryItem, ...]) -> None:
+        self._items = items
+
+    def list_library(self) -> tuple[LibraryItem, ...]:
+        return self._items
+
+    def status(self) -> CatalogStatus:
+        return CatalogStatus(state="connected")
+
+    def fetch_manifest(self, mission_id: str) -> MissionManifest:  # pragma: no cover
+        raise NotImplementedError
+
+
+def test_browse_entry_exposes_the_size_to_the_ui(tmp_path: Path):
+    """The last hop: catalog_view must carry the size onto the CatalogEntry the UI reads."""
+    source = _FakeSource(
+        (
+            LibraryItem(
+                mission_id="chrono-canary",
+                name="Chrono Canary",
+                image=_IMAGE,
+                image_size_bytes=260306509,
+                attachments_size_bytes=384284,
+                download_size_bytes=260690793,
+            ),
+        )
+    )
+
+    entry = list_catalog(CatalogViewDeps(source=source, install_root=tmp_path))[0]
+
+    assert entry.installed is False
+    assert entry.image_size_bytes == 260306509
+    assert entry.attachments_size_bytes == 384284
+    assert entry.download_size_bytes == 260690793
+
+
+# --- CLI surface -----------------------------------------------------------------
+# `xorcise mission list` is the CLI half of the browse card, so it quotes the same
+# number in the same vocabulary the GUI uses (frontend formatBytes) — the parity rule
+# run_state_label already follows.
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(260690793, "260.7 MB"), (1381434670, "1.4 GB"), (6534, "6.5 KB"), (512, "512 B")],
+)
+def test_size_label_matches_the_gui_vocabulary(raw: int, expected: str):
+    assert size_label(raw) == expected
+
+
+def test_size_label_of_unknown_is_a_dash_not_zero():
+    assert size_label(None) == DASH
+
+
+def _wire_missions(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, Any]]) -> None:
+    def fake_get(self: RestClient, path: str, **kwargs: Any) -> Any:
+        assert path == "/missions"
+        return rows
+
+    monkeypatch.setattr(RestClient, "get", fake_get)
+
+
+def test_mission_list_quotes_the_download_size(monkeypatch: pytest.MonkeyPatch):
+    _wire_missions(
+        monkeypatch,
+        [
+            {
+                "source": "library",
+                "mission_id": "chrono-canary",
+                "name": "Chrono Canary",
+                "proficiency": "expert",
+                "installed": False,
+                "download_size_bytes": 260690793,
+            }
+        ],
+    )
+
+    result = runner.invoke(app, ["mission", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "260.7 MB" in result.output
+
+
+def test_mission_list_shows_a_dash_when_the_size_is_unknown(monkeypatch: pytest.MonkeyPatch):
+    """An installed mission carries no size — the download already happened."""
+    _wire_missions(
+        monkeypatch,
+        [
+            {
+                "source": "library",
+                "mission_id": "chrono-canary",
+                "name": "Chrono Canary",
+                "proficiency": "expert",
+                "installed": True,
+            }
+        ],
+    )
+
+    result = runner.invoke(app, ["mission", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "MB" not in result.output


### PR DESCRIPTION
## Why

Browsing the catalog told you what a mission **is** and what it teaches, but not what it **costs** to install. Some missions are over a gigabyte. "Pull" was a commitment made blind, and on a slow link the first real feedback arrived minutes later.

## What changed

The catalog now carries the download size, and both surfaces quote it at the point of decision.

**GUI** — the mission card shows the size beside the Pull button, with the breakdown in its tooltip:

```
[ Pull ]  ⬇ up to 260.7 MB
          title: Image 260.3 MB · Attachments 384.3 KB.
                 Shared layers already on disk are not re-downloaded.
```

**CLI** — `xorcise mission list` gains a Size column:

```
 Source    Id              Name            Difficulty   State       Size
 Library   chrono-canary   Chrono Canary   Expert       Available   260.7 MB
 Library   breachpoint     Breachpoint     Expert       Available   1.4 GB
 Your Own  my-lab          My Lab          Advanced     Installed   —
```

## The contract

`CatalogEntry` gains three fields:

| Field | Meaning |
|---|---|
| `image_size_bytes` | the fused OCI image the runner pulls |
| `attachments_size_bytes` | the attachment bundle fetched out-of-band |
| `download_size_bytes` | their sum — what the card quotes |

Each is **independently nullable**, because a mission's download is two genuinely independent parts: a static mission has no image, and a lab may declare no attachments.

**Null means unknown, never zero.** An installed mission carries no size — its bytes are already on disk, so quoting a download would answer a question nobody is asking. A catalog deployed before these fields serves none. Both render as no badge (GUI) or a dash (CLI), never a confident `0 B`.

## Three decisions worth a reviewer's attention

**1. "up to" is load-bearing, not hedging.** The figure is the mission's full compressed size, but missions share base layers, so a pull that reuses layers already on disk transfers strictly less. Quoting it as exact would make a correct pull look like it had stalled — the same class of confusion that made cached-layer pulls read as "stuck at 0 bytes".

**2. A malformed size degrades one field, not the whole view.** `_opt_int` returns `None` for anything non-numeric rather than raising, so one bad catalog row cannot take browse down with it.

**3. `size_label` mirrors the GUI's `formatBytes`.** Decimal units in both, so the CLI and the console quote the same mission with the same number — the parity rule `run_state_label` already follows for run outcomes.

## Where the numbers come from

The sizes are computed server-side by the catalog and served on `/v1/catalog`; this change is purely the client half — parse, carry, display. Nothing is measured locally and no extra request is made: the fields ride along on the browse response the client already fetches.

## Compatibility

Additive and backward-compatible in both directions:

- Against a catalog that **does not** serve these fields, every size reads as unknown and browse is otherwise unchanged — no error, no empty state.
- `CatalogEntry`'s new fields all default to `None`, so any existing consumer of `GET /missions` is unaffected.

## Verification

- `pytest -m "unit or adapters or topology"` — **2085 passed, 0 failures**
- `vitest run` — **682 passed across 95 files**
- `mypy` — clean, 473 source files
- `ruff check .` — clean
- `lint-imports` — 4 contracts kept, 0 broken
- `tsc --noEmit` — clean

`frontend/openapi.json` and `src/lib/api/schema.ts` are regenerated through the canonical chain (`dump_openapi.py` → `npm run codegen`); the spec diff is purely the three added properties, no unrelated drift.

New tests cover the whole chain in one file (`tests/unit/test_catalog_package_size.py`): wire → `LibraryItem` → `CatalogEntry` → CLI, plus the malformed-row and unknown-size paths. `frontend/src/features/missions/mission-size.test.tsx` covers the card and the compact row, including the two cases that must render *nothing*.
