### PR TITLE
fix(frontend): keep terrain controls in the map footer

### DIFF
--- a/frontend/src/features/live-trace/terrain-map.test.tsx
+++ b/frontend/src/features/live-trace/terrain-map.test.tsx
@@ -578,7 +578,7 @@ describe("TerrainMap", () => {
   });
 
   test("exposes zoom + fit controls", async () => {
-    mount(
+    const { container } = mount(
       terrain({
         groups: [{ id: "g", label: "Group", description: null, kind: "agent", order: 0, hidden: false, discovered: true }],
         nodes: [
@@ -590,6 +590,18 @@ describe("TerrainMap", () => {
     expect(await screen.findByLabelText("zoom in")).toBeInTheDocument();
     expect(await screen.findByLabelText("fit to view")).toBeInTheDocument();
     expect(await screen.findByLabelText("zoom out")).toBeInTheDocument();
+    const viewport = container.querySelector('[data-testid="terrain-viewport"]');
+    const card = screen.getByTestId("terrain-map-card");
+    const canvas = screen.getByTestId("terrain-canvas");
+    const footer = screen.getByTestId("terrain-footer");
+    const controls = screen.getByTestId("terrain-view-controls");
+    expect(card.className).toContain("min-h-[360px]");
+    expect(canvas.className).toContain("min-h-0");
+    expect(canvas.className).not.toContain("min-h-[360px]");
+    expect(viewport).not.toContainElement(controls);
+    expect(footer).toContainElement(controls);
+    expect(controls.className).toContain("flex-wrap");
+    expect(controls.className).not.toContain("absolute");
   });
 
   test("the + / − buttons actually change the map's zoom scale", async () => {

--- a/frontend/src/features/live-trace/terrain-map.tsx
+++ b/frontend/src/features/live-trace/terrain-map.tsx
@@ -451,13 +451,14 @@ function Legend() {
   // graph the operator wants to see. Minimised, it's a single "Legend" pill one click from the key.
   const [open, setOpen] = useState(true);
   return (
-    <div className="absolute right-2 top-2 rounded-md border border-border bg-card/90 backdrop-blur">
+    <div
+      className="absolute right-2 top-2 z-20 max-w-[calc(100%-1rem)] rounded-md border border-border bg-card/90 backdrop-blur"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
       <button
         type="button"
         aria-label={open ? "Minimise legend" : "Expand legend"}
         aria-expanded={open}
-        // stop the pointerdown reaching the viewport, which would otherwise start a map pan.
-        onPointerDown={(e) => e.stopPropagation()}
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between gap-3 px-2.5 py-1.5 text-label uppercase text-text-tertiary hover:text-text-secondary"
       >
@@ -1008,9 +1009,10 @@ export function TerrainMapView({
       onClick={expanded ? () => setExpanded(false) : undefined}
     >
       <div
-        // `relative` anchors the expanded-summary overlay below, which spans the card from
-        // its top edge OVER the map — never through the layout.
-        className="relative flex h-full w-full flex-col rounded-md border border-border bg-card"
+        // `relative` anchors the summary layer, which grows over the map without changing its
+        // dimensions or causing the auto-fit observer to visually zoom the graph.
+        data-testid="terrain-map-card"
+        className="relative flex h-full min-h-[360px] w-full flex-col overflow-hidden rounded-md border border-border bg-card"
         onClick={expanded ? (e) => e.stopPropagation() : undefined}
       >
       {terrain.summary && (
@@ -1050,56 +1052,57 @@ export function TerrainMapView({
           </div>
         </div>
       )}
-      <div className="relative min-h-[360px] flex-1">
+      {/* The component owns the 360px overall floor; the canvas row itself must be allowed to
+          shrink so the summary and in-flow footer can never be pushed beyond the clipped card. */}
+      <div data-testid="terrain-canvas" className="relative min-h-0 flex-1">
         <div
           ref={containerRef}
           data-testid="terrain-viewport"
           // Inset a few px from the card's rounded border and clip HERE, so panned/zoomed content
           // stays inside a clean gutter and never butts up against (or paints over) the outer
           // border — the fit measures this inset box, so a fitted graph gets the gutter too.
-          className="absolute inset-[3px] overflow-hidden rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          className="absolute inset-[3px] isolate overflow-hidden rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
           // focusable so focus/blur/Escape can gate plain-wheel zoom (the wheel listener itself is
           // native + non-passive, attached in the effect above)
           tabIndex={0}
-        onFocus={() => {
-          wheelActiveRef.current = true;
-        }}
-        onBlur={() => {
-          wheelActiveRef.current = false;
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") wheelActiveRef.current = false;
-        }}
-        onPointerDown={(e) => {
-          wheelActiveRef.current = true; // engaging the map opts into plain-wheel zoom
-          drag.current = { x: e.clientX, y: e.clientY, px: pan.x, py: pan.y };
-          setDragging(true);
-          e.currentTarget.setPointerCapture(e.pointerId);
-        }}
-        onPointerMove={(e) => {
-          if (!drag.current) return;
-          userControlled.current = true; // a manual pan opts out of auto-fit
-          setPan({
-            x: drag.current.px + (e.clientX - drag.current.x),
-            y: drag.current.py + (e.clientY - drag.current.y),
-          });
-        }}
-        onPointerUp={() => {
-          drag.current = null;
-          setDragging(false);
-        }}
-        style={{ cursor: dragging ? "grabbing" : "grab" }}
-      >
-        <div
-          style={{
-            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-            transformOrigin: "0 0",
-            transition: dragging ? "none" : "transform 0.15s ease-out",
+          onFocus={() => {
+            wheelActiveRef.current = true;
           }}
+          onBlur={() => {
+            wheelActiveRef.current = false;
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") wheelActiveRef.current = false;
+          }}
+          onPointerDown={(e) => {
+            wheelActiveRef.current = true; // engaging the map opts into plain-wheel zoom
+            drag.current = { x: e.clientX, y: e.clientY, px: pan.x, py: pan.y };
+            setDragging(true);
+            e.currentTarget.setPointerCapture(e.pointerId);
+          }}
+          onPointerMove={(e) => {
+            if (!drag.current) return;
+            userControlled.current = true; // a manual pan opts out of auto-fit
+            setPan({
+              x: drag.current.px + (e.clientX - drag.current.x),
+              y: drag.current.py + (e.clientY - drag.current.y),
+            });
+          }}
+          onPointerUp={() => {
+            drag.current = null;
+            setDragging(false);
+          }}
+          style={{ cursor: dragging ? "grabbing" : "grab" }}
         >
-          {graph}
+          <div
+            style={{
+              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+              transformOrigin: "0 0",
+              transition: dragging ? "none" : "transform 0.15s ease-out",
+            }}
+          >
+            {graph}
           </div>
-        </div>
 
         <Legend />
 
@@ -1109,7 +1112,7 @@ export function TerrainMapView({
             pointerdown so the pannable container beneath can't capture the click. */}
         {selectedEventId && onReturnToLive && (
           <div
-            className="absolute left-1/2 top-2 z-20 -translate-x-1/2"
+            className="absolute left-1/2 top-2 z-20 max-w-[calc(100%-1rem)] -translate-x-1/2"
             onPointerDown={(e) => e.stopPropagation()}
           >
             <button
@@ -1127,17 +1130,28 @@ export function TerrainMapView({
         {wheelTip && (
           <div
             data-testid="wheel-tip"
-            className="pointer-events-none absolute left-1/2 top-2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-card/90 px-2.5 py-1.5 text-caption text-text-secondary backdrop-blur"
+            className="pointer-events-none absolute left-1/2 top-2 z-20 max-w-[calc(100%-1rem)] -translate-x-1/2 truncate whitespace-nowrap rounded-md border border-border bg-card/90 px-2.5 py-1.5 text-caption text-text-secondary backdrop-blur"
           >
             Ctrl/⌘ + scroll to zoom — or click the map
           </div>
         )}
 
-        {/* stopPropagation on pointerdown: the container captures the pointer for panning
-            (setPointerCapture), which otherwise swallows these buttons' click events. */}
+        </div>
+      </div>
+
+      {/* One in-flow footer owns both the caption and view controls. Because the toolbar is no
+          longer absolutely positioned over the canvas, it cannot intersect either terrain border;
+          flex-wrap lets it fall below the caption cleanly in very narrow panes. */}
+      <div
+        data-testid="terrain-footer"
+        className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-t border-border px-4 py-2"
+      >
+        <p className="min-w-[16rem] flex-1 text-caption text-text-tertiary">
+          {caption ?? "Amber ring = what just changed · hover a node to highlight its trace events."}
+        </p>
         <div
-          className="absolute bottom-2 right-2 flex items-center gap-1 text-text-secondary"
-          onPointerDown={(e) => e.stopPropagation()}
+          data-testid="terrain-view-controls"
+          className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-1 text-text-secondary"
         >
           {expandable && (
             <button
@@ -1145,7 +1159,7 @@ export function TerrainMapView({
               aria-label={expanded ? "exit fullscreen" : "fullscreen"}
               title={expanded ? "Exit fullscreen (Esc)" : "Fullscreen"}
               onClick={() => setExpanded((v) => !v)}
-              className="flex items-center self-stretch rounded border border-border bg-card px-2 hover:text-foreground"
+              className="flex h-7 items-center rounded border border-border bg-card px-2 hover:text-foreground"
             >
               {expanded ? (
                 <Minimize2 className="size-3" aria-hidden />
@@ -1158,7 +1172,7 @@ export function TerrainMapView({
             type="button"
             aria-label="zoom out"
             onClick={() => zoomBy(0.9)}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             −
           </button>
@@ -1169,7 +1183,7 @@ export function TerrainMapView({
               userControlled.current = false; // resume auto-fit following
               fitToView();
             }}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             Fit
           </button>
@@ -1177,19 +1191,12 @@ export function TerrainMapView({
             type="button"
             aria-label="zoom in"
             onClick={() => zoomBy(1.1)}
-            className="rounded border border-border bg-card px-2 py-0.5 text-dense hover:text-foreground"
+            className="h-7 rounded border border-border bg-card px-2 text-dense hover:text-foreground"
           >
             +
           </button>
         </div>
       </div>
-
-      {/* Only the facts the legend doesn't already carry: the amber (just-changed) ring and the
-          hover interaction. The colour→state mapping lives in the legend, so it's dropped here to
-          keep this caption short enough to wrap cleanly inside the card. */}
-      <p className="shrink-0 border-t border-border px-4 py-2 text-caption text-text-tertiary">
-        {caption ?? "Amber ring = what just changed · hover a node to highlight its trace events."}
-      </p>
       {attributionOff && hasMissionGroup && (
         <p className="shrink-0 border-t border-border px-4 py-2 text-caption italic text-text-tertiary">
           target attribution off — set a model in Settings


### PR DESCRIPTION
> Part of the terrain stack: based on #26; #27 will be rebased on top of this PR.
> Merge order: #21 → #26 → this → #27.

## What changed

- Moves fullscreen, zoom-out, Fit, and zoom-in into the existing in-flow terrain footer.
- Keeps the toolbar out of the canvas so it cannot intersect the map frame at constrained widths or browser zoom.
- Lets the footer wrap beneath its caption on narrow panes.
- Moves the 360px minimum-height contract from the canvas row to the complete terrain card.
- Allows the canvas to shrink with `min-h-0`, preserving the summary and footer inside bounded flex layouts.
- Keeps terrain overlays clipped and pointer-safe inside the canvas viewport.

## Why

Absolutely positioned controls could overlap the terrain frame. Moving them inside the viewport still allowed their elevated layer to paint over the inset frame, while moving them into a footer initially exposed a second constraint: the canvas retained its own 360px minimum and pushed the footer beyond the clipped card.

The final layout gives the complete component the minimum height and keeps the toolbar in normal flow, making border intersection geometrically impossible.

Fixes #29.
Fixes #30.

## Testing

```
cd frontend
npm run typecheck
npm test
```

- TypeScript: clean
- Frontend: 94 files, 682 tests passed

## User-facing impact

Terrain view controls remain visible and separated from the map frame across split panes, fullscreen, mission previews, narrow layouts, and browser zoom. No API or dependency changes.

<img width="1618" height="960" alt="image" src="https://github.com/user-attachments/assets/9502dbf9-7b70-40c7-9108-ea75f9556f90" />
