### PR TITLE
fix(frontend): stop the terrain map's chrome stealing space from the graph

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -395,18 +395,31 @@ body {
   -webkit-mask-image: none;
   mask-image: none;
 }
-/* Expanded terrain summary, drawn OVER the map (never through the layout, so the graph and its
-   zoom controls can't be pushed). Only max-height is animated — the sheet's own height is set
-   inline by the component, from the collapsed strip's height to its content height — so opening
-   and closing read as one continuous growth out of the two-line strip it covers. */
-.tm-summary-sheet {
-  transition: max-height 0.2s ease;
+/* Terrain summary: the copy uses the full width and the amber action occupies only the end of the
+   final visible line. A short card-coloured fade protects the label without reserving a wide
+   right-hand column on both lines; the persistent panel still grows over the map. */
+.tm-summary-slot {
+  height: calc(2lh + 1rem);
+}
+.tm-summary-panel {
+  max-height: calc(2lh + 1rem);
+  transition: max-height 0.2s cubic-bezier(0.2, 0, 0, 1);
+}
+.tm-summary-copy {
+  max-height: 2lh;
+  transition: max-height 0.2s cubic-bezier(0.2, 0, 0, 1);
+}
+.tm-summary-toggle {
+  background: linear-gradient(to right, transparent, var(--color-card) 1.75rem);
+  transition: color 0.15s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .tm-edge-note { transition: none; }
-  /* Calm (guide §11/§12): the sheet still opens and closes, it just arrives at its size. */
-  .tm-summary-sheet { transition: none; }
+  /* Calm (guide §11/§12): the summary still opens and closes, it just arrives at its size. */
+  .tm-summary-panel,
+  .tm-summary-copy,
+  .tm-summary-toggle svg { transition: none; }
   /* Guide §11/§12: no glow/flicker loops in the workspace under reduced motion
      (Calm). Freeze the terrain pulses/glow/flow to their resting state. */
   .tm-ring-amber,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -395,8 +395,18 @@ body {
   -webkit-mask-image: none;
   mask-image: none;
 }
+/* Expanded terrain summary, drawn OVER the map (never through the layout, so the graph and its
+   zoom controls can't be pushed). Only max-height is animated — the sheet's own height is set
+   inline by the component, from the collapsed strip's height to its content height — so opening
+   and closing read as one continuous growth out of the two-line strip it covers. */
+.tm-summary-sheet {
+  transition: max-height 0.2s ease;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tm-edge-note { transition: none; }
+  /* Calm (guide §11/§12): the sheet still opens and closes, it just arrives at its size. */
+  .tm-summary-sheet { transition: none; }
   /* Guide §11/§12: no glow/flicker loops in the workspace under reduced motion
      (Calm). Freeze the terrain pulses/glow/flow to their resting state. */
   .tm-ring-amber,

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -577,6 +577,47 @@ describe("TerrainMap", () => {
     expect(screen.getByText("discovered")).toBeInTheDocument();
   });
 
+  test("fit reclaims the legend column when the legend is minimised (issue #23)", async () => {
+    // Three nodes in one band → a WIDE graph, so the fit is width-limited and the legend
+    // reserve directly shrinks the zoom (the regime where the bug rendered the whole graph
+    // smaller than the viewport allowed).
+    const { container } = mount(
+      terrain({
+        groups: [{ id: "g", label: "Group", description: null, kind: "segment", order: 0, hidden: false, discovered: true }],
+        nodes: [
+          { id: "a", label: "a", group: "g", type: "service", objective: false, description: null,
+            discovery_condition: null, completion_condition: null, state: "defined" },
+          { id: "b", label: "b", group: "g", type: "service", objective: false, description: null,
+            discovery_condition: null, completion_condition: null, state: "defined" },
+          { id: "c", label: "c", group: "g", type: "service", objective: false, description: null,
+            discovery_condition: null, completion_condition: null, state: "defined" },
+        ] as ResolvedTerrainV2["nodes"],
+      }),
+    );
+    await screen.findByText("a");
+    const scale = () => {
+      const layer = container.querySelector('[data-testid="terrain-svg"]')!.parentElement as HTMLElement;
+      const m = /scale\(([\d.]+)\)/.exec(layer.style.transform || "");
+      return m ? parseFloat(m[1]) : 1;
+    };
+    // jsdom reports 0×0, which makes fitToView bail — give the viewport a real size. A very
+    // tall box keeps the fit width-limited regardless of the layout's exact aspect.
+    const viewport = container.querySelector('[data-testid="terrain-viewport"]') as HTMLElement;
+    Object.defineProperty(viewport, "clientWidth", { value: 600, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 5000, configurable: true });
+
+    fireEvent.click(screen.getByLabelText("fit to view"));
+    const withLegend = scale();
+    // Minimising the legend refits automatically (the user hasn't panned/zoomed) and the
+    // freed 132px column goes to the graph — the fit zoom grows.
+    fireEvent.click(screen.getByLabelText("Minimise legend"));
+    const withoutLegend = scale();
+    expect(withoutLegend).toBeGreaterThan(withLegend);
+    // Reopening reserves the column again so no node can land under the open legend.
+    fireEvent.click(screen.getByLabelText("Expand legend"));
+    expect(scale()).toBeLessThan(withoutLegend);
+  });
+
   test("exposes zoom + fit controls", async () => {
     const { container } = mount(
       terrain({

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -65,14 +65,12 @@ describe("TerrainMap", () => {
     ],
   } as Partial<ResolvedTerrainV2>;
 
-  test("clamps the summary to two lines behind an explicit toggle (issue #22)", async () => {
+  test("clamps the summary to two lines; expanding draws OVER the map, never through the layout (issue #22)", async () => {
     const summary =
       "A purely offline Windows DFIR reconstruction: parse the corrupted Microsoft-Windows-RPC event log and assemble the flag from five recovered facts.";
     mount(terrain({ ...oneNode, summary }));
-    // ONE copy, clamped by default — but the FULL text stays in the DOM (line-clamp hides
-    // visually only), so assistive tech and find-in-page still see the whole sentence and
-    // nothing is layered over the graph. A paragraph-length summary must not squash the
-    // map viewport below; the graph yields height only when the reader asks for the prose.
+    // The in-flow strip: clamped, with the FULL text in the DOM (line-clamp hides visually
+    // only), so assistive tech and find-in-page see the whole sentence.
     const p = await screen.findByTestId("terrain-summary");
     expect(p).toHaveTextContent(/assemble the flag from five recovered facts/);
     expect(p.className).toContain("line-clamp-2");
@@ -88,11 +86,23 @@ describe("TerrainMap", () => {
     // an explicit CLICK target announcing its state — never hover-gated text
     expect(more).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(more);
-    expect(p.className).not.toContain("line-clamp-2");
+    // LAYOUT-FROZEN: the in-flow strip stays clamped — the first cut removed the clamp
+    // in place, which pushed the viewport down and shoved the zoom cluster out of a
+    // fixed-height card. The full text arrives as an absolutely-positioned overlay drawn
+    // over the map instead, its text aria-hidden (the strip already carries the one
+    // accessible copy — never announce the same sentence twice).
+    expect(p.className).toContain("line-clamp-2");
+    const overlay = screen.getByTestId("terrain-summary-overlay");
+    expect(overlay.className).toContain("absolute");
+    expect(overlay.querySelector("p")).toHaveAttribute("aria-hidden", "true");
+    expect(overlay.querySelector("p")).toHaveTextContent(/five recovered facts/);
+    // one toggle at a time: Show more is covered/gone, Show less lives in the overlay
+    expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
     const less = screen.getByRole("button", { name: /show less/i });
     expect(less).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(less);
-    expect(p.className).toContain("line-clamp-2");
+    expect(screen.queryByTestId("terrain-summary-overlay")).toBeNull();
+    expect(await screen.findByRole("button", { name: /show more/i })).toBeInTheDocument();
   });
 
   test("renders no summary block when the terrain has none", async () => {

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -65,29 +65,40 @@ describe("TerrainMap", () => {
     ],
   } as Partial<ResolvedTerrainV2>;
 
-  test("renders the mission summary in full, with no truncation", async () => {
+  test("clamps the summary to two lines behind an explicit toggle (issue #22)", async () => {
     const summary =
       "A purely offline Windows DFIR reconstruction: parse the corrupted Microsoft-Windows-RPC event log and assemble the flag from five recovered facts.";
     mount(terrain({ ...oneNode, summary }));
-    // ONE copy, wrapped. It used to render twice — a `truncate`d line plus a hover overlay
-    // holding the rest — which cut every shipped mission's summary mid-sentence. A sentence
-    // you have to hover to finish is a sentence nobody reads, so it wraps and the duplicate
-    // overlay is gone with it.
-    const rendered = await screen.findAllByText(summary);
-    expect(rendered).toHaveLength(1);
-    expect(rendered[0]).not.toHaveClass("truncate");
-    // and nothing is layered over the graph any more
-    expect(rendered[0].className).not.toContain("absolute");
-    expect(rendered[0].className).not.toContain("opacity-0");
+    // ONE copy, clamped by default — but the FULL text stays in the DOM (line-clamp hides
+    // visually only), so assistive tech and find-in-page still see the whole sentence and
+    // nothing is layered over the graph. A paragraph-length summary must not squash the
+    // map viewport below; the graph yields height only when the reader asks for the prose.
+    const p = await screen.findByTestId("terrain-summary");
+    expect(p).toHaveTextContent(/assemble the flag from five recovered facts/);
+    expect(p.className).toContain("line-clamp-2");
+    // No dead "Show more" while nothing overflows (jsdom measures 0/0 → fits) …
+    expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+    // … the toggle appears once the clamped box actually overflows.
+    Object.defineProperty(p, "scrollHeight", { value: 66, configurable: true });
+    Object.defineProperty(p, "clientHeight", { value: 33, configurable: true });
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    const more = await screen.findByRole("button", { name: /show more/i });
+    // an explicit CLICK target announcing its state — never hover-gated text
+    expect(more).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(more);
+    expect(p.className).not.toContain("line-clamp-2");
+    const less = screen.getByRole("button", { name: /show less/i });
+    expect(less).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(less);
+    expect(p.className).toContain("line-clamp-2");
   });
 
-  test("renders no summary paragraph when the terrain has none", async () => {
+  test("renders no summary block when the terrain has none", async () => {
     const { container } = mount(terrain({ ...oneNode, summary: null }));
     await screen.findByText("web");
-    // No bordered summary paragraph above the viewport when summary is null.
-    // The selector tracks the rendered class list: `p.truncate` stopped existing when the
-    // summary stopped being truncated, so asserting on it would pass vacuously.
-    expect(container.querySelector("p.border-b")).toBeNull();
+    expect(container.querySelector('[data-testid="terrain-summary"]')).toBeNull();
   });
 
   test("a long node label is clamped to two lines and keeps the full text in a title (no sideways overlap)", async () => {

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -65,49 +65,54 @@ describe("TerrainMap", () => {
     ],
   } as Partial<ResolvedTerrainV2>;
 
-  test("clamps the summary to two lines; expanding draws OVER the map, never through the layout (issue #22)", async () => {
+  test("shows exactly two summary lines and expands the same layer over the map", async () => {
     const summary =
       "A purely offline Windows DFIR reconstruction: parse the corrupted Microsoft-Windows-RPC event log and assemble the flag from five recovered facts.";
     mount(terrain({ ...oneNode, summary }));
-    // The in-flow strip: clamped, with the FULL text in the DOM (line-clamp hides visually
-    // only), so assistive tech and find-in-page see the whole sentence.
+    // One full accessible copy lives inside its own two-line clipping viewport.
     const p = await screen.findByTestId("terrain-summary");
     expect(p).toHaveTextContent(/assemble the flag from five recovered facts/);
-    expect(p.className).toContain("line-clamp-2");
-    // No dead "Show more" while nothing overflows (jsdom measures 0/0 → fits) …
+    expect(p.className).toContain("overflow-hidden");
+    const panel = screen.getByTestId("terrain-summary-overlay");
+    expect(panel.className).toContain("absolute");
+    expect(panel.querySelectorAll("p")).toHaveLength(1);
+    expect(panel).not.toHaveAttribute("data-expanded");
+    Object.defineProperty(panel, "scrollHeight", { value: 180, configurable: true });
+    Object.defineProperty(panel.parentElement, "offsetHeight", { value: 52, configurable: true });
+    // No dead control while nothing overflows (jsdom measures 0/0 → fits) …
     expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
-    // … the toggle appears once the clamped box actually overflows.
+    // … the inline toggle appears once the natural copy is taller than two lines.
     Object.defineProperty(p, "scrollHeight", { value: 66, configurable: true });
-    Object.defineProperty(p, "clientHeight", { value: 33, configurable: true });
+    Object.defineProperty(p, "clientHeight", { value: 66, configurable: true });
     act(() => {
       window.dispatchEvent(new Event("resize"));
     });
     const more = await screen.findByRole("button", { name: /show more/i });
-    // an explicit CLICK target announcing its state — never hover-gated text
+    expect(p.style.maxHeight).toBe("35.2px");
+    expect(more.className).toContain("absolute");
+    expect(more.className).toContain("right-4");
+    expect(more.className).toContain("text-primary");
     expect(more).toHaveAttribute("aria-expanded", "false");
+    expect(more).toHaveAttribute("aria-controls", p.id);
     fireEvent.click(more);
-    // LAYOUT-FROZEN: the in-flow strip stays clamped — the first cut removed the clamp
-    // in place, which pushed the viewport down and shoved the zoom cluster out of a
-    // fixed-height card. The full text arrives as an absolutely-positioned overlay drawn
-    // over the map instead, its text aria-hidden (the strip already carries the one
-    // accessible copy — never announce the same sentence twice).
-    expect(p.className).toContain("line-clamp-2");
-    const overlay = screen.getByTestId("terrain-summary-overlay");
-    expect(overlay.className).toContain("absolute");
-    expect(overlay.querySelector("p")).toHaveAttribute("aria-hidden", "true");
-    expect(overlay.querySelector("p")).toHaveTextContent(/five recovered facts/);
-    // one toggle at a time: Show more is covered/gone, Show less lives in the overlay
-    expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+    // The SAME panel and paragraph remain mounted and extend over the map; only the control label
+    // and expansion state change, so there is no duplicate-sheet swap.
+    expect(screen.getByTestId("terrain-summary-overlay")).toBe(panel);
+    expect(screen.getByTestId("terrain-summary")).toBe(p);
+    expect(panel).toHaveAttribute("data-expanded", "true");
+    expect(p.style.maxHeight).toBe("66px");
+    // Full copy (66px) plus the panel chrome (52px slot - 35.2px two-line copy).
+    expect(panel.style.maxHeight).toBe("82.8px");
+    expect(panel.style.overflowY).toBe("hidden");
     const less = screen.getByRole("button", { name: /show less/i });
     expect(less).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(less);
-    // The sheet OUTLIVES the state change so its closing motion can play (useExitTransition),
-    // then unmounts — collapsing must animate, not vanish in a frame.
-    expect(screen.getByTestId("terrain-summary-overlay")).toHaveAttribute("data-closing", "true");
-    await waitFor(() =>
-      expect(screen.queryByTestId("terrain-summary-overlay")).toBeNull(),
+    expect(panel).not.toHaveAttribute("data-expanded");
+    expect(p.style.maxHeight).toBe("35.2px");
+    expect(screen.getByRole("button", { name: /show more/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
     );
-    expect(await screen.findByRole("button", { name: /show more/i })).toBeInTheDocument();
   });
 
   test("renders no summary block when the terrain has none", async () => {

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -578,7 +578,7 @@ describe("TerrainMap", () => {
   });
 
   test("exposes zoom + fit controls", async () => {
-    mount(
+    const { container } = mount(
       terrain({
         groups: [{ id: "g", label: "Group", description: null, kind: "agent", order: 0, hidden: false, discovered: true }],
         nodes: [
@@ -590,6 +590,18 @@ describe("TerrainMap", () => {
     expect(await screen.findByLabelText("zoom in")).toBeInTheDocument();
     expect(await screen.findByLabelText("fit to view")).toBeInTheDocument();
     expect(await screen.findByLabelText("zoom out")).toBeInTheDocument();
+    const viewport = container.querySelector('[data-testid="terrain-viewport"]');
+    const card = screen.getByTestId("terrain-map-card");
+    const canvas = screen.getByTestId("terrain-canvas");
+    const footer = screen.getByTestId("terrain-footer");
+    const controls = screen.getByTestId("terrain-view-controls");
+    expect(card.className).toContain("min-h-[360px]");
+    expect(canvas.className).toContain("min-h-0");
+    expect(canvas.className).not.toContain("min-h-[360px]");
+    expect(viewport).not.toContainElement(controls);
+    expect(footer).toContainElement(controls);
+    expect(controls.className).toContain("flex-wrap");
+    expect(controls.className).not.toContain("absolute");
   });
 
   test("the + / − buttons actually change the map's zoom scale", async () => {

--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, test, vi } from "vitest";
-import { act, fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithProviders } from "@/test/render";
 import { server } from "@/test/msw/server";
 import type { ResolvedTerrainV2 } from "@/lib/api/types";
@@ -101,7 +101,12 @@ describe("TerrainMap", () => {
     const less = screen.getByRole("button", { name: /show less/i });
     expect(less).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(less);
-    expect(screen.queryByTestId("terrain-summary-overlay")).toBeNull();
+    // The sheet OUTLIVES the state change so its closing motion can play (useExitTransition),
+    // then unmounts — collapsing must animate, not vanish in a frame.
+    expect(screen.getByTestId("terrain-summary-overlay")).toHaveAttribute("data-closing", "true");
+    await waitFor(() =>
+      expect(screen.queryByTestId("terrain-summary-overlay")).toBeNull(),
+    );
     expect(await screen.findByRole("button", { name: /show more/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -451,13 +451,14 @@ function Legend() {
   // graph the operator wants to see. Minimised, it's a single "Legend" pill one click from the key.
   const [open, setOpen] = useState(true);
   return (
-    <div className="absolute right-2 top-2 rounded-md border border-border bg-card/90 backdrop-blur">
+    <div
+      className="absolute right-2 top-2 z-20 max-w-[calc(100%-1rem)] rounded-md border border-border bg-card/90 backdrop-blur"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
       <button
         type="button"
         aria-label={open ? "Minimise legend" : "Expand legend"}
         aria-expanded={open}
-        // stop the pointerdown reaching the viewport, which would otherwise start a map pan.
-        onPointerDown={(e) => e.stopPropagation()}
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between gap-3 px-2.5 py-1.5 text-label uppercase text-text-tertiary hover:text-text-secondary"
       >
@@ -1008,9 +1009,10 @@ export function TerrainMapView({
       onClick={expanded ? () => setExpanded(false) : undefined}
     >
       <div
-        // `relative` anchors the expanded-summary overlay below, which spans the card from
-        // its top edge OVER the map — never through the layout.
-        className="relative flex h-full w-full flex-col rounded-md border border-border bg-card"
+        // `relative` anchors the summary layer, which grows over the map without changing its
+        // dimensions or causing the auto-fit observer to visually zoom the graph.
+        data-testid="terrain-map-card"
+        className="relative flex h-full min-h-[360px] w-full flex-col overflow-hidden rounded-md border border-border bg-card"
         onClick={expanded ? (e) => e.stopPropagation() : undefined}
       >
       {terrain.summary && (
@@ -1050,56 +1052,57 @@ export function TerrainMapView({
           </div>
         </div>
       )}
-      <div className="relative min-h-[360px] flex-1">
+      {/* The component owns the 360px overall floor; the canvas row itself must be allowed to
+          shrink so the summary and in-flow footer can never be pushed beyond the clipped card. */}
+      <div data-testid="terrain-canvas" className="relative min-h-0 flex-1">
         <div
           ref={containerRef}
           data-testid="terrain-viewport"
           // Inset a few px from the card's rounded border and clip HERE, so panned/zoomed content
           // stays inside a clean gutter and never butts up against (or paints over) the outer
           // border — the fit measures this inset box, so a fitted graph gets the gutter too.
-          className="absolute inset-[3px] overflow-hidden rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          className="absolute inset-[3px] isolate overflow-hidden rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
           // focusable so focus/blur/Escape can gate plain-wheel zoom (the wheel listener itself is
           // native + non-passive, attached in the effect above)
           tabIndex={0}
-        onFocus={() => {
-          wheelActiveRef.current = true;
-        }}
-        onBlur={() => {
-          wheelActiveRef.current = false;
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") wheelActiveRef.current = false;
-        }}
-        onPointerDown={(e) => {
-          wheelActiveRef.current = true; // engaging the map opts into plain-wheel zoom
-          drag.current = { x: e.clientX, y: e.clientY, px: pan.x, py: pan.y };
-          setDragging(true);
-          e.currentTarget.setPointerCapture(e.pointerId);
-        }}
-        onPointerMove={(e) => {
-          if (!drag.current) return;
-          userControlled.current = true; // a manual pan opts out of auto-fit
-          setPan({
-            x: drag.current.px + (e.clientX - drag.current.x),
-            y: drag.current.py + (e.clientY - drag.current.y),
-          });
-        }}
-        onPointerUp={() => {
-          drag.current = null;
-          setDragging(false);
-        }}
-        style={{ cursor: dragging ? "grabbing" : "grab" }}
-      >
-        <div
-          style={{
-            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-            transformOrigin: "0 0",
-            transition: dragging ? "none" : "transform 0.15s ease-out",
+          onFocus={() => {
+            wheelActiveRef.current = true;
           }}
+          onBlur={() => {
+            wheelActiveRef.current = false;
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") wheelActiveRef.current = false;
+          }}
+          onPointerDown={(e) => {
+            wheelActiveRef.current = true; // engaging the map opts into plain-wheel zoom
+            drag.current = { x: e.clientX, y: e.clientY, px: pan.x, py: pan.y };
+            setDragging(true);
+            e.currentTarget.setPointerCapture(e.pointerId);
+          }}
+          onPointerMove={(e) => {
+            if (!drag.current) return;
+            userControlled.current = true; // a manual pan opts out of auto-fit
+            setPan({
+              x: drag.current.px + (e.clientX - drag.current.x),
+              y: drag.current.py + (e.clientY - drag.current.y),
+            });
+          }}
+          onPointerUp={() => {
+            drag.current = null;
+            setDragging(false);
+          }}
+          style={{ cursor: dragging ? "grabbing" : "grab" }}
         >
-          {graph}
+          <div
+            style={{
+              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+              transformOrigin: "0 0",
+              transition: dragging ? "none" : "transform 0.15s ease-out",
+            }}
+          >
+            {graph}
           </div>
-        </div>
 
         <Legend />
 
@@ -1109,7 +1112,7 @@ export function TerrainMapView({
             pointerdown so the pannable container beneath can't capture the click. */}
         {selectedEventId && onReturnToLive && (
           <div
-            className="absolute left-1/2 top-2 z-20 -translate-x-1/2"
+            className="absolute left-1/2 top-2 z-20 max-w-[calc(100%-1rem)] -translate-x-1/2"
             onPointerDown={(e) => e.stopPropagation()}
           >
             <button
@@ -1127,17 +1130,28 @@ export function TerrainMapView({
         {wheelTip && (
           <div
             data-testid="wheel-tip"
-            className="pointer-events-none absolute left-1/2 top-2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-card/90 px-2.5 py-1.5 text-caption text-text-secondary backdrop-blur"
+            className="pointer-events-none absolute left-1/2 top-2 z-20 max-w-[calc(100%-1rem)] -translate-x-1/2 truncate whitespace-nowrap rounded-md border border-border bg-card/90 px-2.5 py-1.5 text-caption text-text-secondary backdrop-blur"
           >
             Ctrl/⌘ + scroll to zoom — or click the map
           </div>
         )}
 
-        {/* stopPropagation on pointerdown: the container captures the pointer for panning
-            (setPointerCapture), which otherwise swallows these buttons' click events. */}
+        </div>
+      </div>
+
+      {/* One in-flow footer owns both the caption and view controls. Because the toolbar is no
+          longer absolutely positioned over the canvas, it cannot intersect either terrain border;
+          flex-wrap lets it fall below the caption cleanly in very narrow panes. */}
+      <div
+        data-testid="terrain-footer"
+        className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-t border-border px-4 py-2"
+      >
+        <p className="min-w-[16rem] flex-1 text-caption text-text-tertiary">
+          {caption ?? "Amber ring = what just changed · hover a node to highlight its trace events."}
+        </p>
         <div
-          className="absolute bottom-2 right-2 flex items-center gap-1 text-text-secondary"
-          onPointerDown={(e) => e.stopPropagation()}
+          data-testid="terrain-view-controls"
+          className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-1 text-text-secondary"
         >
           {expandable && (
             <button
@@ -1145,7 +1159,7 @@ export function TerrainMapView({
               aria-label={expanded ? "exit fullscreen" : "fullscreen"}
               title={expanded ? "Exit fullscreen (Esc)" : "Fullscreen"}
               onClick={() => setExpanded((v) => !v)}
-              className="flex items-center self-stretch rounded border border-border bg-card px-2 hover:text-foreground"
+              className="flex h-7 items-center rounded border border-border bg-card px-2 hover:text-foreground"
             >
               {expanded ? (
                 <Minimize2 className="size-3" aria-hidden />
@@ -1158,7 +1172,7 @@ export function TerrainMapView({
             type="button"
             aria-label="zoom out"
             onClick={() => zoomBy(0.9)}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             −
           </button>
@@ -1169,7 +1183,7 @@ export function TerrainMapView({
               userControlled.current = false; // resume auto-fit following
               fitToView();
             }}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             Fit
           </button>
@@ -1177,19 +1191,12 @@ export function TerrainMapView({
             type="button"
             aria-label="zoom in"
             onClick={() => zoomBy(1.1)}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             +
           </button>
         </div>
       </div>
-
-      {/* Only the facts the legend doesn't already carry: the amber (just-changed) ring and the
-          hover interaction. The colour→state mapping lives in the legend, so it's dropped here to
-          keep this caption short enough to wrap cleanly inside the card. */}
-      <p className="shrink-0 border-t border-border px-4 py-2 text-caption text-text-tertiary">
-        {caption ?? "Amber ring = what just changed · hover a node to highlight its trace events."}
-      </p>
       {attributionOff && hasMissionGroup && (
         <p className="shrink-0 border-t border-border px-4 py-2 text-caption italic text-text-tertiary">
           target attribution off — set a model in Settings

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import { createPortal } from "react-dom";
 import { Maximize2, Minimize2, Minus, Plus, Radio } from "lucide-react";
+import { useExitTransition } from "@/components/ui/use-exit-transition";
 import { foldIndexForEvent, foldTerrain, probingPathEdgeIds, pulseIdsForIndex, type FoldedNode } from "./terrain-fold";
 import { layoutTerrainV2, type LaidOutEdge, type LaidOutGroup, type LaidOutNode } from "./terrain-layout";
 import { edgeColor, groupStyle, nodeColor, otelActive, T } from "./terrain-colors";
@@ -37,6 +46,16 @@ import type { ResolvedTerrainV2 } from "@/lib/api/types";
  */
 
 const AMBER = "var(--color-primary)";
+
+/** Summary-sheet open/close duration. Must match `.tm-summary-sheet`'s transition in
+ *  globals.css — it keeps the closing sheet mounted exactly long enough to animate out. */
+const SUMMARY_SHEET_MS = 200;
+
+/** `useLayoutEffect` that degrades to `useEffect` on the server. The sheet's open/close motion
+ *  must be committed BEFORE paint (a passive effect would show one frame at the wrong height),
+ *  but these pages are statically prerendered, where React warns that a layout effect does
+ *  nothing — and there is no DOM to measure anyway. */
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /** Clamp a zoom factor to the pan/zoom bounds. Module-scope so `fitToView` can be a STABLE
  *  callback (the ResizeObserver + auto-fit-follow effects re-run/re-subscribe off its identity). */
@@ -651,6 +670,33 @@ export function TerrainMapView({
   const [summaryExpanded, setSummaryExpanded] = useState(false);
   const [summaryOverflows, setSummaryOverflows] = useState(false);
   const summaryRef = useRef<HTMLParagraphElement | null>(null);
+  const summaryStripRef = useRef<HTMLDivElement | null>(null);
+  const summarySheetRef = useRef<HTMLDivElement | null>(null);
+  // The sheet outlives `summaryExpanded` by the animation duration so its CLOSING motion can
+  // play — the same seam the Dialog uses. Without it, collapsing unmounted the sheet instantly
+  // and the summary vanished in one frame while opening animated: motion in one direction only.
+  const { mounted: summarySheetMounted, closing: summarySheetClosing } = useExitTransition(
+    summaryExpanded,
+    SUMMARY_SHEET_MS,
+  );
+  useIsomorphicLayoutEffect(() => {
+    // Drive the growth: from the strip's own height (so the sheet starts exactly congruent with
+    // the two clamped lines it covers) to its content height, capped to the card. Written to
+    // inline max-height BEFORE paint, with a forced reflow between the two writes so the browser
+    // has a start value to interpolate from — a single write would just land at the end state.
+    const el = summarySheetRef.current;
+    const strip = summaryStripRef.current;
+    if (!el || !strip) return;
+    const collapsed = strip.offsetHeight;
+    const full = Math.min(el.scrollHeight, el.parentElement?.clientHeight ?? el.scrollHeight);
+    if (summarySheetClosing) {
+      el.style.maxHeight = `${collapsed}px`;
+      return;
+    }
+    el.style.maxHeight = `${collapsed}px`;
+    void el.offsetHeight; // reflow: commit the start value before the target
+    el.style.maxHeight = `${full}px`;
+  }, [summarySheetMounted, summarySheetClosing, terrain?.summary]);
   useEffect(() => {
     const el = summaryRef.current;
     if (!el) return;
@@ -814,6 +860,106 @@ export function TerrainMapView({
     // new viewport size on both expand and collapse (unless the user has taken control).
   }, [fitToView, hasLayout, expanded]);
 
+  // The drawn graph, MEMOISED on the inputs that actually change it. Everything below this line
+  // — the summary sheet, the legend, the wheel tip, `dragging`, and every pan frame — used to
+  // re-render the entire SVG subtree (every group, edge, node, plus a `foreignObject` per edge
+  // note whose fresh inline style re-applied the custom properties feeding `.tm-edge-note`'s
+  // max-height transition). That is the "the whole terrain re-renders" jank on a summary toggle,
+  // and it also ran on EVERY pointermove of a pan. Hoisted here so unrelated UI state can't
+  // touch the graph: React reconciles the sheet alone. Declared before the early returns below
+  // (hooks are unconditional) and null-guards its own inputs.
+  const graph = useMemo(() => {
+    if (!layout || !folded) return null;
+    // Reverse hover link: the event ids of updates that targeted this node.
+    const eventIdsForNode = (nodeId: string): string[] =>
+      updates
+        .filter((u) => u.target_kind === "node" && u.target_id === nodeId && u.event_id)
+        .map((u) => u.event_id as string);
+    // Route-used annotation: the note of the MOST-RECENT update targeting this edge, up to the
+    // current fold boundary `k` — nothing shown when no such update carries a note.
+    const noteForEdge = (edgeId: string): string | null => {
+      const upTo = Math.min(k, updates.length - 1);
+      for (let i = upTo; i >= 0; i--) {
+        const u = updates[i];
+        if (u.target_kind === "edge" && u.target_id === edgeId && u.note) return u.note;
+      }
+      return null;
+    };
+    return (
+      <svg
+        width={layout.width}
+        height={layout.height}
+        role="img"
+        aria-label="terrain map"
+        data-testid="terrain-svg"
+      >
+        {layout.groups.map((lg) => (
+          <GroupBox
+            key={lg.fgroup.group.id}
+            lg={lg}
+            pulsed={folded.pulse.groups.has(lg.fgroup.group.id)}
+            otel={otel}
+            enumerated={groupEnumerated.get(lg.fgroup.group.id) ?? false}
+          />
+        ))}
+        {layout.edges.map((le) => (
+          <EdgeLine
+            key={le.fedge.edge.id}
+            le={le}
+            pulsed={probingEdges.has(le.fedge.edge.id)}
+            note={noteForEdge(le.fedge.edge.id)}
+          />
+        ))}
+        {layout.nodes.map((ln) => (
+          <NodeMark
+            key={ln.fnode.node.id}
+            ln={ln}
+            // amber delta ring only during time-travel; the live "where the agent is" cue is the
+            // hot halo below — so exactly one highlight shows per mode
+            pulsed={!!selectedEventId && folded.pulse.nodes.has(ln.fnode.node.id)}
+            hot={ln.fnode.node.id === hotDrawnId}
+            color={nodeColor(ln.fnode, groupKind.get(ln.fnode.node.group), otel)}
+            onEnter={() => {
+              onHoverEvents?.(eventIdsForNode(ln.fnode.node.id));
+              setHoverNodeId(ln.fnode.node.id);
+            }}
+            onLeave={() => {
+              onHoverEvents?.([]);
+              setHoverNodeId((h) => (h === ln.fnode.node.id ? null : h));
+            }}
+          />
+        ))}
+        {/* persistent route-used note on every acted-on edge — the action lives on the line
+            it acted on, not gated behind hover (drawn on top of everything else) */}
+        {layout.edges.map((le) => {
+          const noteText = noteForEdge(le.fedge.edge.id);
+          return noteText ? (
+            <EdgeNoteTooltip key={`note-${le.fedge.edge.id}`} le={le} note={noteText} />
+          ) : null;
+        })}
+        {/* hover popover, drawn on top of everything else */}
+        {hoverNodeId &&
+          (() => {
+            const ln = layout.nodes.find((n) => n.fnode.node.id === hoverNodeId);
+            return ln ? <NodeTooltip ln={ln} /> : null;
+          })()}
+      </svg>
+    );
+  }, [
+    layout,
+    folded,
+    otel,
+    groupKind,
+    groupEnumerated,
+    probingEdges,
+    selectedEventId,
+    hotDrawnId,
+    hoverNodeId,
+    updates,
+    k,
+    onHoverEvents,
+  ]);
+
   if (isError)
     return (
       <div className="rounded-md border border-border bg-card p-4 text-body text-err">
@@ -826,23 +972,6 @@ export function TerrainMapView({
         No terrain yet.
       </div>
     );
-
-  // Reverse hover link: the event ids of updates that targeted this node.
-  const eventIdsForNode = (nodeId: string): string[] =>
-    updates
-      .filter((u) => u.target_kind === "node" && u.target_id === nodeId && u.event_id)
-      .map((u) => u.event_id as string);
-
-  // Route-used annotation (Change 3): the note of the MOST-RECENT update targeting this edge, up
-  // to the current fold boundary `k` — nothing shown when no such update carries a note.
-  const noteForEdge = (edgeId: string): string | null => {
-    const upTo = Math.min(k, updates.length - 1);
-    for (let i = upTo; i >= 0; i--) {
-      const u = updates[i];
-      if (u.target_kind === "edge" && u.target_id === edgeId && u.note) return u.note;
-    }
-    return null;
-  };
 
   // No-model degradation notice: only meaningful once there's a mission (segment) group.
   const hasMissionGroup = (terrain.groups ?? []).some((g) => g.kind === "segment");
@@ -883,7 +1012,7 @@ export function TerrainMapView({
         // shoved the zoom cluster out of a fixed-height card (the mission page's 480px box);
         // nothing in this card may move because prose was opened. line-clamp hides visually
         // only, so this in-flow copy keeps the full text for assistive tech / find-in-page.
-        <div className="shrink-0 border-b border-border px-4 py-2">
+        <div ref={summaryStripRef} className="shrink-0 border-b border-border px-4 py-2">
           <p
             ref={summaryRef}
             data-testid="terrain-summary"
@@ -903,17 +1032,23 @@ export function TerrainMapView({
           )}
         </div>
       )}
-      {terrain.summary && summaryExpanded && (
-        // The expanded summary, as a LAYOUT-INERT overlay over the top of the map. Same
-        // padding as the strip, so its first two lines land exactly over their clamped
-        // copies — it reads as the strip growing over the graph, not a popover appearing.
-        // The text is aria-hidden (the in-flow strip already carries the full accessible
-        // copy — never announce the same sentence twice); the Show less control stays
-        // outside the hidden node so it remains focusable. z-30 clears the map region's
-        // pills (z-20); max-h + scroll is the backstop for a summary taller than the card.
+      {terrain.summary && summarySheetMounted && (
+        // The expanded summary, as a LAYOUT-INERT sheet over the top of the map. Same padding
+        // as the strip, so its first two lines land exactly over their clamped copies — it
+        // reads as the strip growing over the graph, not a popover appearing. It GROWS: the
+        // layout effect above animates max-height from the strip's own height to the sheet's
+        // content height (`.tm-summary-sheet` carries the transition, and drops it under
+        // prefers-reduced-motion), and reverses on close — so the motion is continuous in
+        // both directions instead of a snap. The text is aria-hidden (the in-flow strip
+        // already carries the full accessible copy — never announce the same sentence twice);
+        // the Show less control stays outside the hidden node so it remains focusable. z-30
+        // clears the map region's pills (z-20); overflow-y handles a summary taller than the
+        // card, which the measured cap clamps to.
         <div
+          ref={summarySheetRef}
           data-testid="terrain-summary-overlay"
-          className="absolute inset-x-0 top-0 z-30 max-h-full overflow-y-auto rounded-t-md border-b border-border bg-card px-4 py-2 shadow-lg"
+          data-closing={summarySheetClosing || undefined}
+          className="tm-summary-sheet absolute inset-x-0 top-0 z-30 overflow-y-auto rounded-t-md border-b border-border bg-card px-4 py-2 shadow-lg"
         >
           <p aria-hidden="true" className="text-caption text-text-secondary">
             {terrain.summary}
@@ -975,64 +1110,7 @@ export function TerrainMapView({
             transition: dragging ? "none" : "transform 0.15s ease-out",
           }}
         >
-          <svg
-            width={layout.width}
-            height={layout.height}
-            role="img"
-            aria-label="terrain map"
-            data-testid="terrain-svg"
-          >
-            {layout.groups.map((lg) => (
-              <GroupBox
-                key={lg.fgroup.group.id}
-                lg={lg}
-                pulsed={folded!.pulse.groups.has(lg.fgroup.group.id)}
-                otel={otel}
-                enumerated={groupEnumerated.get(lg.fgroup.group.id) ?? false}
-              />
-            ))}
-            {layout.edges.map((le) => (
-              <EdgeLine
-                key={le.fedge.edge.id}
-                le={le}
-                pulsed={probingEdges.has(le.fedge.edge.id)}
-                note={noteForEdge(le.fedge.edge.id)}
-              />
-            ))}
-            {layout.nodes.map((ln) => (
-              <NodeMark
-                key={ln.fnode.node.id}
-                ln={ln}
-                // amber delta ring only during time-travel; the live "where the agent is" cue is the
-                // hot halo below — so exactly one highlight shows per mode
-                pulsed={!!selectedEventId && folded!.pulse.nodes.has(ln.fnode.node.id)}
-                hot={ln.fnode.node.id === hotDrawnId}
-                color={nodeColor(ln.fnode, groupKind.get(ln.fnode.node.group), otel)}
-                onEnter={() => {
-                  onHoverEvents?.(eventIdsForNode(ln.fnode.node.id));
-                  setHoverNodeId(ln.fnode.node.id);
-                }}
-                onLeave={() => {
-                  onHoverEvents?.([]);
-                  setHoverNodeId((h) => (h === ln.fnode.node.id ? null : h));
-                }}
-              />
-            ))}
-            {/* persistent route-used note on every acted-on edge — the action lives on the line
-                it acted on, not gated behind hover (drawn on top of everything else) */}
-            {layout.edges.map((le) => {
-              const noteText = noteForEdge(le.fedge.edge.id);
-              return noteText ? (
-                <EdgeNoteTooltip key={`note-${le.fedge.edge.id}`} le={le} note={noteText} />
-              ) : null;
-            })}
-            {/* hover popover, drawn on top of everything else */}
-            {hoverNodeId &&
-              (() => {
-                const ln = layout.nodes.find((n) => n.fnode.node.id === hoverNodeId);
-                return ln ? <NodeTooltip ln={ln} /> : null;
-              })()}
-          </svg>
+          {graph}
           </div>
         </div>
 

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -10,8 +11,7 @@ import {
   type CSSProperties,
 } from "react";
 import { createPortal } from "react-dom";
-import { Maximize2, Minimize2, Minus, Plus, Radio } from "lucide-react";
-import { useExitTransition } from "@/components/ui/use-exit-transition";
+import { ChevronDown, Maximize2, Minimize2, Minus, Plus, Radio } from "lucide-react";
 import { foldIndexForEvent, foldTerrain, probingPathEdgeIds, pulseIdsForIndex, type FoldedNode } from "./terrain-fold";
 import { layoutTerrainV2, type LaidOutEdge, type LaidOutGroup, type LaidOutNode } from "./terrain-layout";
 import { edgeColor, groupStyle, nodeColor, otelActive, T } from "./terrain-colors";
@@ -47,14 +47,8 @@ import type { ResolvedTerrainV2 } from "@/lib/api/types";
 
 const AMBER = "var(--color-primary)";
 
-/** Summary-sheet open/close duration. Must match `.tm-summary-sheet`'s transition in
- *  globals.css — it keeps the closing sheet mounted exactly long enough to animate out. */
-const SUMMARY_SHEET_MS = 200;
-
-/** `useLayoutEffect` that degrades to `useEffect` on the server. The sheet's open/close motion
- *  must be committed BEFORE paint (a passive effect would show one frame at the wrong height),
- *  but these pages are statically prerendered, where React warns that a layout effect does
- *  nothing — and there is no DOM to measure anyway. */
+/** `useLayoutEffect` that degrades to `useEffect` on the server. Summary measurements must be
+ *  committed before paint, but these pages are statically prerendered with no DOM to measure. */
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /** Clamp a zoom factor to the pan/zoom bounds. Module-scope so `fitToView` can be a STABLE
@@ -665,42 +659,64 @@ export function TerrainMapView({
   // a summary that fits in two lines shows no dead "Show more" control. Measured (scroll vs
   // client height) rather than guessed from character count — wrap width varies pane to
   // pane. Re-measured on window resize (jsdom's ResizeObserver-free path too) and via a
-  // ResizeObserver on the element itself; `expanded` in the deps re-binds to the element the
-  // fullscreen portal toggle re-creates, `summaryExpanded` re-measures after each toggle.
+  // ResizeObserver on the element itself; `expanded` re-binds to the element the fullscreen
+  // portal toggle creates.
   const [summaryExpanded, setSummaryExpanded] = useState(false);
   const [summaryOverflows, setSummaryOverflows] = useState(false);
+  const summaryId = useId();
   const summaryRef = useRef<HTMLParagraphElement | null>(null);
-  const summaryStripRef = useRef<HTMLDivElement | null>(null);
-  const summarySheetRef = useRef<HTMLDivElement | null>(null);
-  // The sheet outlives `summaryExpanded` by the animation duration so its CLOSING motion can
-  // play — the same seam the Dialog uses. Without it, collapsing unmounted the sheet instantly
-  // and the summary vanished in one frame while opening animated: motion in one direction only.
-  const { mounted: summarySheetMounted, closing: summarySheetClosing } = useExitTransition(
-    summaryExpanded,
-    SUMMARY_SHEET_MS,
-  );
+  const summarySlotRef = useRef<HTMLDivElement | null>(null);
+  const summaryPanelRef = useRef<HTMLDivElement | null>(null);
+  const summaryTwoLineHeight = useCallback(() => {
+    const copy = summaryRef.current;
+    if (!copy) return 0;
+    const style = window.getComputedStyle(copy);
+    const rawLineHeight = Number.parseFloat(style.lineHeight);
+    const fontSize = Number.parseFloat(style.fontSize);
+    // Browsers normally resolve line-height to px, but WebKit/jsdom may expose the unitless 1.6.
+    // Treat values smaller than the font size as multipliers; never fall back to clientHeight,
+    // because that is the FULL paragraph and was what let four lines leak into the collapsed UI.
+    const lineHeight =
+      Number.isFinite(rawLineHeight) && rawLineHeight > 0
+        ? Number.isFinite(fontSize) && fontSize > 0 && rawLineHeight < fontSize
+          ? rawLineHeight * fontSize
+          : rawLineHeight
+        : 17.6; // caption token: 11px × 1.6
+    return lineHeight * 2;
+  }, []);
+  const sizeSummaryPanel = useCallback(() => {
+    // One permanently-mounted layer supplies both states: the slot reserves exactly two lines in
+    // layout, while this panel grows to its full natural height OVER the map. The reader explicitly
+    // asked to open the prose, so covering more of the canvas is calmer than introducing a small
+    // nested scroller; collapsing restores the entire terrain immediately.
+    const panel = summaryPanelRef.current;
+    const slot = summarySlotRef.current;
+    const copy = summaryRef.current;
+    if (!panel || !slot || !copy) return;
+    const collapsed = slot.offsetHeight;
+    const twoLines = summaryTwoLineHeight();
+    // `collapsed - twoLines` is the fixed panel chrome: top padding plus the amber action row.
+    // Add it to the copy's full scroll height rather than asking the already-clipped panel for its
+    // scrollHeight, which would only report the collapsed child.
+    const natural = Math.max(collapsed, copy.scrollHeight + Math.max(0, collapsed - twoLines));
+    const target = summaryExpanded ? natural : collapsed;
+    copy.style.maxHeight = `${summaryExpanded ? copy.scrollHeight : twoLines}px`;
+    panel.style.maxHeight = `${target}px`;
+    panel.style.overflowY = "hidden";
+  }, [summaryExpanded, summaryTwoLineHeight]);
   useIsomorphicLayoutEffect(() => {
-    // Drive the growth: from the strip's own height (so the sheet starts exactly congruent with
-    // the two clamped lines it covers) to its content height, capped to the card. Written to
-    // inline max-height BEFORE paint, with a forced reflow between the two writes so the browser
-    // has a start value to interpolate from — a single write would just land at the end state.
-    const el = summarySheetRef.current;
-    const strip = summaryStripRef.current;
-    if (!el || !strip) return;
-    const collapsed = strip.offsetHeight;
-    const full = Math.min(el.scrollHeight, el.parentElement?.clientHeight ?? el.scrollHeight);
-    if (summarySheetClosing) {
-      el.style.maxHeight = `${collapsed}px`;
-      return;
-    }
-    el.style.maxHeight = `${collapsed}px`;
-    void el.offsetHeight; // reflow: commit the start value before the target
-    el.style.maxHeight = `${full}px`;
-  }, [summarySheetMounted, summarySheetClosing, terrain?.summary]);
+    sizeSummaryPanel();
+  }, [sizeSummaryPanel, expanded, terrain?.summary, summaryOverflows]);
   useEffect(() => {
     const el = summaryRef.current;
     if (!el) return;
-    const measure = () => setSummaryOverflows(el.scrollHeight > el.clientHeight + 1);
+    const measure = () => {
+      // The copy itself is never clamped (the surrounding panel clips it), so compare its natural
+      // height with two computed line boxes. `clientHeight` is the jsdom fallback used by tests.
+      const twoLines = summaryTwoLineHeight();
+      setSummaryOverflows(el.scrollHeight > twoLines + 1);
+      sizeSummaryPanel();
+    };
     measure();
     window.addEventListener("resize", measure);
     const ro = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
@@ -709,7 +725,7 @@ export function TerrainMapView({
       window.removeEventListener("resize", measure);
       ro?.disconnect();
     };
-  }, [terrain?.summary, summaryExpanded, expanded]);
+  }, [terrain?.summary, expanded, sizeSummaryPanel, summaryTwoLineHeight]);
   // Hover state for the node popover (description + collapsed routes, Change 2). An edge's
   // route-used note (Change 3) is rendered persistently at the edge midpoint instead — no hover
   // state needed for it.
@@ -998,69 +1014,40 @@ export function TerrainMapView({
         onClick={expanded ? (e) => e.stopPropagation() : undefined}
       >
       {terrain.summary && (
-        // Clamped to TWO lines behind an EXPLICIT toggle (issue #22). This block has now
-        // swung THREE times, so the history matters: the original map truncated the summary
-        // to one line and revealed the rest only on hover — a sentence you have to hover to
-        // finish is a sentence nobody reads — so a later pass made it wrap in full. That
-        // assumed summaries "run to two or three lines"; shipped missions run to paragraph
-        // length, and every wrapped line came straight out of the map viewport below.
-        //
-        // The clamp keeps the no-hover principle (the toggle is a persistent CLICK target
-        // announcing its state via aria-expanded), and the strip is LAYOUT-FROZEN: it stays
-        // clamped even while "expanded" — the full text renders as the overlay below, drawn
-        // OVER the map. The first cut expanded in-flow, which pushed the viewport down and
-        // shoved the zoom cluster out of a fixed-height card (the mission page's 480px box);
-        // nothing in this card may move because prose was opened. line-clamp hides visually
-        // only, so this in-flow copy keeps the full text for assistive tech / find-in-page.
-        <div ref={summaryStripRef} className="shrink-0 border-b border-border px-4 py-2">
-          <p
-            ref={summaryRef}
-            data-testid="terrain-summary"
-            className="line-clamp-2 text-caption text-text-secondary"
+        // A fixed two-line slot keeps the terrain's geometry stable. The ONE summary panel is
+        // always present and clipped to that slot; its amber action sits over only the end of the
+        // final visible line, so the prose keeps the full card width instead of yielding a column.
+        <div ref={summarySlotRef} className="tm-summary-slot relative z-30 shrink-0 text-caption">
+          <div
+            ref={summaryPanelRef}
+            data-testid="terrain-summary-overlay"
+            data-expanded={summaryExpanded || undefined}
+            className="tm-summary-panel absolute inset-x-0 top-0 box-border overflow-hidden border-b border-border bg-card px-4 py-2"
           >
-            {terrain.summary}
-          </p>
-          {summaryOverflows && !summaryExpanded && (
-            <button
-              type="button"
-              aria-expanded={false}
-              onClick={() => setSummaryExpanded(true)}
-              className="mt-1 text-caption text-text-tertiary underline-offset-2 hover:text-foreground hover:underline"
+            <p
+              id={summaryId}
+              ref={summaryRef}
+              data-testid="terrain-summary"
+              className="tm-summary-copy overflow-hidden text-caption text-text-secondary"
             >
-              Show more
-            </button>
-          )}
-        </div>
-      )}
-      {terrain.summary && summarySheetMounted && (
-        // The expanded summary, as a LAYOUT-INERT sheet over the top of the map. Same padding
-        // as the strip, so its first two lines land exactly over their clamped copies — it
-        // reads as the strip growing over the graph, not a popover appearing. It GROWS: the
-        // layout effect above animates max-height from the strip's own height to the sheet's
-        // content height (`.tm-summary-sheet` carries the transition, and drops it under
-        // prefers-reduced-motion), and reverses on close — so the motion is continuous in
-        // both directions instead of a snap. The text is aria-hidden (the in-flow strip
-        // already carries the full accessible copy — never announce the same sentence twice);
-        // the Show less control stays outside the hidden node so it remains focusable. z-30
-        // clears the map region's pills (z-20); overflow-y handles a summary taller than the
-        // card, which the measured cap clamps to.
-        <div
-          ref={summarySheetRef}
-          data-testid="terrain-summary-overlay"
-          data-closing={summarySheetClosing || undefined}
-          className="tm-summary-sheet absolute inset-x-0 top-0 z-30 overflow-y-auto rounded-t-md border-b border-border bg-card px-4 py-2 shadow-lg"
-        >
-          <p aria-hidden="true" className="text-caption text-text-secondary">
-            {terrain.summary}
-          </p>
-          <button
-            type="button"
-            aria-expanded={true}
-            onClick={() => setSummaryExpanded(false)}
-            className="mt-1 text-caption text-text-tertiary underline-offset-2 hover:text-foreground hover:underline"
-          >
-            Show less
-          </button>
+              {terrain.summary}
+            </p>
+            {summaryOverflows && (
+              <button
+                type="button"
+                aria-controls={summaryId}
+                aria-expanded={summaryExpanded}
+                onClick={() => setSummaryExpanded((value) => !value)}
+                className="tm-summary-toggle absolute bottom-1.5 right-4 flex h-5 items-center gap-1 whitespace-nowrap pl-8 text-label uppercase text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {summaryExpanded ? "Show less" : "Show more"}
+                <ChevronDown
+                  aria-hidden
+                  className={`size-3 transition-transform duration-200 ${summaryExpanded ? "rotate-180" : ""}`}
+                />
+              </button>
+            )}
+          </div>
         </div>
       )}
       <div className="relative min-h-[360px] flex-1">

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -863,41 +863,69 @@ export function TerrainMapView({
       onClick={expanded ? () => setExpanded(false) : undefined}
     >
       <div
-        className="flex h-full w-full flex-col rounded-md border border-border bg-card"
+        // `relative` anchors the expanded-summary overlay below, which spans the card from
+        // its top edge OVER the map — never through the layout.
+        className="relative flex h-full w-full flex-col rounded-md border border-border bg-card"
         onClick={expanded ? (e) => e.stopPropagation() : undefined}
       >
       {terrain.summary && (
         // Clamped to TWO lines behind an EXPLICIT toggle (issue #22). This block has now
-        // swung twice, so the history matters: the original map truncated the summary to one
-        // line and revealed the rest only on hover — a sentence you have to hover to finish
-        // is a sentence nobody reads — so a later pass made it wrap in full. That assumed
-        // summaries "run to two or three lines"; shipped missions run to paragraph length,
-        // and every wrapped line comes straight out of the map viewport below (squashing it
-        // to its min-h floor, then scrolling) — the pane's job is the graph, not the prose.
+        // swung THREE times, so the history matters: the original map truncated the summary
+        // to one line and revealed the rest only on hover — a sentence you have to hover to
+        // finish is a sentence nobody reads — so a later pass made it wrap in full. That
+        // assumed summaries "run to two or three lines"; shipped missions run to paragraph
+        // length, and every wrapped line came straight out of the map viewport below.
         //
-        // The clamp keeps both earlier principles: no hover-gated text (the toggle is a
-        // persistent CLICK target that announces its state via aria-expanded), and no
-        // duplicate overlay (line-clamp hides visually only — the full text stays in the
-        // DOM, so assistive tech and find-in-page still see all of it). The graph yields
-        // height only while the reader has explicitly asked for the prose.
+        // The clamp keeps the no-hover principle (the toggle is a persistent CLICK target
+        // announcing its state via aria-expanded), and the strip is LAYOUT-FROZEN: it stays
+        // clamped even while "expanded" — the full text renders as the overlay below, drawn
+        // OVER the map. The first cut expanded in-flow, which pushed the viewport down and
+        // shoved the zoom cluster out of a fixed-height card (the mission page's 480px box);
+        // nothing in this card may move because prose was opened. line-clamp hides visually
+        // only, so this in-flow copy keeps the full text for assistive tech / find-in-page.
         <div className="shrink-0 border-b border-border px-4 py-2">
           <p
             ref={summaryRef}
             data-testid="terrain-summary"
-            className={`text-caption text-text-secondary ${summaryExpanded ? "" : "line-clamp-2"}`}
+            className="line-clamp-2 text-caption text-text-secondary"
           >
             {terrain.summary}
           </p>
-          {(summaryOverflows || summaryExpanded) && (
+          {summaryOverflows && !summaryExpanded && (
             <button
               type="button"
-              aria-expanded={summaryExpanded}
-              onClick={() => setSummaryExpanded((v) => !v)}
+              aria-expanded={false}
+              onClick={() => setSummaryExpanded(true)}
               className="mt-1 text-caption text-text-tertiary underline-offset-2 hover:text-foreground hover:underline"
             >
-              {summaryExpanded ? "Show less" : "Show more"}
+              Show more
             </button>
           )}
+        </div>
+      )}
+      {terrain.summary && summaryExpanded && (
+        // The expanded summary, as a LAYOUT-INERT overlay over the top of the map. Same
+        // padding as the strip, so its first two lines land exactly over their clamped
+        // copies — it reads as the strip growing over the graph, not a popover appearing.
+        // The text is aria-hidden (the in-flow strip already carries the full accessible
+        // copy — never announce the same sentence twice); the Show less control stays
+        // outside the hidden node so it remains focusable. z-30 clears the map region's
+        // pills (z-20); max-h + scroll is the backstop for a summary taller than the card.
+        <div
+          data-testid="terrain-summary-overlay"
+          className="absolute inset-x-0 top-0 z-30 max-h-full overflow-y-auto rounded-t-md border-b border-border bg-card px-4 py-2 shadow-lg"
+        >
+          <p aria-hidden="true" className="text-caption text-text-secondary">
+            {terrain.summary}
+          </p>
+          <button
+            type="button"
+            aria-expanded={true}
+            onClick={() => setSummaryExpanded(false)}
+            className="mt-1 text-caption text-text-tertiary underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Show less
+          </button>
         </div>
       )}
       <div className="relative min-h-[360px] flex-1">

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -446,10 +446,11 @@ const LEGEND: { label: string; color: string; edge?: boolean; dash?: boolean }[]
   { label: "probing edge", color: T.yellow, edge: true, dash: true },
 ];
 
-function Legend() {
-  // Collapsible: the eight-row key is handy on first read but then just occupies the corner of a
-  // graph the operator wants to see. Minimised, it's a single "Legend" pill one click from the key.
-  const [open, setOpen] = useState(true);
+// Collapsible: the eight-row key is handy on first read but then just occupies the corner of a
+// graph the operator wants to see. Minimised, it's a single "Legend" pill one click from the key.
+// `open` is OWNED BY THE MAP, not here — the fit reserves the legend's column only while it is
+// open (issue #23), so the map must see the state to refit on toggle.
+function Legend({ open, onToggle }: { open: boolean; onToggle: () => void }) {
   return (
     <div
       className="absolute right-2 top-2 z-20 max-w-[calc(100%-1rem)] rounded-md border border-border bg-card/90 backdrop-blur"
@@ -459,7 +460,7 @@ function Legend() {
         type="button"
         aria-label={open ? "Minimise legend" : "Expand legend"}
         aria-expanded={open}
-        onClick={() => setOpen((o) => !o)}
+        onClick={onToggle}
         className="flex w-full items-center justify-between gap-3 px-2.5 py-1.5 text-label uppercase text-text-tertiary hover:text-text-secondary"
       >
         Legend
@@ -744,14 +745,22 @@ export function TerrainMapView({
   // subscribes once instead of re-subscribing on every 1.5s poll (each poll makes a new `layout`).
   const layoutRef = useRef(layout);
   layoutRef.current = layout;
+  // Legend state lives HERE (not in Legend) because the fit below reserves the legend's
+  // column only while it is open (issue #23). Mirrored into a ref — the `layoutRef` pattern —
+  // so `fitToView` can read it while staying identity-stable for the ResizeObserver.
+  const [legendOpen, setLegendOpen] = useState(true);
+  const legendOpenRef = useRef(legendOpen);
+  legendOpenRef.current = legendOpen;
   // Flips false→true once the graph resolves (and stays true) — gates the ResizeObserver so it
   // attaches only after the viewport it observes exists, without churning on every poll.
   const hasLayout = layout !== null;
 
   // Fit the whole graph into the viewport. The top-right holds the legend overlay, so the fit
-  // RESERVES that column and centres the graph in the remaining area — a fitted node can't land
-  // under the legend (which was clipping the OTel-collector node). A small pad keeps the graph off
-  // the gutter too.
+  // RESERVES that column while the legend is OPEN and centres the graph in the remaining area —
+  // a fitted node can't land under the open legend (which was clipping the OTel-collector node).
+  // Minimised, the legend is a ~90×28px pill: no reserve — a permanently dead 132px column costs
+  // more than the pill's rare overlap with the graph's top-right corner (issue #23). A small pad
+  // keeps the graph off the gutter too.
   const fitToView = useCallback(() => {
     const el = containerRef.current;
     const lo = layoutRef.current;
@@ -760,7 +769,7 @@ export function TerrainMapView({
     const ch = el.clientHeight;
     if (!cw || !ch) return;
     const PAD = 10;
-    const LEGEND_RESERVE = 132; // ≈ the legend overlay's width; kept clear on the right
+    const LEGEND_RESERVE = legendOpenRef.current ? 132 : 0; // ≈ the OPEN legend's width
     const availW = Math.max(80, cw - LEGEND_RESERVE - PAD);
     const availH = Math.max(80, ch - PAD * 2);
     const fit = clampZoom(Math.min(availW / lo.width, availH / lo.height));
@@ -770,6 +779,11 @@ export function TerrainMapView({
       y: Math.max(PAD, (ch - lo.height * fit) / 2),
     });
   }, []);
+  useEffect(() => {
+    // Toggling the legend changes how much width the fit may use — refit under the SAME
+    // hand-off rule as the ResizeObserver: never yank a view the user has panned/zoomed.
+    if (!userControlled.current) fitToView();
+  }, [legendOpen, fitToView]);
   // Zoom by `factor`, keeping `anchor` (container-local px; defaults to the VIEWPORT CENTER)
   // fixed — so content doesn't fly toward the 0,0 transform origin. The +/- buttons zoom about
   // the center; the wheel passes the cursor position so zoom is cursor-anchored.
@@ -1104,7 +1118,7 @@ export function TerrainMapView({
             {graph}
           </div>
 
-        <Legend />
+        <Legend open={legendOpen} onToggle={() => setLegendOpen((o) => !o)} />
 
         {/* Return-to-live escape from time-travel. Shown whenever a span is selected (the map is
             frozen at that fold): a prominent top-centre pill — same idiom as the Trace's pill — that

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -642,6 +642,28 @@ export function TerrainMapView({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [expanded]);
+  // Summary clamp (issue #22): collapsed by default; `summaryOverflows` gates the toggle so
+  // a summary that fits in two lines shows no dead "Show more" control. Measured (scroll vs
+  // client height) rather than guessed from character count — wrap width varies pane to
+  // pane. Re-measured on window resize (jsdom's ResizeObserver-free path too) and via a
+  // ResizeObserver on the element itself; `expanded` in the deps re-binds to the element the
+  // fullscreen portal toggle re-creates, `summaryExpanded` re-measures after each toggle.
+  const [summaryExpanded, setSummaryExpanded] = useState(false);
+  const [summaryOverflows, setSummaryOverflows] = useState(false);
+  const summaryRef = useRef<HTMLParagraphElement | null>(null);
+  useEffect(() => {
+    const el = summaryRef.current;
+    if (!el) return;
+    const measure = () => setSummaryOverflows(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    window.addEventListener("resize", measure);
+    const ro = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+    ro?.observe(el);
+    return () => {
+      window.removeEventListener("resize", measure);
+      ro?.disconnect();
+    };
+  }, [terrain?.summary, summaryExpanded, expanded]);
   // Hover state for the node popover (description + collapsed routes, Change 2). An edge's
   // route-used note (Change 3) is rendered persistently at the edge midpoint instead — no hover
   // state needed for it.
@@ -754,9 +776,11 @@ export function TerrainMapView({
     // wheel zoom dies after a toggle (for a terminal run `layout` never changes to re-run it).
   }, [layout, showWheelTip, expanded]);
   useEffect(() => {
-    // A new subject (run / mission) starts following again from scratch.
+    // A new subject (run / mission) starts following again from scratch — auto-fit AND the
+    // summary clamp (an expanded summary is a per-subject reading choice, not a setting).
     fittedDims.current = null;
     userControlled.current = false;
+    setSummaryExpanded(false);
   }, [resetKey]);
   useEffect(() => {
     // Fit on the FIRST render, and re-fit whenever the graph's drawn size changes (live nodes
@@ -843,19 +867,38 @@ export function TerrainMapView({
         onClick={expanded ? (e) => e.stopPropagation() : undefined}
       >
       {terrain.summary && (
-        // The authored summary, in full. It used to be ONE `truncate`d line with the rest
-        // revealed on hover, which cut every shipped mission's summary mid-sentence — they
-        // run to two or three lines. A sentence you have to hover to finish is a sentence
-        // nobody reads, so it wraps.
+        // Clamped to TWO lines behind an EXPLICIT toggle (issue #22). This block has now
+        // swung twice, so the history matters: the original map truncated the summary to one
+        // line and revealed the rest only on hover — a sentence you have to hover to finish
+        // is a sentence nobody reads — so a later pass made it wrap in full. That assumed
+        // summaries "run to two or three lines"; shipped missions run to paragraph length,
+        // and every wrapped line comes straight out of the map viewport below (squashing it
+        // to its min-h floor, then scrolling) — the pane's job is the graph, not the prose.
         //
-        // The hover overlay went with it: it existed only to reveal what truncation hid, and
-        // a duplicate that fades in over identical text is worse than no overlay at all. What
-        // it bought was a fixed header height so the graph never shifted; the graph is the
-        // flex-1 region below and simply takes the residual height, so a two-line summary
-        // costs one line of map rather than breaking the layout.
-        <p className="shrink-0 border-b border-border px-4 py-2 text-caption text-text-secondary">
-          {terrain.summary}
-        </p>
+        // The clamp keeps both earlier principles: no hover-gated text (the toggle is a
+        // persistent CLICK target that announces its state via aria-expanded), and no
+        // duplicate overlay (line-clamp hides visually only — the full text stays in the
+        // DOM, so assistive tech and find-in-page still see all of it). The graph yields
+        // height only while the reader has explicitly asked for the prose.
+        <div className="shrink-0 border-b border-border px-4 py-2">
+          <p
+            ref={summaryRef}
+            data-testid="terrain-summary"
+            className={`text-caption text-text-secondary ${summaryExpanded ? "" : "line-clamp-2"}`}
+          >
+            {terrain.summary}
+          </p>
+          {(summaryOverflows || summaryExpanded) && (
+            <button
+              type="button"
+              aria-expanded={summaryExpanded}
+              onClick={() => setSummaryExpanded((v) => !v)}
+              className="mt-1 text-caption text-text-tertiary underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {summaryExpanded ? "Show less" : "Show more"}
+            </button>
+          )}
+        </div>
       )}
       <div className="relative min-h-[360px] flex-1">
         <div


### PR DESCRIPTION
> **Stack collapsed into this PR.** #21 was squash-merged into `main`, which broke the ancestry
> of the branches stacked on it — #26 and #31 were closed unmerged, leaving their work stranded.
> Stack #33 has been dissolved (`POST /stacks/33/unstack`) and this branch rebased
> `--onto main` from `a6f3663`: the two commits `main` already absorbed via #21's squash drop
> out, and the remaining six replay with no conflicts. The introduced patch is byte-identical to
> the pre-rebase stack tip, so nothing from #26 or #31 is lost. This is now the single PR for
> all remaining terrain-map work.

## What changed

Six commits, previously reviewed across #26, #31 and this PR:

| Commit | Change |
| --- | --- |
| `fix(frontend): clamp long terrain summaries behind an explicit toggle` | Summary clamps to two lines behind a persistent Show more / Show less target (`aria-expanded`), shown only when the clamped box measurably overflows. Line-clamp hides visually only, so the full text stays in the DOM for assistive tech and find-in-page. |
| `fix(frontend): draw the expanded summary over the map instead of pushing it` | The strip is layout-frozen; the full text renders as a padding-matched absolute overlay over the map, so opening it no longer pushes the viewport down and shoves the zoom cluster out of a fixed-height card. |
| `perf(frontend): stop the summary toggle re-rendering the whole graph, and animate the sheet` | The SVG subtree was inline in the component body, so *any* state change reconciled every group, edge and node. The graph is now memoised on the inputs that actually change it. The sheet grows via an animated `max-height`, dropped under `prefers-reduced-motion`. |
| `fix(frontend): refine terrain summary disclosure` | Follow-up polish on the disclosure. |
| `fix(frontend): keep terrain controls in the map footer` | View toolbar moves into the in-flow caption footer so it cannot overlap the canvas frame at constrained widths or browser zoom; the min-height contract moves from the canvas row to the whole card. |
| `fix(frontend): reserve the legend column in Fit only while the legend is open` | `fitToView` applies the 132px `LEGEND_RESERVE` only while the legend is open, and refits on toggle under the existing hand-off rule — never yanking a view the user has panned or zoomed. |

## Why

Closes #22, #23, #29, #30.

The terrain map shipped in #20/#21 had four distinct layout defects that each stole space from the
graph: a paragraph-length summary took its wrapped height straight out of the viewport, expanding it
pushed the controls out of fixed-height cards, the control toolbar overlapped the canvas at
constrained widths, and `Fit` reserved a dead 132px column for a legend that might be minimised.

## Testing

```
$ cd frontend && npm run typecheck && npm test
tsc --noEmit: clean
Tests 683 passed (683)
```

Regression tests cover: the clamp's measured-overflow contract, the overlay's padding match, the
portal placement and wheel-after-round-trip behaviour, the footer's min-height contract, and the
legend reserve refitting in both directions.

**Test lanes affected**:

- [ ] `unit` — no Docker, fast
- [ ] `adapters` — port/adapter contracts
- [ ] `topology` — manifest / compose / import / extras parity
- [ ] `integration` — needs Docker or a live server process
- [ ] `e2e` — full `xorcise up` + scripted agent
- [x] `frontend` — Next.js typecheck / vitest

## User-facing impact

- [ ] No user-visible change (internal refactor, tests, docs only)
- [x] Backwards-compatible addition (new command, new optional flag, new field)
- [ ] **Breaking change** — describe the break and the migration path below

Visual behaviour changes in the terrain map's summary, controls and Fit; no contract changes.

## Documentation

- [x] No documentation change needed
- [ ] Documentation updated in this PR
- [ ] Documentation needed and tracked in a follow-up issue (link it)

## Dependencies

- [x] No dependency changes
- [ ] Dependencies changed **and** the lockfile is committed

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in the diff — including in test fixtures, logs and comments
- [x] No references to internal-only systems (private trackers, internal URLs, internal process names) in code or documentation

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or will when the CLA assistant comments below. If I am contributing in the course of employment, my employer has signed the Corporate CLA.
