### PR TITLE
fix(runner): strip mission host port publishes

### DIFF
--- a/src/xorcise/core/runner/docker/__init__.py
+++ b/src/xorcise/core/runner/docker/__init__.py
@@ -114,6 +114,14 @@ class DockerDriver(ABC):
     def image_exists(self, image: str) -> bool:
         """Whether the image is already in the local store (local-store-first pull)."""
 
+    def published_port_services(self, image: str) -> tuple[str, ...]:
+        """Services whose authored Compose definitions publish ports on the Docker host.
+
+        Real drivers inspect the already-pulled fused image without starting it. The default is
+        empty for non-Docker drivers; their placeholder images have no mission stack to inspect.
+        """
+        return ()
+
     @abstractmethod
     def reap_managed(self) -> list[str]:
         """Force-remove every xorcise-managed per-run container; return what was reaped.
@@ -175,6 +183,7 @@ class StubDockerDriver(DockerDriver):
         # unknown, so existing stub-mode behaviour (a plain READY) is preserved.
         self.container_states: dict[str, ContainerState] = {}
         self.service_states: dict[str, tuple[ServiceState, ...]] = {}
+        self.port_services: dict[str, tuple[str, ...]] = {}
         self.compose_projects: set[str] = set()  # test-settable projects holding a network
         self.removed_projects: list[str] = []  # projects released by remove_run_resources
         self.specs: list[ContainerSpec] = []  # every run()'s spec, for assertions
@@ -198,6 +207,9 @@ class StubDockerDriver(DockerDriver):
 
     def image_exists(self, image: str) -> bool:
         return image in self.present
+
+    def published_port_services(self, image: str) -> tuple[str, ...]:
+        return self.port_services.get(image, ())
 
     def run(self, spec: ContainerSpec) -> ContainerHandle:
         self._counter += 1

--- a/src/xorcise/core/runner/docker/driver.py
+++ b/src/xorcise/core/runner/docker/driver.py
@@ -6,10 +6,16 @@ the `runner` extra; only constructing the driver requires the SDK + a daemon.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json as _json
 import platform as _platform
-from collections.abc import Callable
+import tarfile
+from collections.abc import Callable, Mapping
+from pathlib import PurePosixPath
 from typing import Any
+
+import yaml
 
 from xorcise.core.runner.docker import (
     MANAGED_LABEL,
@@ -21,6 +27,27 @@ from xorcise.core.runner.docker import (
     PullProgress,
     ServiceState,
 )
+
+_MISSION_COMPOSE_PATH = "/mission/docker-compose.yml"
+_MAX_COMPOSE_BYTES = 4 * 1024 * 1024
+
+
+def _published_port_services(content: bytes | str) -> tuple[str, ...]:
+    """Parse authored Compose and return services that declare host publications."""
+    try:
+        compose = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise RuntimeError("mission docker-compose.yml is not valid YAML") from exc
+    if not isinstance(compose, Mapping):
+        raise RuntimeError("mission docker-compose.yml must contain a mapping")
+    services = compose.get("services")
+    if not isinstance(services, Mapping):
+        raise RuntimeError("mission docker-compose.yml must contain a services mapping")
+    return tuple(
+        str(name)
+        for name, spec in services.items()
+        if isinstance(spec, Mapping) and "ports" in spec
+    )
 
 
 def _parse_compose_ps(output: bytes | str) -> tuple[ServiceState, ...]:
@@ -86,6 +113,7 @@ class DockerSdkDriver(DockerDriver):
             client = docker.from_env()
         self._client = client
         self._platform = platform
+        self._published_ports_by_image_id: dict[str, tuple[str, ...]] = {}
 
     def pull(
         self,
@@ -137,6 +165,72 @@ class DockerSdkDriver(DockerDriver):
             return True
         except docker.errors.ImageNotFound:
             return False
+
+    def published_port_services(self, image: str) -> tuple[str, ...]:
+        """Inspect a fused image's authored Compose without executing mission code.
+
+        ``get_archive`` only operates on containers, so create a stopped throwaway container,
+        read the one bounded file, and remove it in all cases. Cache by immutable image id: stable
+        local tags are overwritten when missions update, while ids identify the exact filesystem
+        that was inspected.
+        """
+        import docker.errors
+
+        try:
+            image_obj = self._client.images.get(image)
+        except docker.errors.ImageNotFound as exc:
+            from xorcise.core.contracts.errors import ImageNotInstalledError
+
+            raise ImageNotInstalledError(f"image {image!r} is not in the local store") from exc
+        image_id = str(image_obj.id)
+        cached = self._published_ports_by_image_id.get(image_id)
+        if cached is not None:
+            return cached
+
+        container = self._client.containers.create(
+            image_id,
+            entrypoint=["/bin/true"],
+            platform=self._platform or None,
+        )
+        try:
+            stream, stat = container.get_archive(_MISSION_COMPOSE_PATH)
+            size = int(stat.get("size") or 0)
+            if size > _MAX_COMPOSE_BYTES:
+                raise RuntimeError(
+                    f"mission docker-compose.yml is too large ({size} bytes; "
+                    f"maximum {_MAX_COMPOSE_BYTES})"
+                )
+            archive = b"".join(stream)
+            with tarfile.open(fileobj=io.BytesIO(archive), mode="r:*") as tar:
+                member = next(
+                    (
+                        item
+                        for item in tar.getmembers()
+                        if item.isfile() and PurePosixPath(item.name).name == "docker-compose.yml"
+                    ),
+                    None,
+                )
+                if member is None or member.size > _MAX_COMPOSE_BYTES:
+                    raise RuntimeError("mission docker-compose.yml could not be read safely")
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    raise RuntimeError("mission docker-compose.yml could not be read")
+                content = extracted.read(_MAX_COMPOSE_BYTES + 1)
+                if len(content) > _MAX_COMPOSE_BYTES:
+                    raise RuntimeError("mission docker-compose.yml exceeds the size limit")
+            services = _published_port_services(content)
+        except Exception as exc:
+            if isinstance(exc, RuntimeError):
+                raise
+            raise RuntimeError(
+                f"could not inspect {_MISSION_COMPOSE_PATH} in mission image {image!r}"
+            ) from exc
+        finally:
+            with contextlib.suppress(Exception):
+                container.remove(force=True)
+
+        self._published_ports_by_image_id[image_id] = services
+        return services
 
     def run(self, spec: ContainerSpec) -> ContainerHandle:
         # The fused image is local-only (no registry). containers.run auto-PULLS a missing image,

--- a/src/xorcise/core/runner/netoverride.py
+++ b/src/xorcise/core/runner/netoverride.py
@@ -11,11 +11,32 @@ import ipaddress
 import math
 from collections.abc import Mapping, Sequence
 
+import yaml
+
 from xorcise.core.runner.docker import MANAGED_LABEL, RUN_ID_LABEL
 
 # The Tailscale router runs as its own inner container from the official image; the builder
 # bakes this into the fused image's images.tar so no run-time pull is needed at deploy.
 ROUTER_IMAGE = "tailscale/tailscale:stable"
+
+
+class _ResetList(list[object]):
+    """A Compose ``!reset []`` value used to clear an authored sequence."""
+
+
+class _ComposeOverrideDumper(yaml.SafeDumper):
+    pass
+
+
+_ComposeOverrideDumper.add_representer(
+    _ResetList,
+    lambda dumper, value: dumper.represent_sequence("!reset", value),
+)
+
+
+def dump_net_override(override: Mapping[str, object]) -> str:
+    """Serialize a network override while preserving Compose-specific reset tags."""
+    return yaml.dump(override, Dumper=_ComposeOverrideDumper, sort_keys=False)
 
 
 def carve_entry_subnets(run_cidr: str, entry_networks: Sequence[str]) -> dict[str, str]:
@@ -69,6 +90,7 @@ def build_net_override(
     extra_hosts: Sequence[str] = (),
     ca_cert_path: str = "",
     static_ips: Mapping[str, Mapping[str, int]] | None = None,
+    reset_ports_for: Sequence[str] = (),
 ) -> dict[str, object]:
     """Compose override pinning each entry network's subnet + a Tailscale router service.
 
@@ -135,6 +157,11 @@ def build_net_override(
     # carved subnet so docker stops handing out sequential IPs. A service on an un-carved network
     # is skipped. Compose merges these networks blocks with the base mission compose.
     services: dict[str, object] = {"xorcise-router": router}
+    # Mission services are reached at their container IP + container port over the tailnet.
+    # A host publish is both unnecessary and, in macOS host-daemon mode, a collision with the
+    # operator's machine. Compose appends ports across files unless the later value uses !reset.
+    for service in reset_ports_for:
+        services[str(service)] = {"ports": _ResetList()}
     for service, by_net in (static_ips or {}).items():
         for net, octet in by_net.items():
             cidr = entry_subnets.get(net)

--- a/src/xorcise/core/runner/service.py
+++ b/src/xorcise/core/runner/service.py
@@ -14,8 +14,6 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
-import yaml
-
 from xorcise.core.contracts.control import (
     CollectTargetsResult,
     DeployRequest,
@@ -28,7 +26,7 @@ from xorcise.core.contracts.control import (
 )
 from xorcise.core.contracts.errors import NotFoundError
 from xorcise.core.runner.docker import ContainerHandle, ContainerSpec, DockerDriver
-from xorcise.core.runner.netoverride import build_net_override
+from xorcise.core.runner.netoverride import build_net_override, dump_net_override
 
 # Where the entrypoint writes the delivered Headscale CA (in the OUTER fused container); the
 # net-override bind-mounts this into the router. Kept in sync with the entrypoint.
@@ -65,11 +63,16 @@ class RunnerControlService:
                 f"deploy({request.run_id}): empty tailnet auth key — the router key was not "
                 "minted; refusing to deploy a router that cannot join the tailnet"
             )
+        reset_ports_for = self.driver.published_port_services(request.mission.image)
         handle = self.driver.run(
             ContainerSpec(
                 image=request.mission.image,
                 name=request.run_id,
-                env=self._deploy_env(request.run_id, request.network),
+                env=self._deploy_env(
+                    request.run_id,
+                    request.network,
+                    reset_ports_for=reset_ports_for,
+                ),
             )
         )
         endpoints = RunnerEndpoints(
@@ -84,7 +87,13 @@ class RunnerControlService:
         self._torn_down.discard(request.run_id)
         return endpoints
 
-    def _deploy_env(self, run_id: RunId, network: NetworkSpec) -> tuple[tuple[str, str], ...]:
+    def _deploy_env(
+        self,
+        run_id: RunId,
+        network: NetworkSpec,
+        *,
+        reset_ports_for: Sequence[str] = (),
+    ) -> tuple[tuple[str, str], ...]:
         """The env the fused entrypoint needs: the per-run net-override (the mission nets +
         the Tailscale router as an inner container) plus the secrets compose interpolates into
         it. The override is base64'd so multi-line YAML rides a single env var cleanly; the
@@ -108,8 +117,9 @@ class RunnerControlService:
             extra_hosts=network.extra_hosts,
             ca_cert_path=ca_path,
             static_ips=network.static_ips,
+            reset_ports_for=reset_ports_for,
         )
-        override_b64 = base64.b64encode(yaml.safe_dump(override).encode()).decode()
+        override_b64 = base64.b64encode(dump_net_override(override).encode()).decode()
         env = [
             ("XORCISE_PROJECT", run_id),
             ("XORCISE_LOGIN_SERVER", network.login_server or self.login_server),

--- a/tests/adapters/test_docker_driver_compose_inspection.py
+++ b/tests/adapters/test_docker_driver_compose_inspection.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import io
+import tarfile
+from typing import Any
+
+import pytest
+
+from xorcise.core.runner.docker.driver import DockerSdkDriver
+
+pytestmark = pytest.mark.adapters
+
+
+def _archive(content: bytes) -> bytes:
+    out = io.BytesIO()
+    with tarfile.open(fileobj=out, mode="w") as tar:
+        member = tarfile.TarInfo("docker-compose.yml")
+        member.size = len(content)
+        tar.addfile(member, io.BytesIO(content))
+    return out.getvalue()
+
+
+class _Image:
+    id = "sha256:mission-image"
+
+
+class _Images:
+    def get(self, image: str) -> _Image:
+        assert image == "registry.example/mission:1"
+        return _Image()
+
+
+class _InspectionContainer:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.removed = False
+
+    def get_archive(self, path: str):
+        assert path == "/mission/docker-compose.yml"
+        return iter([_archive(self.content)]), {"size": len(self.content)}
+
+    def remove(self, *, force: bool) -> None:
+        assert force
+        self.removed = True
+
+
+class _Containers:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.created: list[tuple[str, dict[str, Any]]] = []
+        self.last: _InspectionContainer | None = None
+
+    def create(self, image: str, **kwargs: Any) -> _InspectionContainer:
+        self.created.append((image, kwargs))
+        self.last = _InspectionContainer(self.content)
+        return self.last
+
+
+class _Client:
+    def __init__(self, content: bytes) -> None:
+        self.images = _Images()
+        self.containers = _Containers(content)
+
+
+def test_inspects_stopped_image_cleans_up_and_caches_by_image_id() -> None:
+    client = _Client(b"services:\n  web:\n    ports: ['5000:5000']\n  db:\n    expose: [5432]\n")
+    driver = DockerSdkDriver(client=client)
+
+    assert driver.published_port_services("registry.example/mission:1") == ("web",)
+    assert driver.published_port_services("registry.example/mission:1") == ("web",)
+
+    assert client.containers.created == [
+        (
+            "sha256:mission-image",
+            {"entrypoint": ["/bin/true"], "platform": "linux/amd64"},
+        )
+    ]
+    assert client.containers.last is not None and client.containers.last.removed
+
+
+def test_invalid_compose_fails_closed_and_still_removes_container() -> None:
+    client = _Client(b"not-services: true\n")
+
+    with pytest.raises(RuntimeError, match="services mapping"):
+        DockerSdkDriver(client=client).published_port_services("registry.example/mission:1")
+
+    assert client.containers.last is not None and client.containers.last.removed

--- a/tests/unit/test_mission_compose_ports.py
+++ b/tests/unit/test_mission_compose_ports.py
@@ -1,0 +1,24 @@
+import pytest
+
+from xorcise.core.runner.docker.driver import _published_port_services
+
+
+def test_finds_short_and_long_syntax_host_publications() -> None:
+    compose = """
+services:
+  web:
+    ports: ["5000:5000"]
+  harness:
+    ports:
+      - target: 5000
+        published: "5055"
+  database:
+    expose: [5432]
+"""
+
+    assert _published_port_services(compose) == ("web", "harness")
+
+
+def test_rejects_compose_without_a_services_mapping() -> None:
+    with pytest.raises(RuntimeError, match="services mapping"):
+        _published_port_services("name: not-a-mission-stack\n")

--- a/tests/unit/test_runner_netoverride.py
+++ b/tests/unit/test_runner_netoverride.py
@@ -1,6 +1,7 @@
 from xorcise.core.runner.netoverride import (
     build_net_override,
     carve_entry_subnets,
+    dump_net_override,
     target_ips_for,
 )
 
@@ -27,6 +28,21 @@ def test_build_override_pins_subnets_and_adds_router():
     assert isinstance(networks, dict) and isinstance(services, dict)
     assert networks["dmz"]["ipam"]["config"][0]["subnet"] == "10.200.1.0/25"
     assert "xorcise-router" in services
+
+
+def test_build_override_resets_authored_ports_without_losing_static_ip():
+    override = build_net_override(
+        "run-1",
+        {"default": "10.200.1.0/24"},
+        static_ips={"web": {"default": 10}},
+        reset_ports_for=("web", "eval-harness"),
+    )
+    rendered = dump_net_override(override)
+
+    assert rendered.count("ports: !reset []") == 2
+    services = override["services"]
+    assert isinstance(services, dict)
+    assert services["web"]["networks"]["default"]["ipv4_address"] == "10.200.1.10"
 
 
 def test_router_is_official_tailscale_image_in_kernel_mode():

--- a/tests/unit/test_runner_service_stub.py
+++ b/tests/unit/test_runner_service_stub.py
@@ -81,6 +81,18 @@ def test_deploy_delivers_net_override_and_authkey_env():
     assert "tskey-abc" not in base64.b64decode(env["XORCISE_NET_OVERRIDE_B64"]).decode()
 
 
+def test_deploy_resets_every_host_publish_reported_by_the_image():
+    driver = StubDockerDriver()
+    image = "xorcise/mission-c:0"
+    driver.port_services[image] = ("web", "kusto")
+
+    RunnerControlService(driver).deploy(_req())
+
+    rendered = base64.b64decode(dict(driver.specs[0].env)["XORCISE_NET_OVERRIDE_B64"]).decode()
+    assert "web:\n    ports: !reset []" in rendered
+    assert "kusto:\n    ports: !reset []" in rendered
+
+
 def test_deploy_delivers_ca_and_extra_hosts_when_airgapped():
     driver = StubDockerDriver()
     svc = RunnerControlService(driver, login_server="https://headscale.local:8443")


### PR DESCRIPTION
## What changed

Before each mission deployment, the runner inspects the already-pulled fused image without starting mission code and identifies every Compose service declaring `ports:`. It adds `ports: !reset []` for those services to the existing per-run network override, alongside the carved subnet, router, and static-IP configuration.

The inspection is bounded, fail-closed, cleaned up in all cases, and cached by immutable image ID. Because existing remote images already consume `/mission/net-override.yml`, no mission or base-image rebuild is required.

## Why

Mission services are reached over their carved tailnet subnet at the service container IP and container port. Host publications are unnecessary and can collide with unrelated listeners on the operator host, notably macOS AirPlay on port 5000.

Closes #34

## Testing

```text
uv run pytest tests/unit -q
1949 passed

uv run pytest tests/adapters -q
128 passed

uv run ruff check .
All checks passed!

uv run ruff format --check .
499 files already formatted

uv run mypy
Success: no issues found in 475 source files

uv run lint-imports
Contracts: 4 kept, 0 broken
```

Remote-image validation:

- Pulled the existing remote `breachpoint` image through the patched checkout.
- Deployment-time inspection detected authored publications on `kusto` and `web`.
- Merged the generated override using the image embedded Compose v2.33.0; the effective service model contained no published ports.
- Held host port 5000 open and started a service with an authored `5000:80` publication using the dynamically generated override; it started successfully and Docker reported `published_ports={}`.

**Test lanes affected:**

- [x] `unit` — no Docker, fast
- [x] `adapters` — port/adapter contracts
- [x] `topology` — manifest / compose / import / extras parity
- [x] `integration` — needs Docker or a live server process
- [ ] `e2e` — full `xorcise up` + scripted agent
- [ ] `frontend` — Next.js typecheck / vitest

This runner/networking change should receive the `full-ci` label before merge.

## User-facing impact

- [x] Backwards-compatible correction: mission-authored host publications are suppressed while container and tailnet ports remain unchanged

Existing installed remote missions receive the fix on their next deployment after upgrading XORCISE. They do not need to be pulled or rebuilt again.

## Documentation

- [x] No documentation change needed

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] No secrets, credentials, tokens, keys, internal hostnames or customer data appear in the diff
- [x] No references to internal-only systems appear in code or documentation

## Release notes

Suggested label: `bug`

---

- [x] I have signed the Contributor License Agreement, or will when the CLA assistant comments below.