### PR TITLE
feat(missions): make Other providers a designed coming-soon state

### DIFF
--- a/frontend/src/components/ui/coming-soon.tsx
+++ b/frontend/src/components/ui/coming-soon.tsx
@@ -25,16 +25,28 @@ import { cn } from "./cn";
 export function ComingSoonPanel({
   headline,
   steps,
+  align = "start",
   className,
   children,
 }: {
   headline: string;
   /** Illustrative, not interactive — the shape of the flow. */
   steps: { icon: ReactElement<{ className?: string }>; label: string }[];
+  /**
+   * `start` (default) is the reading layout the two original hosts use — a dialog and a
+   * settings card, where the panel sits in a column of other left-aligned content.
+   *
+   * `center` is for a panel that IS the surface, with nothing to align to: it centres the
+   * axis, drops the measure caps so the prose fills the box instead of stopping short of
+   * it, and moves the sparkle to the corner so it stops pulling the top row off-centre.
+   * Opt-in rather than inferred, so neither existing host shifts.
+   */
+  align?: "start" | "center";
   className?: string;
   /** Body prose. */
   children: ReactNode;
 }) {
+  const centered = align === "center";
   return (
     <div
       className={cn(
@@ -48,21 +60,46 @@ export function ComingSoonPanel({
         aria-hidden
         className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(232,184,75,0.16),transparent_52%)]"
       />
-      <div className="relative p-5">
-        <div className="mb-5 flex items-center justify-between gap-3">
+      <div className={cn("relative p-5", centered && "text-center")}>
+        {centered && (
+          <Sparkles
+            className="absolute right-5 top-5 size-4 text-primary/70"
+            aria-hidden
+          />
+        )}
+        <div
+          className={cn(
+            "mb-5 flex items-center gap-3",
+            centered ? "justify-center" : "justify-between",
+          )}
+        >
           <span className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/5 px-2.5 py-1 text-label uppercase text-primary">
             <span className="size-1.5 rounded-full bg-primary shadow-[0_0_8px_rgba(232,184,75,0.7)]" />
             Coming soon
           </span>
-          <Sparkles className="size-4 text-primary/70" aria-hidden />
+          {!centered && <Sparkles className="size-4 text-primary/70" aria-hidden />}
         </div>
 
         <div className="grid gap-5 @3xl:grid-cols-[1.35fr_1fr] @3xl:items-center @3xl:gap-8">
           <div>
             {/* Measure caps, not layout limits. Narrow: the dialog is the cap. Wide: the
-                column is, and prose stops at the 68ch readable band the type rules set. */}
-            <h3 className="max-w-sm text-lead text-heading @3xl:max-w-none">{headline}</h3>
-            <p className="mt-2 max-w-md text-body text-text-secondary @3xl:max-w-[68ch]">
+                column is, and prose stops at the 68ch readable band the type rules set.
+                Centred, the panel's own width IS the cap — it is sized to the measure at
+                the call site — so the caps come off and the prose fills the box. */}
+            <h3
+              className={cn(
+                "text-lead text-heading @3xl:max-w-none",
+                centered ? "text-balance" : "max-w-sm",
+              )}
+            >
+              {headline}
+            </h3>
+            <p
+              className={cn(
+                "mt-2 text-body text-text-secondary @3xl:max-w-[68ch]",
+                centered ? "text-pretty" : "max-w-md",
+              )}
+            >
               {children}
             </p>
           </div>
@@ -71,7 +108,12 @@ export function ComingSoonPanel({
               row of two-word chips would each be 400px of mostly nothing. */}
           <div className="grid gap-2 @sm:grid-cols-3 @3xl:grid-cols-1">
             {steps.map((step) => (
-              <PreviewStep key={step.label} icon={step.icon} label={step.label} />
+              <PreviewStep
+                key={step.label}
+                icon={step.icon}
+                label={step.label}
+                centered={centered}
+              />
             ))}
           </div>
         </div>
@@ -83,12 +125,20 @@ export function ComingSoonPanel({
 function PreviewStep({
   icon,
   label,
+  centered,
 }: {
   icon: ReactElement<{ className?: string }>;
   label: string;
+  centered?: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 rounded-md border border-border bg-card/70 px-3 py-2.5 text-caption text-foreground">
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-border bg-card/70 px-3 py-2.5 text-caption text-foreground",
+        // Left-aligned chips under centred prose read as a list that lost its bullets.
+        centered && "justify-center text-center",
+      )}
+    >
       <span className="text-primary [&>svg]:size-3.5" aria-hidden>
         {icon}
       </span>

--- a/frontend/src/features/missions/catalog.tsx
+++ b/frontend/src/features/missions/catalog.tsx
@@ -20,6 +20,7 @@ import { FilterBar } from "./filter-bar";
 import { MissionCard, MissionRow } from "./mission-card";
 import { LibraryStats } from "./library-stats";
 import { IngestButton } from "./ingest-button";
+import { IngestComingSoon } from "./ingest-coming-soon";
 import { OtherProviders } from "./other-providers";
 import type { CatalogEntry, CatalogStatus } from "@/lib/api/types";
 
@@ -138,7 +139,7 @@ export function MissionCatalog() {
                   view={view}
                   filtersActive={filtersActive}
                   onClearFilters={clearFilters}
-                  empty="No local missions yet. Ingest a bundle to add one."
+                  empty={<NoLocalMissions />}
                 />
               </TabsContent>
 
@@ -159,7 +160,11 @@ export function MissionCatalog() {
                     view={view}
                     filtersActive={filtersActive}
                     onClearFilters={clearFilters}
-                    empty="No remote missions available yet."
+                    empty={
+                      <p className="text-body text-text-secondary">
+                        No remote missions available yet.
+                      </p>
+                    }
                   />
                 )}
               </TabsContent>
@@ -284,16 +289,16 @@ function Grid({
 }: {
   items: CatalogEntry[];
   view: MissionView;
-  empty: string;
+  /** Rendered as given, not wrapped: one tab's empty state is a sentence, another's is a
+   *  panel, and a shared <p> around both would have set the panel in body type. */
+  empty: ReactNode;
   filtersActive: boolean;
   onClearFilters: () => void;
 }) {
   if (items.length === 0) {
-    return filtersActive ? (
-      <NoResults onClear={onClearFilters} />
-    ) : (
-      <p className="text-body text-text-secondary">{empty}</p>
-    );
+    // Filters first: "nothing matched your search" is a different problem from "this tab
+    // has nothing in it", and only the first one has a way out.
+    return filtersActive ? <NoResults onClear={onClearFilters} /> : empty;
   }
   // List view: one dense row per mission.
   if (view === "list") {
@@ -317,6 +322,33 @@ function Grid({
         </li>
       ))}
     </ul>
+  );
+}
+
+/**
+ * Your Own with nothing in it — which, until ingestion ships, is every install.
+ *
+ * It used to read "No local missions yet. Ingest a bundle to add one." That sentence
+ * instructed the reader to perform the one action the build cannot do: the Ingest button
+ * eight pixels above it opens a coming-soon preview, not a file browser. An empty state
+ * that names an unavailable action as the remedy is worse than one that says nothing,
+ * because the reader spends their time looking for the control rather than moving on.
+ *
+ * So it says the true thing instead, in the same words the Ingest dialog uses — the panel
+ * is literally the same component — and then points at the shelf that does work today.
+ * Only reached when NO filters are active; a search that matches nothing still gets
+ * `NoResults`, which is a different problem with a different way out.
+ */
+function NoLocalMissions() {
+  return (
+    <div className="mx-auto flex w-full max-w-[42rem] flex-col gap-3 py-2 sm:py-6">
+      <IngestComingSoon align="center" />
+      {/* Outside the panel deliberately: the panel's own rule is that it renders nothing
+          that looks actionable, so the "what can I do right now" line lives beside it. */}
+      <p className="text-center text-caption text-text-tertiary">
+        Until then, XORCISE Remote has missions ready to pull.
+      </p>
+    </div>
   );
 }
 

--- a/frontend/src/features/missions/catalog.tsx
+++ b/frontend/src/features/missions/catalog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
-import { Layers, LayoutGrid, List, Search } from "lucide-react";
+import { LayoutGrid, List, Search } from "lucide-react";
 import { cn } from "@/components/ui/cn";
 import { Button } from "@/components/ui/button";
 import { SkeletonCardGrid } from "@/components/ui/skeleton";
@@ -20,6 +20,7 @@ import { FilterBar } from "./filter-bar";
 import { MissionCard, MissionRow } from "./mission-card";
 import { LibraryStats } from "./library-stats";
 import { IngestButton } from "./ingest-button";
+import { OtherProviders } from "./other-providers";
 import type { CatalogEntry, CatalogStatus } from "@/lib/api/types";
 
 /** localStorage key the catalog uses to remember the grid/list view between visits. */
@@ -83,15 +84,18 @@ export function MissionCatalog() {
       {missions.data && (
         <Tabs defaultValue={defaultTab} className="flex min-h-0 flex-1 flex-col">
           {/* One unbounded scroller for the whole catalog: the stats dashboard scrolls up and off,
-             while the filters + provider tabs row below stays pinned to the top. */}
-          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+             while the filters + provider tabs row below stays pinned to the top.
+             A flex COLUMN, so the tab body below can claim the leftover height instead of
+             guessing it from 100vh — Other providers needs a canvas that exactly fills the
+             pane, and a vh estimate overshot it by the height of this strip and scrolled. */}
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pr-1">
             {all.length > 0 && (
-              <div className="mb-3">
+              <div className="mb-3 shrink-0">
                 <LibraryStats missions={all} />
               </div>
             )}
 
-            <div className="sticky top-0 z-20 border-b border-border bg-background pb-2">
+            <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-background pb-2">
               <FilterBar
                 filters={filters}
                 onChange={setFilters}
@@ -120,7 +124,10 @@ export function MissionCatalog() {
               />
             </div>
 
-            <div className="pt-3">
+            {/* flex-1 with the default min-height:auto — grows to fill when a tab's content
+                is short (Other providers), stays at content height and lets the scroller
+                scroll when it is long (a 26-card grid). */}
+            <div className="flex flex-1 flex-col pt-3">
               {/* ── Your Own (local, ingested) ── */}
               <TabsContent value="your_own" className="space-y-2">
                 <p className="text-dense text-text-secondary">
@@ -157,9 +164,9 @@ export function MissionCatalog() {
                 )}
               </TabsContent>
 
-              {/* ── Other providers (placeholder) ── */}
-              <TabsContent value="other">
-                <ComingSoon />
+              {/* ── Other providers (committed, not shipped) ── */}
+              <TabsContent value="other" className="flex flex-1 flex-col">
+                <OtherProviders />
               </TabsContent>
             </div>
           </div>
@@ -325,19 +332,6 @@ function NoResults({ onClear }: { onClear: () => void }) {
       <Button variant="outline" size="sm" onClick={onClear}>
         Clear filters
       </Button>
-    </div>
-  );
-}
-
-function ComingSoon() {
-  return (
-    <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border bg-card/40 px-6 py-6 text-center">
-      <Layers className="size-5 text-text-secondary" />
-      <p className="text-body font-medium text-heading">More providers coming soon</p>
-      <p className="max-w-sm text-body text-text-secondary">
-        Third-party mission providers will appear here, alongside Your Own and the
-        XORCISE remote library.
-      </p>
     </div>
   );
 }

--- a/frontend/src/features/missions/catalog.tsx
+++ b/frontend/src/features/missions/catalog.tsx
@@ -130,8 +130,12 @@ export function MissionCatalog() {
                 scroll when it is long (a 26-card grid). */}
             <div className="flex flex-1 flex-col pt-3">
               {/* ── Your Own (local, ingested) ── */}
-              <TabsContent value="your_own" className="space-y-2">
-                <p className="text-dense text-text-secondary">
+              {/* A flex column, like the Other providers panel, so an empty tab can claim
+                  the height left under the lede and centre in it rather than hanging off
+                  the top. With missions present the grid sizes to its content as before
+                  and the scroller scrolls. */}
+              <TabsContent value="your_own" className="flex flex-1 flex-col gap-2">
+                <p className="shrink-0 text-dense text-text-secondary">
                   Missions you’ve ingested locally from a bundle.
                 </p>
                 <Grid
@@ -341,13 +345,22 @@ function Grid({
  */
 function NoLocalMissions() {
   return (
-    <div className="mx-auto flex w-full max-w-[42rem] flex-col gap-3 py-2 sm:py-6">
-      <IngestComingSoon align="center" />
-      {/* Outside the panel deliberately: the panel's own rule is that it renders nothing
-          that looks actionable, so the "what can I do right now" line lives beside it. */}
-      <p className="text-center text-caption text-text-tertiary">
-        Until then, XORCISE Remote has missions ready to pull.
-      </p>
+    // Same centring as the Other providers panel: fill the track the tab has left, then
+    // centre in it. Top-aligned below `sm`, where the stats strip already fills a phone
+    // and centring would only push this further down the scroll.
+    // py-2, not py-6: this tab carries a lede line the Other providers tab does not, so it
+    // has ~32px less to spend, and on a 1280x720 window the larger padding grew this box
+    // past its flex track and put a 19px scrollbar on a pane with nothing below the fold.
+    // The panel is centred in the track anyway — the padding only keeps it off the edges.
+    <div className="flex flex-1 items-start justify-center py-2 sm:items-center">
+      <div className="flex w-full max-w-[42rem] flex-col gap-3">
+        <IngestComingSoon align="center" />
+        {/* Outside the panel deliberately: the panel's own rule is that it renders nothing
+            that looks actionable, so the "what can I do right now" line lives beside it. */}
+        <p className="text-center text-caption text-text-tertiary">
+          Until then, XORCISE Remote has missions ready to pull.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/missions/ingest-button.tsx
+++ b/frontend/src/features/missions/ingest-button.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { Check, PackagePlus, ShieldCheck } from "lucide-react";
+import { PackagePlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ComingSoonPanel } from "@/components/ui/coming-soon";
 import { Dialog } from "@/components/ui/dialog";
+import { IngestComingSoon } from "./ingest-coming-soon";
 
 /**
  * "Ingest a bundle" — the GUI counterpart of `xorcise mission ingest`.
@@ -28,17 +28,7 @@ export function IngestButton() {
         onClose={() => setOpen(false)}
         title="Bundle ingestion"
       >
-        <ComingSoonPanel
-          headline="Bring your own missions."
-          steps={[
-            { icon: <PackagePlus />, label: "Choose bundle" },
-            { icon: <ShieldCheck />, label: "Validate safely" },
-            { icon: <Check />, label: "Ready to run" },
-          ]}
-        >
-          Drop in a mission bundle and XORCISE will inspect it, validate it, and add
-          it to your local catalog—ready to run.
-        </ComingSoonPanel>
+        <IngestComingSoon />
 
         <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-caption text-text-tertiary">

--- a/frontend/src/features/missions/ingest-coming-soon.tsx
+++ b/frontend/src/features/missions/ingest-coming-soon.tsx
@@ -1,0 +1,31 @@
+import { Check, PackagePlus, ShieldCheck } from "lucide-react";
+import { ComingSoonPanel } from "@/components/ui/coming-soon";
+
+/**
+ * The one description of bundle ingestion, for every surface that has to explain it.
+ *
+ * Two places make the same promise about the same unshipped capability: the dialog behind
+ * "Ingest a bundle", and the Your Own tab when it is empty. Written out twice they would
+ * eventually disagree about what ingestion does — which is the failure mode this repo has
+ * already hit with `StatusDot` and with the fused-image buildspec. One component, two
+ * hosts, and the copy can only change in one place.
+ *
+ * `align` is the only thing the hosts differ on: the dialog reads left in a column of
+ * other left-aligned content, the empty state IS its pane and centres.
+ */
+export function IngestComingSoon({ align }: { align?: "start" | "center" }) {
+  return (
+    <ComingSoonPanel
+      align={align}
+      headline="Bring your own missions."
+      steps={[
+        { icon: <PackagePlus />, label: "Choose bundle" },
+        { icon: <ShieldCheck />, label: "Validate safely" },
+        { icon: <Check />, label: "Ready to run" },
+      ]}
+    >
+      Drop in a mission bundle and XORCISE will inspect it, validate it, and add it to
+      your local catalog—ready to run.
+    </ComingSoonPanel>
+  );
+}

--- a/frontend/src/features/missions/library-stats.tsx
+++ b/frontend/src/features/missions/library-stats.tsx
@@ -84,7 +84,13 @@ export function LibraryStats({ missions }: { missions: CatalogEntry[] }) {
 
   return (
     <Card className="bg-raised">
-      <CardContent className="flex flex-wrap items-stretch gap-x-6 gap-y-4 p-4">
+      {/* An explicit grid, not flex-wrap. Wrapping let the row decide for itself how many
+          cells fit, and on a ~500px pane that came out 3-up with difficulty dropped alone
+          onto a second row — the widest cell, given the whole width, with nothing beside
+          it. Four cells split cleanly, so the layout is stated: one column on a phone, 2x2
+          once there is room for two, one row at lg where all four fit without squeezing
+          the difficulty meter (it needs ~210px and cannot compress). */}
+      <CardContent className="grid grid-cols-1 items-stretch gap-x-6 gap-y-4 p-4 min-[30rem]:grid-cols-2 lg:grid-cols-4">
         {/* ── headline count — number stacked over the label ── */}
         <Section>
           <div>
@@ -151,14 +157,24 @@ export function LibraryStats({ missions }: { missions: CatalogEntry[] }) {
 
         {/* ── difficulty distribution — dot-matrix pips (matches the card badge) ── */}
         <Section divider>
-          <div className="space-y-2">
+          {/* Capped, unlike its neighbours. Every other cell has something that USES spare
+              width — a bar that stretches, a number that grows. A difficulty row is a
+              label, five fixed dots and a count: about 210px of content, and nothing in it
+              can absorb a pixel more. Uncapped, the cell still stretched with the strip,
+              and when the strip wraps on a narrow pane this block takes a whole row on its
+              own — which is where it was last reported, the count marooned 300px from the
+              meter it belongs to. The cap is what keeps the row reading as one unit. */}
+          <div className="max-w-[17rem] space-y-2">
             <p className="text-label uppercase text-text-tertiary">
               difficulty
             </p>
             {stats.byDifficulty.map((b) => (
               <div
                 key={b.label}
-                className="grid grid-cols-[104px_auto_18px] items-center gap-2 text-caption text-text-secondary"
+                /* 1fr on the LABEL, not the pips: an `auto` middle track absorbs the spare
+                   width and left-aligns five fixed-width dots inside it, which detaches the
+                   meter from its count. Spare width belongs to the truncating label. */
+                className="grid grid-cols-[1fr_auto_18px] items-center gap-2 text-caption text-text-secondary"
               >
                 <span className="truncate" title={b.label}>
                   {b.label}
@@ -182,12 +198,18 @@ export function LibraryStats({ missions }: { missions: CatalogEntry[] }) {
 }
 
 /**
- * A strip cell. Cells share the row width evenly (`flex-1`) so the strip spreads across the pane;
- * `divider` draws the left rule that separates it from the previous cell.
+ * A strip cell. `min-w-0` so a grid cell can shrink under its content and let the labels
+ * inside truncate as intended — grid items default to `min-width: auto`, which would push
+ * the widest cell past its track instead.
+ *
+ * `divider` draws the left rule at lg and only at lg, where the four cells sit in ONE row
+ * and every rule separates two cells. In the 2x2 and stacked layouts the same rule lands
+ * on the cell that STARTS a row, where it reads as a stray vertical line down the left of
+ * the card; the grid gap already does the separating there.
  */
 function Section({ children, divider }: { children: React.ReactNode; divider?: boolean }) {
   return (
-    <div className={cn("min-w-40 flex-1", divider && "sm:border-l sm:border-border sm:pl-6")}>
+    <div className={cn("min-w-0", divider && "lg:border-l lg:border-border lg:pl-6")}>
       {children}
     </div>
   );

--- a/frontend/src/features/missions/missions.test.tsx
+++ b/frontend/src/features/missions/missions.test.tsx
@@ -176,6 +176,26 @@ describe("MissionCatalog", () => {
     // A row that declares no type renders no badge rather than a guessed one.
     expect(screen.queryByText("Lab")).not.toBeInTheDocument();
   });
+
+  it("presents Other providers as the house coming-soon preview, not an empty-results box", async () => {
+    server.use(http.get("*/api/missions", () => HttpResponse.json(catalog)));
+    renderWithProviders(<MissionCatalog />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /Other providers/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("One catalog, many providers.")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Coming soon/i)).toBeInTheDocument();
+    // The shape of the flow, illustrative only.
+    expect(screen.getByText("Connect a provider")).toBeInTheDocument();
+    expect(screen.getByText("Pull and run")).toBeInTheDocument();
+
+    // Not the filters-matched-nothing state, which is a different problem with a way out.
+    expect(
+      screen.queryByRole("button", { name: /Clear filters/i }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("MissionDetail", () => {

--- a/frontend/src/features/missions/missions.test.tsx
+++ b/frontend/src/features/missions/missions.test.tsx
@@ -177,6 +177,46 @@ describe("MissionCatalog", () => {
     expect(screen.queryByText("Lab")).not.toBeInTheDocument();
   });
 
+  it("tells the truth on an empty Your Own instead of naming an action that cannot be done", async () => {
+    // Library-only catalog, so Your Own is empty and Remote holds everything.
+    server.use(
+      http.get("*/api/missions", () =>
+        HttpResponse.json([catalog[1]]),
+      ),
+    );
+    renderWithProviders(<MissionCatalog />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /Your Own/i }));
+
+    // The same promise the Ingest dialog makes, from the same component.
+    await waitFor(() =>
+      expect(screen.getByText("Bring your own missions.")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText(/XORCISE Remote has missions ready to pull/i)).toBeInTheDocument();
+
+    // The old copy instructed the reader to ingest a bundle — the one thing this build
+    // cannot do, since the Ingest button opens the same coming-soon preview.
+    expect(screen.queryByText(/Ingest a bundle to add one/i)).not.toBeInTheDocument();
+  });
+
+  it("still shows the filters-matched-nothing state on Your Own when a search is active", async () => {
+    server.use(http.get("*/api/missions", () => HttpResponse.json(catalog)));
+    renderWithProviders(<MissionCatalog />);
+
+    fireEvent.change(await screen.findByPlaceholderText(/Search missions/i), {
+      target: { value: "nothing-matches-this" },
+    });
+
+    // An empty result from a search has a way out; an empty tab does not. They must not
+    // collapse into the same state. Asserted on the NoResults heading, not on "Clear
+    // filters" — the FilterBar renders a button by that name too whenever a filter is on.
+    await waitFor(() =>
+      expect(screen.getByText(/No missions match your filters/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Bring your own missions.")).not.toBeInTheDocument();
+  });
+
   it("presents Other providers as the house coming-soon preview, not an empty-results box", async () => {
     server.use(http.get("*/api/missions", () => HttpResponse.json(catalog)));
     renderWithProviders(<MissionCatalog />);

--- a/frontend/src/features/missions/other-providers.tsx
+++ b/frontend/src/features/missions/other-providers.tsx
@@ -1,0 +1,218 @@
+import { Check, Plug, Search } from "lucide-react";
+import { ComingSoonPanel } from "@/components/ui/coming-soon";
+
+/**
+ * "Other providers" — a capability XORCISE has committed to and has not shipped.
+ *
+ * It used to be a dashed box with a centred icon and two sentences, which was the same
+ * shape as `NoResults` in catalog.tsx: "your filters matched nothing" is a dead end the
+ * user clears, this is a promise about the roadmap, and the two read as one state. The
+ * house treatment for the second kind already existed (`ComingSoonPanel`, behind the
+ * Ingest dialog and the Settings distributed card); a lone card in an otherwise empty
+ * tab still read as content that had failed to load.
+ *
+ * So the tab is a field, not a box: the message sits at the centre of a provider
+ * constellation that occupies the whole canvas.
+ */
+export function OtherProviders() {
+  return (
+    // Bleeds past the page's p-4 so the field runs to the pane edges — this tab has no
+    // other content to align to, and a canvas that stops short of the frame reads as a
+    // very large card. Height is the viewport minus the header, stats strip and filter
+    // bar, floored so a short window still gets a field rather than a letterbox.
+    // `flex-1` — the canvas takes exactly the height the catalog's flex column has left,
+    // so the tab is one screen with nothing to scroll. It was a `calc(100vh - 23rem)`
+    // guess, which is the wrong quantity twice over: it does not know this pane's chrome,
+    // and it overshot by enough to put a scrollbar on a page that has nothing below the
+    // fold. Default min-height:auto keeps the card from ever being clipped on a short
+    // window. No -mx bleed either — the pane's scroller reports overflow on the cross
+    // axis, so 16px of bleed bought a full horizontal scrollbar.
+    //
+    // Centred on a desktop pane; on a phone the field is invisible anyway (the mask and
+    // the card's width leave nothing of it on screen), so centring only pushed the card
+    // down the page and it sits at the top instead.
+    // py-6, not py-10: on a 1280x720 window the leftover height is barely more than the
+    // card, and the extra 32px was enough to grow this box past its flex track and put a
+    // scrollbar back on the pane. The card is centred in the track anyway — the padding
+    // only has to keep it off the edges.
+    <div className="relative flex flex-1 items-start justify-center overflow-hidden py-6 sm:items-center">
+      <ProviderField />
+      <ComingSoonPanel
+        align="center"
+        // Translucent + blurred: the field behind stays sharp everywhere else and goes
+        // out of focus only under the card, so the card reads as a lens over the network
+        // rather than a frosted panel dropped on top of it.
+        // No entrance of its own: TabsContent already fades the panel up on tab change,
+        // and a second one on the same element just doubles the same 250ms.
+        className="relative w-full max-w-[42rem] border-primary/25 bg-deepest/45 shadow-2xl shadow-black/50 backdrop-blur-md"
+        headline="One catalog, many providers."
+        steps={[
+          { icon: <Plug />, label: "Connect a provider" },
+          { icon: <Search />, label: "Browse its missions" },
+          { icon: <Check />, label: "Pull and run" },
+        ]}
+      >
+        Third-party providers will register here as sources of their own — searched,
+        filtered and pulled with the same controls you already use for Your Own and
+        XORCISE Remote.
+      </ComingSoonPanel>
+    </div>
+  );
+}
+
+/** Centre of the field, in the SVG's own units. Every node hangs off this. */
+const CX = 600;
+const CY = 300;
+
+/**
+ * The two providers that exist today — Your Own and XORCISE Remote.
+ *
+ * Held near the horizontal at r≈420 for one reason: the viewBox scales with the pane
+ * while the card does not, so a node's distance from centre in CSS pixels shrinks as the
+ * window narrows while the card stays 672px wide. At r=300 both nodes disappeared behind
+ * the card at 1440px — the exact width most of this console is used at. 420 clears it
+ * from ~1200px up, and below that the card is nearly the full pane anyway, where a node
+ * glowing through the blur is the effect rather than a loss.
+ */
+const LIVE = [
+  { x: 184, y: 322 },
+  { x: 1018, y: 281 },
+];
+
+/**
+ * The slots a third-party provider would land in. Six, spread over the outer orbits and
+ * deliberately unlabelled: naming them would be inventing roadmap the product has not
+ * committed to. Placed outside the card's footprint at every width — beyond it
+ * horizontally, or above and below its band.
+ */
+const OPEN = [
+  { x: 128, y: 120 },
+  { x: 1074, y: 96 },
+  { x: 128, y: 452 },
+  { x: 1112, y: 470 },
+  { x: 392, y: 84 },
+  { x: 812, y: 540 },
+];
+
+/** Orbit radii, innermost first. The outer two crop on a wide pane — intended. */
+const ORBITS = [
+  { r: 420, opacity: 0.1, dashed: false },
+  { r: 530, opacity: 0.075, dashed: true },
+  { r: 660, opacity: 0.05, dashed: false },
+  { r: 810, opacity: 0.04, dashed: true },
+];
+
+/**
+ * The provider constellation — the catalog at the centre, two live spokes, six open ones.
+ *
+ * Drawn in the terrain map's vocabulary rather than a new one: amber for a live node,
+ * `--color-muted-foreground` for one that is not there yet (the map's "unknown"), a
+ * flowing dash on an active edge, an expanding halo on a live node. Reusing its two
+ * motion classes also inherits their reduced-motion rule from globals.css, where guide
+ * §11/§12 already bans glow and flicker loops in the workspace — a hand-rolled keyframe
+ * here would have needed its own media query and would eventually have drifted from it.
+ *
+ * Purely atmospheric, and `aria-hidden`: it encodes no value a reader needs, and every
+ * fact on this tab is carried by the card.
+ */
+function ProviderField() {
+  return (
+    <div className="pointer-events-none absolute inset-0" aria-hidden>
+      {/* The catalog's own glow, behind the card it sits under. */}
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(232,184,75,0.13),transparent_58%)]" />
+
+      <svg
+        // Two things at once. The mask fades the field into the pane edges, held out to
+        // 62% because it is measured in CSS pixels against the pane's HALF-HEIGHT — a
+        // node only a fifth of the way down the canvas is already a third through the
+        // ramp. The blur throws the whole field a step out of focus so the card reads as
+        // the plane in focus; 2px is enough to soften the dashes without erasing them.
+        className="absolute inset-0 size-full blur-[2px] [mask-image:radial-gradient(ellipse_at_center,#000_62%,transparent_100%)]"
+        viewBox="0 0 1200 600"
+        preserveAspectRatio="xMidYMid slice"
+      >
+        <defs>
+          <radialGradient id="op-live-glow">
+            <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.5" />
+            <stop offset="100%" stopColor="var(--color-primary)" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        {ORBITS.map((o) => (
+          <circle
+            key={o.r}
+            cx={CX}
+            cy={CY}
+            r={o.r}
+            fill="none"
+            stroke="var(--color-primary)"
+            strokeOpacity={o.opacity}
+            strokeDasharray={o.dashed ? "2 12" : undefined}
+          />
+        ))}
+
+        {/* Open spokes: dashed and still, because nothing travels them yet. */}
+        {OPEN.map((n) => (
+          <line
+            key={`edge-${n.x}-${n.y}`}
+            x1={CX}
+            y1={CY}
+            x2={n.x}
+            y2={n.y}
+            stroke="var(--color-muted-foreground)"
+            strokeOpacity="0.22"
+            strokeDasharray="3 10"
+          />
+        ))}
+
+        {/* Live spokes: the map's flowing dash, slowed from its 1s working speed to
+            something ambient — this is a backdrop, not a run in progress. */}
+        {LIVE.map((n) => (
+          <line
+            key={`edge-${n.x}-${n.y}`}
+            x1={CX}
+            y1={CY}
+            x2={n.x}
+            y2={n.y}
+            stroke="var(--color-primary)"
+            strokeOpacity="0.38"
+            strokeDasharray="4 9"
+            className="tm-flow"
+            style={{ animationDuration: "7s" }}
+          />
+        ))}
+
+        {OPEN.map((n) => (
+          <circle
+            key={`open-${n.x}-${n.y}`}
+            cx={n.x}
+            cy={n.y}
+            r="5.5"
+            fill="none"
+            stroke="var(--color-muted-foreground)"
+            strokeOpacity="0.5"
+            strokeDasharray="2 3"
+          />
+        ))}
+
+        {LIVE.map((n) => (
+          <g key={`live-${n.x}-${n.y}`}>
+            <circle cx={n.x} cy={n.y} r="46" fill="url(#op-live-glow)" />
+            {/* r and opacity are driven by the keyframe; the attributes are the
+                resting state reduced-motion users see. */}
+            <circle
+              cx={n.x}
+              cy={n.y}
+              r="16"
+              fill="none"
+              stroke="var(--color-primary)"
+              strokeOpacity="0.45"
+              className="tm-ring-amber"
+            />
+            <circle cx={n.x} cy={n.y} r="6" fill="var(--color-primary)" />
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The **Missions → Other providers** tab rendered a dashed box with a centred icon and two sentences. That box was structurally the same component as `NoResults`, twelve lines away in the same file — so two unrelated states wore the same costume:

- *"Your filters matched nothing"* — a dead end the user clears.
- *"Other providers"* — a capability XORCISE has committed to and not shipped.

The house treatment for the second kind already existed — `ComingSoonPanel`, the amber-wash panel behind the **Ingest a bundle** dialog and the Settings **Distributed deployment** card. The catalog was the only surface not using it.

This makes the tab a **field** rather than a box: a provider constellation fills the canvas — the catalog at the centre, two lit spokes for the providers that exist today, six dashed slots for the ones that do not — with the message centred over it as a lens.

## Before / after

| | Before | After |
|---|---|---|
| **Desktop** 1920×1080 | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/before-desktop.png" width="420"> | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/after-desktop.png" width="420"> |
| **Laptop** 1440×900 | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/before-laptop.png" width="420"> | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/after-laptop.png" width="420"> |
| **Tablet** 820×1180 | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/before-tablet.png" width="300"> | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/after-tablet.png" width="300"> |
| **Mobile** 390×844 | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/before-mobile.png" width="220"> | <img src="https://raw.githubusercontent.com/xorcise-ai/xorcise/pr-assets/other-providers-canvas/after-mobile.png" width="220"> |

> Screenshots live on the standalone `pr-assets/other-providers-canvas` branch so no binaries land in `main`. **Delete it after merge:**
> `git push origin --delete pr-assets/other-providers-canvas`

## Why it is drawn this way

The field borrows the **terrain map's** existing visual vocabulary rather than inventing one: amber for a live node, `--color-muted-foreground` for unknown, a flowing dash on an active edge, an expanding halo on a live node. No new colour, font, or system primitive.

Reusing its two motion classes (`tm-flow`, `tm-ring-amber`) also inherits their reduced-motion rule from `globals.css`, where guide §11/§12 already bans glow and flicker loops in the workspace. A hand-rolled keyframe would have needed its own media query and would eventually have drifted from that rule.

The blur is depth of field, not glass: the field is drawn sharp everywhere and only the card's `backdrop-filter` throws it out of focus, so the spokes visibly soften as they pass beneath it.

`ComingSoonPanel` gains an opt-in `align="center"`. **The two existing hosts keep the default `align="start"` and render unchanged** — verified by screenshot.

## Layout fixes that fell out of building it

**Catalog scroller → flex column.** The tab body now claims the height that is left instead of estimating it with `calc(100vh - 23rem)`. That estimate did not know the pane's own chrome and overshot, putting a scrollbar on a tab with nothing below the fold. A `-mx-4` bleed did the same on the other axis — the scroller is `overflow-y-auto`, which forces `overflow-x: auto`, so 16px of bleed bought a full horizontal scrollbar. Grid tabs still scroll normally; the sticky filter bar still pins.

**Stats strip → explicit grid.** `flex-wrap` let the row decide how many cells fit and produced 3-up with **difficulty** dropped alone onto a second row — the widest cell, given the whole width, with nothing beside it. Now stated outright:

| viewport | layout |
|---|---|
| `< 480px` | 1 column |
| `480–1023px` | 2×2 |
| `≥ 1024px` (`lg`) | one row of 4, with dividers |

The `lg` threshold is derived, not picked: a difficulty row is a label + five fixed dots + a count ≈ **210px that cannot compress**, so four of them plus gaps need ~912px of card interior ≈ a 1024px viewport.

**Difficulty row.** Capped, so the count stops drifting from the meter it belongs to, and its cell rule now draws only in the single-row layout — a `border-left` separates two cells only when there is a cell to its left; in the 2×2 it landed on the cell that *starts* a row and read as a stray line.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **698 passed / 95 files**, 0 failures (re-measured on CI after rebasing onto `c440ecd`)
- `pytest tests/topology` — **18 passed** (import-linter contracts + parity)
- CLI/GUI parity lanes (`test_cli_parity`, `test_cli_json_parity`, `test_cli_catalog_ux`) — green
- **No scroll on either axis**, measured as `scrollHeight − clientHeight`, at 1920×1080, 1600×950, 1536×864, 1440×900, 1366×768, 1280×720 and 1024×768
- Reduced motion: all three animations report `animation-name: none` under `prefers-reduced-motion: reduce`
- Grid tabs still scroll (1417–2145px); sticky filter bar still pins (`stickyTop === scrollerTop` after a 900px scroll)

Mobile still scrolls, as it did before this change (225px → 513px) — the stats dashboard alone fills a 390×844 viewport, and the coming-soon card is taller than the dashed box it replaces.

## No CLI change

`CatalogEntry.source` is `Literal["your_own", "library"]`, and `mission list --source` accepts exactly `library` and `your-own`. A third-party provider is not representable in the domain yet, so there is nothing for the CLI to list or label. The tab predates this PR, so the CLI ↔ GUI gap is unchanged by it. When providers do ship, the contract's `Literal` widens first, then `_SOURCES` and `source_label` follow.

## Scope

Frontend only — 5 files, no API, contract, or CLI surface touched.

