### PR TITLE
fix(missions): address review on the download-size display

### DIFF
--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -46,34 +46,44 @@ function EnvironmentBadge({ type }: { type: string }) {
 /**
  * What this mission will cost to download, shown while it is still a decision.
  *
- * "up to" is load-bearing, not hedging: this is the mission's full compressed size, but
- * missions share base layers, so a pull that reuses layers already on disk transfers
- * strictly less. Quoting it as an exact figure would make a correct pull look broken —
- * the same confusion that made cached-layer pulls read as "stuck at 0 bytes".
+ * The card shows the bare figure; the CEILING caveat lives in the tooltip. This is the
+ * mission's full compressed size, but missions share base layers — 17 of 19 labs sit on
+ * one base image — so the first pull transfers this much and later pulls transfer roughly
+ * half. Hedging the label ("up to …") bought accuracy at the cost of reading as vagueness
+ * on a first pull, where the figure is exact; the tooltip carries the nuance instead.
  *
  * Renders nothing when the size is unknown (an installed mission, or a catalog that
  * predates the field) rather than a confident "0 B".
  */
-function DownloadSize({ mission: c }: { mission: CatalogEntry }) {
+function DownloadSize({ mission: c, className }: { mission: CatalogEntry; className?: string }) {
   if (c.download_size_bytes == null) return null;
-  const parts = [
+  // Only worth breaking down when the total actually decomposes. A mission with no
+  // attachments would otherwise read "280.5 MB — Image 280.5 MB", stating one number twice.
+  const known = [
     c.image_size_bytes != null ? `Image ${formatBytes(c.image_size_bytes)}` : null,
     c.attachments_size_bytes != null
       ? `Attachments ${formatBytes(c.attachments_size_bytes)}`
       : null,
   ].filter(Boolean);
+  const parts = known.length > 1 ? known : [];
+  // The layer caveat is about the IMAGE. A static mission is an attachment bundle with no
+  // layers at all, so its figure is exact and the caveat would describe something that
+  // cannot happen. With no breakdown and no caveat there is nothing left to say — omit
+  // the tooltip entirely rather than attach an empty one.
+  const caveat = c.image_size_bytes != null
+    ? "Shared layers already on disk are not re-downloaded, so a later pull transfers less."
+    : "";
+  const tooltip = [parts.join(" · "), caveat].filter(Boolean).join(". ");
+  // No icon: this sits directly beside the Pull button, which already carries the download
+  // glyph. A second identical icon read as two separate affordances rather than one action
+  // and its cost.
   return (
     <span
       data-testid="mission-download-size"
-      title={
-        parts.length > 0
-          ? `${parts.join(" · ")}. Shared layers already on disk are not re-downloaded.`
-          : undefined
-      }
-      className="inline-flex items-center gap-1 whitespace-nowrap text-caption text-text-tertiary"
+      title={tooltip || undefined}
+      className={cn("whitespace-nowrap text-caption text-text-tertiary", className)}
     >
-      <Download className="size-3" aria-hidden />
-      up to {formatBytes(c.download_size_bytes)}
+      {formatBytes(c.download_size_bytes)}
     </span>
   );
 }
@@ -223,8 +233,9 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
               <PullProgressBlock pull={pull} />
             </div>
           ) : (
-            // Size sits beside the button, not up with the badges: it is the last thing
-            // read before committing, so it belongs at the point of commitment.
+            // Size sits immediately beside the button, not flush right: it is the cost OF
+            // this action, and pushing it to the far edge separated the two enough that it
+            // read as unrelated card metadata rather than a caption on the button.
             <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1">
               <Button size="sm" onClick={() => pull.start()}>
                 <Download className="size-3.5" />

--- a/frontend/src/features/missions/mission-detail.tsx
+++ b/frontend/src/features/missions/mission-detail.tsx
@@ -33,6 +33,7 @@ import type { CatalogEntry, MissionManifest } from "@/lib/api/types";
 import { PullProgressBlock } from "./mission-card";
 import { MissionTerrain } from "./mission-terrain";
 import {
+  formatBytes,
   useMission,
   useMissionManifest,
   useDeleteMission,
@@ -277,6 +278,37 @@ export function MissionDetail({ id }: { id: string | null }) {
                 This mission lives in the XORCISE remote library. Pull it to install
                 locally, or just start a run — it’s pulled automatically on start.
               </p>
+              {/* The other place a pull gets decided, so it quotes the same cost as the
+                  card. There is room here, so the image/attachment split is shown outright
+                  rather than hidden in a tooltip, and the shared-layer caveat is spelled
+                  out — this page is where someone goes to understand before committing. */}
+              {c.download_size_bytes != null && (
+                <p
+                  data-testid="mission-detail-download-size"
+                  className="max-w-full break-words text-dense text-text-tertiary"
+                >
+                  <span className="text-text-secondary">
+                    Download {formatBytes(c.download_size_bytes)}
+                  </span>
+                  {/* Split shown only when the total genuinely decomposes: a mission with
+                      no attachments would otherwise read "Download 280.5 MB — image
+                      280.5 MB", repeating one number as if it were two facts. */}
+                  {c.image_size_bytes != null && c.attachments_size_bytes != null && (
+                    <>
+                      {" — "}
+                      {`image ${formatBytes(c.image_size_bytes)}`}
+                      {" · "}
+                      {`attachments ${formatBytes(c.attachments_size_bytes)}`}
+                    </>
+                  )}
+                  {/* Layer reuse is an IMAGE property. A static mission is an attachment
+                      bundle with no layers, so its figure is exact and this caveat would
+                      describe something that cannot happen to it. */}
+                  {c.image_size_bytes != null
+                    ? ". Shared layers already on disk are not re-downloaded, so a later pull transfers less."
+                    : "."}
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/features/missions/mission-size.test.tsx
+++ b/frontend/src/features/missions/mission-size.test.tsx
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/msw/server";
 import { renderWithProviders } from "@/test/render";
 import { MissionCard, MissionRow } from "./mission-card";
+import { MissionDetail } from "./mission-detail";
 import type { CatalogEntry } from "@/lib/api/types";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 /**
  * The download size is a decision input BEFORE a pull, so it has to reach the card
@@ -37,11 +40,22 @@ describe("MissionCard download size", () => {
     expect(await screen.findByText(/260\.7 MB/)).toBeInTheDocument();
   });
 
-  it("frames the size as an upper bound, since shared layers transfer less", async () => {
+  it("shows the bare figure on the card, with no hedging language", async () => {
     renderWithProviders(<MissionCard mission={AVAILABLE} />);
 
     const size = await screen.findByTestId("mission-download-size");
-    expect(size.textContent).toMatch(/up to/i);
+    expect(size.textContent?.trim()).toBe("260.7 MB");
+  });
+
+  it("keeps the shared-layer caveat in the tooltip, where the bare figure would mislead", async () => {
+    /* The figure is a ceiling, not a prediction: 17 of 19 lab missions share one base
+       image, so a second pull transfers roughly half. The card stays clean and the
+       caveat lives on hover rather than in the label. */
+    renderWithProviders(<MissionCard mission={AVAILABLE} />);
+
+    const size = await screen.findByTestId("mission-download-size");
+    expect(size.getAttribute("title")).toMatch(/not re-downloaded/i);
+    expect(size.getAttribute("title")).toMatch(/transfers less/i);
   });
 
   it("renders no size for an installed mission — the download already happened", () => {
@@ -68,6 +82,42 @@ describe("MissionCard download size", () => {
     expect(size.getAttribute("title")).toMatch(/260\.3 MB/); // image
     expect(size.getAttribute("title")).toMatch(/384\.3 KB/); // attachments
   });
+
+  it("gives a static mission no tooltip at all — nothing left to qualify", async () => {
+    renderWithProviders(
+      <MissionCard
+        mission={{
+          ...AVAILABLE,
+          image_size_bytes: null,
+          attachments_size_bytes: 590400000,
+          download_size_bytes: 590400000,
+        }}
+      />,
+    );
+
+    const size = await screen.findByTestId("mission-download-size");
+    expect(size.getAttribute("title")).toBeNull();
+  });
+
+  it("omits the breakdown when the total is a single component", async () => {
+    /* A mission with no attachments would otherwise read "280.5 MB — image 280.5 MB",
+       stating the same number twice. A breakdown only earns its place when the figure
+       actually decomposes. */
+    renderWithProviders(
+      <MissionCard
+        mission={{
+          ...AVAILABLE,
+          attachments_size_bytes: null,
+          image_size_bytes: 280500000,
+          download_size_bytes: 280500000,
+        }}
+      />,
+    );
+
+    const size = await screen.findByTestId("mission-download-size");
+    expect(size.getAttribute("title")).not.toMatch(/image/i);
+    expect(size.getAttribute("title")).toMatch(/not re-downloaded/i);
+  });
 });
 
 describe("MissionRow download size", () => {
@@ -79,5 +129,81 @@ describe("MissionRow download size", () => {
     );
 
     expect(await screen.findByText(/260\.7 MB/)).toBeInTheDocument();
+  });
+});
+
+describe("MissionDetail download size", () => {
+  /* The detail page is the other place a pull gets decided, so it must quote the same
+     cost. It has more room than a card, so it shows the image/attachment split outright
+     instead of hiding it in a tooltip. */
+  // Only the catalog row is stubbed. The manifest endpoint is deliberately left unhandled
+  // so `manifest.data` stays undefined and the page takes its `m?.` guarded path — a
+  // PARTIAL manifest fixture crashes the render outright (the rich sections index into
+  // fields a stub omits), which reads as "the size never appeared". Same choice the other
+  // mission-detail tests make. The size comes from the catalog row anyway, not the manifest.
+  const serve = (entry: CatalogEntry) =>
+    server.use(http.get("*/api/missions", () => HttpResponse.json([entry])));
+
+  it("quotes the download size for a mission that is not yet installed", async () => {
+    serve(AVAILABLE);
+
+    renderWithProviders(<MissionDetail id="chrono-canary" />);
+
+    const size = await screen.findByTestId("mission-detail-download-size");
+    expect(size.textContent).toMatch(/260\.7 MB/);
+  });
+
+  it("breaks the figure into image and attachments, since there is room here", async () => {
+    serve(AVAILABLE);
+
+    renderWithProviders(<MissionDetail id="chrono-canary" />);
+
+    const size = await screen.findByTestId("mission-detail-download-size");
+    expect(size.textContent).toMatch(/260\.3 MB/); // image
+    expect(size.textContent).toMatch(/384\.3 KB/); // attachments
+  });
+
+  it("omits the breakdown when the total is a single component", async () => {
+    serve({
+      ...AVAILABLE,
+      attachments_size_bytes: null,
+      image_size_bytes: 280500000,
+      download_size_bytes: 280500000,
+    });
+
+    renderWithProviders(<MissionDetail id="chrono-canary" />);
+
+    const size = await screen.findByTestId("mission-detail-download-size");
+    expect(size.textContent).toMatch(/Download 280\.5 MB/);
+    expect(size.textContent).not.toMatch(/image/i);
+  });
+
+  it("drops the shared-layer caveat for a static mission, which has no layers", async () => {
+    /* A STATIC mission is an attachment bundle, not an image — nothing is layered and
+       nothing is ever reused from disk, so its figure is exact. Repeating the layer
+       caveat there states something that cannot happen. */
+    serve({
+      ...AVAILABLE,
+      image_size_bytes: null,
+      attachments_size_bytes: 590400000,
+      download_size_bytes: 590400000,
+    });
+
+    renderWithProviders(<MissionDetail id="chrono-canary" />);
+
+    const size = await screen.findByTestId("mission-detail-download-size");
+    expect(size.textContent).toMatch(/Download 590\.4 MB/);
+    expect(size.textContent).not.toMatch(/shared layers/i);
+  });
+
+  it("shows no size once the mission is installed", async () => {
+    serve({ ...AVAILABLE, installed: true, source: "your_own", download_size_bytes: null });
+
+    renderWithProviders(<MissionDetail id="chrono-canary" />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Chrono Canary" })).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("mission-detail-download-size")).not.toBeInTheDocument();
   });
 });

--- a/src/xorcise/core/cli/commands/mission.py
+++ b/src/xorcise/core/cli/commands/mission.py
@@ -177,6 +177,18 @@ def show_mission(
     field("Environment", _ENVIRONMENT_LABELS.get(env, md.get("type") or DASH))
     field("Difficulty", difficulty_label(md.get("proficiency")))
     field("Specialty", str(md.get("specialty") or DASH).replace("-", " ").title())
+    # Pull cost — the CLI half of the GUI's "not yet installed" preview. Only while the
+    # download is still ahead of you: an installed mission has its bytes on disk already,
+    # so there is no cost left to quote. The split is shown only when the total genuinely
+    # decomposes; a lab with no attachments would otherwise restate one number as two.
+    if not installed:
+        download = entry.get("download_size_bytes")
+        if download is not None:
+            image, attachments = entry.get("image_size_bytes"), entry.get("attachments_size_bytes")
+            detail = ""
+            if image is not None and attachments is not None:
+                detail = f"  (image {size_label(image)} · attachments {size_label(attachments)})"
+            field("Download", f"{size_label(download)}{detail}")
 
     # Prose, wrapped. These were single unwrapped lines — a real objective runs to
     # ~1,500 characters and broke `| less`, editors and pasted tickets.

--- a/tests/unit/test_catalog_package_size.py
+++ b/tests/unit/test_catalog_package_size.py
@@ -188,6 +188,81 @@ def test_mission_list_quotes_the_download_size(monkeypatch: pytest.MonkeyPatch):
     assert "260.7 MB" in result.output
 
 
+def _wire_show(monkeypatch: pytest.MonkeyPatch, entry: dict[str, Any]) -> None:
+    """`mission show` reads the catalog row (for the entry) then the manifest."""
+
+    def fake_get(self: RestClient, path: str, **kwargs: Any) -> Any:
+        if path == "/missions":
+            return [entry]
+        assert path.endswith("/manifest")
+        return {
+            "schema_version": "2.0",
+            "metadata": {"mission_id": entry["mission_id"], "name": entry["name"]},
+        }
+
+    monkeypatch.setattr(RestClient, "get", fake_get)
+
+
+_SHOW_ENTRY = {
+    "source": "library",
+    "mission_id": "chrono-canary",
+    "name": "Chrono Canary",
+    "proficiency": "expert",
+    "installed": False,
+    "image_size_bytes": 260306509,
+    "attachments_size_bytes": 384284,
+    "download_size_bytes": 260690793,
+}
+
+
+def test_mission_show_quotes_the_download_size(monkeypatch: pytest.MonkeyPatch):
+    """`mission show` is the CLI's detail page — it must quote the same cost the card does."""
+    _wire_show(monkeypatch, dict(_SHOW_ENTRY))
+
+    result = runner.invoke(app, ["mission", "show", "chrono-canary"])
+
+    assert result.exit_code == 0, result.output
+    assert "Download" in result.output
+    assert "260.7 MB" in result.output
+
+
+def test_mission_show_breaks_down_a_two_part_download(monkeypatch: pytest.MonkeyPatch):
+    _wire_show(monkeypatch, dict(_SHOW_ENTRY))
+
+    result = runner.invoke(app, ["mission", "show", "chrono-canary"])
+
+    assert "260.3 MB" in result.output  # image
+    assert "384.3 KB" in result.output  # attachments
+
+
+def test_mission_show_omits_a_redundant_single_part_breakdown(monkeypatch: pytest.MonkeyPatch):
+    """One component must not be restated as its own breakdown."""
+    _wire_show(
+        monkeypatch,
+        {
+            **_SHOW_ENTRY,
+            "attachments_size_bytes": None,
+            "image_size_bytes": 280500000,
+            "download_size_bytes": 280500000,
+        },
+    )
+
+    result = runner.invoke(app, ["mission", "show", "chrono-canary"])
+
+    assert "280.5 MB" in result.output
+    assert "image" not in result.output.lower()
+
+
+def test_mission_show_omits_the_size_once_installed(monkeypatch: pytest.MonkeyPatch):
+    """The download already happened; there is no cost left to quote."""
+    _wire_show(monkeypatch, {**_SHOW_ENTRY, "installed": True, "download_size_bytes": None})
+
+    result = runner.invoke(app, ["mission", "show", "chrono-canary"])
+
+    assert result.exit_code == 0, result.output
+    assert "Download" not in result.output
+
+
 def test_mission_list_shows_a_dash_when_the_size_is_unknown(monkeypatch: pytest.MonkeyPatch):
     """An installed mission carries no size — the download already happened."""
     _wire_missions(


### PR DESCRIPTION
Follow-up to #24 — carries the review changes @christo-xorciseai asked for there, plus a wording pass. #24 was merged before these landed, so they ship as their own reviewable diff rather than arriving inside something already merged.

## 1. The duplicate icon (#24 review)

The size sat beside the Pull button and **both carried a download icon** — two identical glyphs reading as two separate affordances rather than one action and its cost. The size drops its icon; the button keeps the one that belongs to the action.

<img width="470" alt="Pull button with the download size beside it, single icon" src="https://github.com/user-attachments/assets/e38b1c7f-43e0-467e-abac-f73c35b48954" />

## 2. Why it stayed outside the button

The other option on #24 was moving the size **inside** the button in brackets. It stays outside, because the figure is a **ceiling, not a prediction**, and a bracketed number inside a button reads as exact. Measured on our own images:

```
chrono-canary     260.3 MB  (21 layers)
guardrail-proxy   306.1 MB  (21 layers)
shared            177.3 MB  (19 of the 21 layers)

pull chrono-canary, then guardrail-proxy
  → actually transfers 128.8 MB, not 306.1 MB
```

**17 of our 19 lab missions sit on one base image.** The first pull costs the full amount; nearly every pull after it costs roughly half. `PULL (306.1 MB)` would overstate a typical second pull by ~2.4× — the same class of confusion behind the old "stuck at 0 bytes" reports.

Secondary: the button would take a variable width across the grid (`PULL (1.4 GB)` vs `PULL (532.4 KB)`), and its accessible name would become "Pull 280.5 MB", a poor label for an action.

## 3. The label drops "up to"

Accurate, but it read as vagueness on a first pull — where the figure *is* exact. The ceiling caveat moves to the tooltip, which is where someone looks when a number surprises them:

> Image 280.5 MB. Shared layers already on disk are not re-downloaded, so a later pull transfers less.

## 4. Two things the bare figure exposed

**A breakdown that restated the total.** A mission with no attachments rendered `Download 280.5 MB — image 280.5 MB`: one number presented as two facts. The split now appears only when the total genuinely decomposes.

**A caveat that could not apply.** A STATIC mission is an attachment bundle with *no layers* — nothing is ever reused from disk and its figure is always exact — yet it still claimed shared layers would not be re-downloaded. Static missions now carry no tooltip at all rather than a false one.

| Shape | Renders |
|---|---|
| lab + attachments | `260.7 MB` · tooltip with split + caveat |
| lab, image only | `280.5 MB` · tooltip with caveat, no redundant split |
| static | `590.4 MB` · **no tooltip** |
| installed | nothing — the download already happened |

## 5. The size reached only the catalog

The mission **detail page** and **`xorcise mission show`** are the two other places a pull gets decided, and neither quoted the cost. Both do now, with the split spelled out inline since neither is space-constrained the way a card is.

<img width="1911" alt="Mission catalog grid with download sizes on every card" src="https://github.com/user-attachments/assets/2ad84032-44cc-4fdb-b0b6-43cd8a5628b1" />

```
❯ xorcise mission show ghostwire

Ghostwire
ghostwire  ·  Library  ·  Not installed

  Environment     Lab — a live containerised environment the agent connects to
  Difficulty      Expert
  Specialty       Intelligence
  Download        280.5 MB
```

A lab with attachments shows the split; an installed mission shows no size at all:

```
  Download        281.0 MB  (image 280.3 MB · attachments 713.6 KB)
```

## Coverage

Every surface that shows a mission now quotes its cost: catalog cards, compact rows, detail page, `mission list`, `mission show`.

```
pytest (unit/adapters/topology)   2089 passed
vitest                             696 passed  (95 files)
mypy                               clean, 473 source files
ruff check / ruff format           clean
lint-imports                       4 contracts kept, 0 broken
tsc --noEmit                       clean
```

Verified against live production catalog data, not fixtures — the cloud side of #24 is already deployed, so every figure above came off `api.xorcise.ai`.
