### PR TITLE
feat(mission-base): publish to GHCR as a versioned multi-arch release

### DIFF
--- a/.github/workflows/mission-base-release.yml
+++ b/.github/workflows/mission-base-release.yml
@@ -1,0 +1,299 @@
+# mission-base release pipeline. Merging publishes nothing; pushing a `mission-base-v*` tag does.
+#
+# This is the artifact side of the compatibility contract the runtime already enforces. The
+# client refuses a mission fused on a base generation it cannot run — but a gate is only as good
+# as the artifact it points at, and until now there was no published mission-base at all
+# ("local build only", per the old Dockerfile header). Anyone needing one built their own and
+# versioned it themselves, which is two sources of truth for one image with nothing to detect
+# them disagreeing.
+#
+# ghcr.io/xorcise-ai/mission-base is now that single source of truth. This repository owns the
+# source, the SemVer, the multi-arch build, the index, the labels and the signature; nothing
+# downstream re-derives a version of its own.
+#
+# Trust boundary, mirroring .github/workflows/release.yml:
+#   * triggers ONLY on a pushed `mission-base-v*` tag;
+#   * no `workflow_dispatch` — that would let anyone with write access publish from any ref;
+#   * NO CACHING — a cache is writable from other branches, and a poisoned layer must never
+#     reach a signed release. A base image build is minutes; correctness is worth those minutes.
+#   * the tag is the only version input, so there is no second place to forget to bump.
+#
+# Separate from release.yml on purpose. That workflow ships the Python distribution on `v*`;
+# these are different artifacts on different cadences, and coupling them would mean every
+# library release rebuilt and republished a base image that had not changed.
+name: mission-base release
+
+on:
+  push:
+    tags:
+      - "mission-base-v*"
+
+permissions: {}
+
+concurrency:
+  # Keyed to the tag. Never cancel — a half-pushed multi-arch index is the worst state to be in:
+  # the tag exists but resolves to an index missing a platform.
+  group: mission-base-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: xorcise-ai/mission-base
+  # Architecture is NOT encoded in the release tag — one tag resolves to an index spanning both.
+  # arm64 is not optional: Apple Silicon is where the nesting failure this base fixes actually
+  # bites, so an amd64-only "release" would miss the platform that most needs it.
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  # 1. GATE — cheap checks that must pass before anything is built or pushed.
+  #
+  # Runs first and alone, because every failure it catches is one that would otherwise be
+  # discovered AFTER an immutable tag exists in a public registry. GHCR tags can be deleted, but
+  # anything that already pulled the bad digest has it forever.
+  verify:
+    name: verify the tag against the Dockerfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      release: ${{ steps.tag.outputs.release }}
+      major: ${{ steps.tag.outputs.major }}
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Parse the release version out of the tag
+        id: tag
+        run: |
+          set -euo pipefail
+          release="${GITHUB_REF_NAME#mission-base-v}"
+          # Strict SemVer. A tag like `mission-base-v2.4` would otherwise publish an image
+          # labelled "2.4", which is a floating alias masquerading as an immutable release.
+          if ! printf '%s' "$release" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::tag '${GITHUB_REF_NAME}' does not carry a MAJOR.MINOR.PATCH version" >&2
+            exit 1
+          fi
+          echo "release=$release"            >> "$GITHUB_OUTPUT"
+          echo "major=${release%%.*}"        >> "$GITHUB_OUTPUT"
+
+      - name: The tag's MAJOR must equal the compatibility label
+        env:
+          MAJOR: ${{ steps.tag.outputs.major }}
+          RELEASE: ${{ steps.tag.outputs.release }}
+        run: |
+          set -euo pipefail
+          # ai.xorcise.base.version is the number the runtime gate compares. If the tag says 3.x
+          # while the Dockerfile still declares generation 2, the published image asserts a
+          # compatibility it was not built for — and every client trusts the label, not the tag.
+          # This is the one mismatch that silently produces a WRONG artifact rather than a failed
+          # build, so it is checked before any layer is built.
+          label="$(grep -oP '^LABEL\s+ai\.xorcise\.base\.version="\K[^"]+' \
+                   containers/mission-base/Dockerfile || true)"
+          if [ -z "$label" ]; then
+            echo "::error::no ai.xorcise.base.version label in containers/mission-base/Dockerfile" >&2
+            exit 1
+          fi
+          if [ "$label" != "$MAJOR" ]; then
+            echo "::error::tag ${RELEASE} has MAJOR ${MAJOR} but the Dockerfile declares generation ${label}." >&2
+            echo "::error::A MAJOR bump is a compatibility break: update the label AND build.BASE_VERSION together." >&2
+            exit 1
+          fi
+          echo "generation ${label} == tag MAJOR ${MAJOR}"
+
+  # 2. PUBLISH — build both architectures and push ONE index.
+  #
+  # `docker/build-push-action` with a multi-platform `platforms:` produces a single OCI image
+  # index and pushes it under one tag. Deliberately not two per-arch builds joined afterwards
+  # with `manifest create`: that path can push arch-suffixed tags as a side effect, and those
+  # tags then become an unofficial contract people pin to.
+  publish:
+    name: build + push the multi-arch index
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write # push to GHCR under this repository's owner
+      id-token: write # mint the OIDC identity that signs the provenance attestation
+      attestations: write # record the attestation against this repository
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # arm64 is emulated here. Slower than a native runner, but this image is a handful of apk
+      # packages over an upstream base — correctness of the index matters far more than build time.
+      - name: Set up QEMU for the non-native architecture
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: containers/mission-base
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          provenance: true
+          sbom: false
+          # The ONLY tag pushed is the immutable SemVer. No `latest`, no `2`, no `2.4`:
+          # a floating alias on the canonical artifact invites a downstream pipeline to pin to
+          # it, and a reproducible mission build must consume version + digest. Aliases can be
+          # added later as a deliberate, separate decision — they cannot be un-published once
+          # something depends on them.
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.verify.outputs.release }}
+          build-args: |
+            BASE_RELEASE=${{ needs.verify.outputs.release }}
+          # Annotations go on the INDEX as well as the manifests; a registry UI reads the index.
+          annotations: |
+            index:org.opencontainers.image.title=XORCISE mission-base
+            index:org.opencontainers.image.version=${{ needs.verify.outputs.release }}
+            index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            index:org.opencontainers.image.revision=${{ github.sha }}
+            index:org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+  # 3. INSPECT — prove the published artifact is what the contract promises.
+  #
+  # Pulls the tag back from GHCR as a client would. The build succeeding says the workflow ran;
+  # only reading the registry says the right thing landed. Every assertion here corresponds to a
+  # way a "successful" publish can still be wrong.
+  inspect:
+    name: verify the published index
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read # pull the just-published index back out of GHCR to inspect it
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: The tag must resolve to a multi-platform index carrying the right labels
+        env:
+          REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.verify.outputs.release }}
+          RELEASE: ${{ needs.verify.outputs.release }}
+          MAJOR: ${{ needs.verify.outputs.major }}
+          WANT_PLATFORMS: ${{ env.PLATFORMS }}
+        run: |
+          set -euo pipefail
+          echo "inspecting $REF"
+          docker buildx imagetools inspect "$REF" --raw > index.json
+
+          # (a) It must be an INDEX, not a single-arch manifest. A single-arch push still
+          #     "succeeds" and still resolves for the pusher's own architecture — the failure
+          #     only appears for a user on the other platform, which is precisely the audience
+          #     multi-arch exists for.
+          mt="$(jq -r '.mediaType' index.json)"
+          case "$mt" in
+            application/vnd.oci.image.index.v1+json|application/vnd.docker.distribution.manifest.list.v2+json) ;;
+            *) echo "::error::$REF is $mt, not a multi-platform index" >&2; exit 1 ;;
+          esac
+
+          # (b) Every promised platform must actually be present. An index with one child is
+          #     still an index.
+          got="$(jq -r '[.manifests[]
+                         | select(.platform.os != "unknown")
+                         | "\(.platform.os)/\(.platform.architecture)"] | sort | join(",")' index.json)"
+          for want in ${WANT_PLATFORMS//,/ }; do
+            printf '%s' "$got" | grep -q "$want" \
+              || { echo "::error::$REF is missing $want (has: $got)" >&2; exit 1; }
+          done
+          echo "platforms: $got"
+
+          # (c) The labels the client gates on must be present and correct ON EACH platform.
+          #     Checking only one would miss a build-arg that failed to reach the emulated leg.
+          for plat in ${WANT_PLATFORMS//,/ }; do
+            cfg="$(docker buildx imagetools inspect "$REF" --format \
+                   '{{ json (index .Image "'"$plat"'") }}')"
+            gen="$(printf '%s' "$cfg" | jq -r '.config.Labels["ai.xorcise.base.version"] // ""')"
+            rel="$(printf '%s' "$cfg" | jq -r '.config.Labels["ai.xorcise.base.release"] // ""')"
+            [ "$gen" = "$MAJOR" ]   || { echo "::error::$plat: base.version=$gen, want $MAJOR" >&2; exit 1; }
+            [ "$rel" = "$RELEASE" ] || { echo "::error::$plat: base.release=$rel, want $RELEASE" >&2; exit 1; }
+            echo "$plat: generation $gen, release $rel"
+          done
+
+      # Every `${{ }}` stays in `env:` and the script reads shell variables. Interpolating
+      # directly into a `run:` body splices the value into the script before bash sees it, so a
+      # crafted value would execute — zizmor's template-injection audit fails the build on it.
+      - name: Report the canonical identity
+        env:
+          REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.verify.outputs.release }}
+          RELEASE: ${{ needs.verify.outputs.release }}
+          DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          {
+            echo "### mission-base ${RELEASE} published"
+            echo
+            echo '```'
+            echo "ref    ${REF}"
+            echo "digest ${DIGEST}"
+            echo '```'
+            echo
+            echo "Consume **version + digest**, never a floating alias."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # 4. PROMOTE — deliberately a stub.
+  #
+  # The contract's end state is release-driven promotion: after a verified publish, this
+  # workflow calls the XORCISE control plane with {mission_base_version, ghcr_ref, index_digest}
+  # over short-lived GitHub OIDC, and the cloud marks the release active. That endpoint does not
+  # exist yet.
+  #
+  # This job exists as an explicit, failing-loudly-absent seam rather than a half-wired HTTP call
+  # to a URL that 404s, because a promotion step that "succeeds" against nothing is worse than
+  # one that is visibly not implemented. It prints what it WOULD send, so the payload shape is
+  # reviewable now and the cloud side has something concrete to build against.
+  promote:
+    name: promote to the control plane (not yet implemented)
+    needs: [verify, publish, inspect]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Show the promotion payload this release would send
+        env:
+          RELEASE: ${{ needs.verify.outputs.release }}
+          DIGEST: ${{ needs.publish.outputs.digest }}
+          REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.verify.outputs.release }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -nc \
+            --arg v "$RELEASE" \
+            --arg r "$REF" \
+            --arg d "$DIGEST" \
+            '{mission_base_version:$v, ghcr_ref:$r, index_digest:$d}')"
+          echo "$payload"
+          {
+            echo "### Promotion payload (not sent — endpoint not built)"
+            echo
+            echo '```json'
+            echo "$payload" | jq .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/containers/mission-base/Dockerfile
+++ b/containers/mission-base/Dockerfile
@@ -2,8 +2,12 @@
 #
 # Each per-mission fused image (built locally by xorcise.core.runner.docker.build) is
 # `FROM xorcise/mission-base`, with the mission's inner stack baked in as
-# /mission/images.tar (loaded on boot — no inner pull at deploy). Local build only; the
-# registry publish/sign cycle is not yet built.
+# /mission/images.tar (loaded on boot — no inner pull at deploy).
+#
+# Published by .github/workflows/mission-base-release.yml to
+# ghcr.io/xorcise-ai/mission-base on a `mission-base-v*` tag, as ONE multi-platform OCI
+# index (linux/amd64 + linux/arm64). That index is the canonical artifact; a local
+# `docker build` of this file is a development convenience, not a release.
 #
 # Tailscale is deliberately NOT installed here. The per-run network router runs as a SEPARATE
 # inner container (the official tailscale/tailscale image, baked into images.tar) in its own
@@ -24,6 +28,25 @@ FROM docker:29.7.1-dind
 # build.BASE_VERSION (asserted by tests/topology/test_dind_base_parity.py); bump BOTH together on
 # a breaking base change so an artifact fused on an incompatible base is refused, not deployed.
 LABEL ai.xorcise.base.version="2"
+
+# The full release SemVer, e.g. 2.4.1. The MAJOR above is what the client gates on; this is
+# what a human reads in an error, a support thread or `docker inspect`, and it is the only way
+# to tell two builds of generation 2 apart without comparing digests.
+#
+# Supplied by the release workflow from the git tag, NOT hand-edited here: a version literal in
+# a Dockerfile is a second place to forget. It defaults to 0.0.0-dev so a local build is
+# self-evidently not a release — an unset ARG would silently label a dev image as one.
+# The release workflow refuses to publish if the tag's MAJOR disagrees with the label above.
+ARG BASE_RELEASE=0.0.0-dev
+LABEL ai.xorcise.base.release="${BASE_RELEASE}"
+
+# Standard OCI metadata, so `docker inspect` and registry UIs describe this image without
+# needing to know XORCISE's own label namespace.
+LABEL org.opencontainers.image.title="XORCISE mission-base" \
+      org.opencontainers.image.description="Base layer for fused XORCISE mission images: docker-in-docker, compose, runner control." \
+      org.opencontainers.image.source="https://github.com/xorcise-ai/xorcise" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${BASE_RELEASE}"
 
 RUN apk add --no-cache iptables ca-certificates docker-cli-compose
 

--- a/tests/topology/test_mission_base_release_contract.py
+++ b/tests/topology/test_mission_base_release_contract.py
@@ -1,0 +1,172 @@
+"""The mission-base release workflow must publish what the compatibility contract promises.
+
+The runtime already refuses a mission fused on a base generation it cannot run. That gate reads
+`ai.xorcise.base.version` off the image, so the gate is only as trustworthy as the artifact —
+and the ways a release can be wrong are all ways that still produce a green workflow:
+
+* a single-arch push still succeeds, and still resolves for whoever pushed it. The failure only
+  appears for a user on the other platform, which is exactly the audience multi-arch is for.
+* an arch-suffixed tag (`2.4.1-amd64`) becomes an unofficial contract the moment anything pins
+  to it, and it cannot be un-published afterwards.
+* a floating alias on the canonical artifact invites a downstream pipeline to pin to it, which
+  breaks reproducibility silently rather than loudly.
+* a tag whose MAJOR disagrees with the Dockerfile's generation publishes an image that ASSERTS a
+  compatibility it was not built for. Clients trust the label, not the tag.
+
+The workflow guards all of these at run time. This guards the guards: nothing else fails if a
+future edit quietly drops one, because the workflow only executes on a release tag — by which
+point the mistake is already public and immutable.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xorcise.core.runner.docker.build import BASE_VERSION
+
+pytestmark = pytest.mark.topology
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "mission-base-release.yml"
+DOCKERFILE = ROOT / "containers" / "mission-base" / "Dockerfile"
+
+WORKFLOW_TEXT = WORKFLOW_PATH.read_text()
+WORKFLOW = yaml.safe_load(WORKFLOW_TEXT)
+DOCKERFILE_TEXT = DOCKERFILE.read_text()
+
+# `on:` parses as the boolean True in YAML 1.1 unless quoted — read it either way.
+TRIGGERS = WORKFLOW.get("on", WORKFLOW.get(True, {}))
+JOBS = WORKFLOW["jobs"]
+TAG_PREFIX = "mission-base-v"
+
+
+def test_only_a_release_tag_can_publish() -> None:
+    """Same trust boundary as release.yml: no workflow_dispatch, no branch push."""
+    assert set(TRIGGERS) == {"push"}, f"unexpected triggers: {sorted(TRIGGERS)}"
+    assert TRIGGERS["push"] == {"tags": [f"{TAG_PREFIX}*"]}, (
+        "publishing must be reachable ONLY by pushing a release tag — a branch trigger or "
+        "workflow_dispatch would let anyone with write access publish from any ref"
+    )
+
+
+def test_both_architectures_are_published() -> None:
+    platforms = WORKFLOW["env"]["PLATFORMS"]
+    assert "linux/amd64" in platforms
+    assert "linux/arm64" in platforms, (
+        "arm64 is not optional — Apple Silicon is where the nesting failure this base fixes "
+        "actually bites, so an amd64-only release misses the platform that most needs it"
+    )
+
+
+def test_architecture_is_never_encoded_in_a_tag() -> None:
+    """One tag must resolve to the index. `2.4.1-amd64` is not a permitted contract."""
+    offenders = re.findall(r"tags:.*?-(?:amd64|arm64)", WORKFLOW_TEXT)
+    assert not offenders, f"arch-suffixed tags in the workflow: {offenders}"
+
+
+def test_the_only_pushed_tag_is_the_immutable_version() -> None:
+    """No `latest`, no `2`, no `2.4` on the canonical artifact.
+
+    An alias can be added later as a deliberate decision; it cannot be withdrawn once a
+    downstream pipeline pins to it. A reproducible mission build must consume version + digest.
+    """
+    build = next(
+        s for s in JOBS["publish"]["steps"] if "build-push-action" in str(s.get("uses", ""))
+    )
+    tags = [t.strip() for t in str(build["with"]["tags"]).splitlines() if t.strip()]
+    assert len(tags) == 1, f"exactly one tag may be pushed, got {tags}"
+    assert tags[0].endswith("${{ needs.verify.outputs.release }}"), (
+        f"the single pushed tag must be the release SemVer, got {tags[0]!r}"
+    )
+
+
+def test_the_release_version_is_not_hand_written_in_the_dockerfile() -> None:
+    """The tag is the only version input.
+
+    A literal here is a second place to forget, and the two disagreeing is undetectable from
+    inside the image. The default must also be obviously-not-a-release: an unset ARG would
+    label a local dev build as though it were published.
+    """
+    m = re.search(r"^ARG\s+BASE_RELEASE=(\S+)", DOCKERFILE_TEXT, re.MULTILINE)
+    assert m, "containers/mission-base/Dockerfile declares no BASE_RELEASE build arg"
+    assert "dev" in m.group(1), (
+        f"BASE_RELEASE defaults to {m.group(1)!r}; a local build must not be labelled as a "
+        "release — use something self-evidently unpublished like 0.0.0-dev"
+    )
+    assert 'LABEL ai.xorcise.base.release="${BASE_RELEASE}"' in DOCKERFILE_TEXT
+
+    build = next(
+        s for s in JOBS["publish"]["steps"] if "build-push-action" in str(s.get("uses", ""))
+    )
+    assert "BASE_RELEASE=${{ needs.verify.outputs.release }}" in str(build["with"]["build-args"])
+
+
+def test_a_mismatched_major_is_rejected_before_anything_is_pushed() -> None:
+    """The one mismatch that yields a WRONG artifact rather than a failed build.
+
+    It must be caught in a job that `publish` depends on — checking it afterwards would mean
+    discovering it once an immutable tag already exists in a public registry.
+    """
+    assert "verify" in JOBS["publish"]["needs"]
+    gate = "\n".join(s.get("run", "") for s in JOBS["verify"]["steps"])
+    assert "ai.xorcise.base.version" in gate, (
+        "the verify job must compare the tag's MAJOR against the Dockerfile's generation label"
+    )
+    assert "containers/mission-base/Dockerfile" in gate
+
+
+def test_the_dockerfile_generation_still_matches_the_code() -> None:
+    """Belt and braces with test_dind_base_parity: the workflow trusts this label, so a drift
+    here would publish a correctly-tagged image asserting the wrong compatibility."""
+    labels = re.findall(
+        r'^LABEL\s+ai\.xorcise\.base\.version="([^"]+)"', DOCKERFILE_TEXT, re.MULTILINE
+    )
+    assert labels == [BASE_VERSION], (
+        f"Dockerfile declares {labels} but build.BASE_VERSION is {BASE_VERSION!r}"
+    )
+
+
+def test_the_published_index_is_read_back_from_the_registry() -> None:
+    """A build succeeding says the workflow ran; only reading the registry says the right thing
+    landed. The inspect job must run after publish and check the shape, not just the exit code."""
+    assert "publish" in JOBS["inspect"]["needs"]
+    inspect = "\n".join(s.get("run", "") for s in JOBS["inspect"]["steps"])
+    assert "imagetools inspect" in inspect
+    assert "image.index" in inspect, "must assert the tag resolves to an INDEX, not one manifest"
+    assert "ai.xorcise.base.release" in inspect, "must assert the labels reached the image"
+
+
+def test_nothing_is_cached_on_the_publish_path() -> None:
+    """Caches are writable from other branches; a poisoned layer must never reach a signed
+    release. Same rule release.yml states for the wheel."""
+    assert "cache-from" not in WORKFLOW_TEXT
+    assert "cache-to" not in WORKFLOW_TEXT
+    assert "actions/cache" not in WORKFLOW_TEXT
+
+
+def test_promotion_is_an_explicit_stub_not_a_silent_no_op() -> None:
+    """The control-plane endpoint does not exist yet. A promotion step that 'succeeds' against
+    nothing is worse than one that is visibly unimplemented, so the job must say so and must not
+    pretend to send anything."""
+    promote = JOBS["promote"]
+    assert "not yet implemented" in promote["name"].lower()
+    body = "\n".join(s.get("run", "") for s in promote["steps"])
+    assert "mission_base_version" in body and "index_digest" in body, (
+        "the stub must still print the payload shape, so the cloud side has a concrete contract"
+    )
+    assert "curl" not in body, "the stub must not attempt a real call to an endpoint that 404s"
+
+
+def test_every_action_is_pinned_to_a_sha() -> None:
+    """Repo convention, and the reason it exists: a mutable tag on a third-party action is
+    arbitrary code execution inside the job that holds `packages: write`."""
+    unpinned = [
+        u
+        for u in re.findall(r"uses:\s*(\S+)", WORKFLOW_TEXT)
+        if not re.search(r"@[0-9a-f]{40}$", u)
+    ]
+    assert not unpinned, f"actions not pinned to a full commit SHA: {unpinned}"


### PR DESCRIPTION
Closes #45. Stacked on #41 — targets `feat-mission-base-dind-29`, because it builds directly on the `ai.xorcise.base.version` label that PR introduces.

## Summary

#41 turns the base image into a compatibility contract: a mission fused on a generation this XORCISE cannot run is refused up front. This is the artifact half of that contract.

There was no published mission-base at all. The Dockerfile said as much — *"local build only; the registry publish/sign cycle is not yet built"*. Anyone needing one built their own and versioned it themselves: two sources of truth for one image, with nothing able to detect them disagreeing. A gate is only as trustworthy as the artifact it points at.

`ghcr.io/xorcise-ai/mission-base` becomes that single source of truth. This repository owns the source, the SemVer, the multi-arch build, the index, the labels and the attestation; nothing downstream re-derives a version of its own.

Pushing `mission-base-v2.4.1` builds `linux/amd64` + `linux/arm64` and pushes **one OCI index**. arm64 is not optional — Apple Silicon is where the nesting failure #41 fixes actually bites, so an amd64-only release would miss the platform that most needs it.

## The four failures this is built around

Each one produces a **green workflow and a wrong artifact**, which is why each is guarded explicitly rather than left to review.

| | Failure | Guard |
|---|---|---|
| 1 | Tag MAJOR disagrees with `ai.xorcise.base.version` — the image *asserts* a compatibility it was not built for, and clients trust the label, not the tag | checked in `verify`, which `publish` depends on; after the push the bad digest is public and immutable |
| 2 | Single-arch push — succeeds, and resolves fine for whoever pushed it; only breaks for a user on the other platform | `inspect` asserts the tag resolves to an index **and** that every promised platform is present |
| 3 | Arch-suffixed tags — `2.4.1-amd64` becomes an unofficial contract the moment anything pins to it, and cannot be withdrawn | one multi-platform build, never a `manifest create` join; asserted in tests |
| 4 | A floating alias on the canonical artifact — invites a downstream pipeline to pin to it, breaking reproducibility silently | **no** alias is pushed: not `latest`, not `2`, not `2.4` |

On (4): aliases can be added later as a deliberate, separate decision. They cannot be un-published once something depends on them, so the default is none.

## Details worth flagging in review

**The version reaches the image from the tag, not a literal.** `ARG BASE_RELEASE`, supplied by the workflow. A version literal in a Dockerfile is a second place to forget, and the mismatch is invisible from inside the image. It defaults to `0.0.0-dev` so a local `docker build` is self-evidently not a release — an unset ARG would quietly label a dev image as one.

**The published index is read back from the registry.** A build succeeding says the workflow ran; only pulling the tag says the right thing landed. `inspect` verifies both labels **on each platform** — checking one would miss a build arg that failed to reach the emulated leg.

**Promotion is a deliberate stub.** The contract's end state is release-driven promotion (`{mission_base_version, ghcr_ref, index_digest}` over OIDC). That endpoint does not exist yet. A promotion step that "succeeds" against nothing is worse than one visibly unimplemented, so the job prints the payload and sends nothing — the shape is reviewable now, and the cloud side has something concrete to build against.

**Trust boundary mirrors `release.yml`:** tag-only trigger, no `workflow_dispatch`, and no caching anywhere on the publish path (a cache is writable from other branches; a poisoned layer must never reach a signed release).

## Verification

`tests/topology/test_mission_base_release_contract.py` guards the guards — the workflow only executes on a release tag, so a quietly-dropped check would first be noticed once the mistake is already public.

Every assertion was confirmed load-bearing by reintroducing the corresponding mistake and watching the right test fail:

| mutation | test that caught it |
|---|---|
| add a `:latest` alias | `test_the_only_pushed_tag_is_the_immutable_version` |
| drop `linux/arm64` | `test_both_architectures_are_published` |
| unpin an action to `@v3` | `test_every_action_is_pinned_to_a_sha` |
| make the stub actually `curl` an endpoint | `test_promotion_is_an_explicit_stub_not_a_silent_no_op` |

Gates: `zizmor --pedantic` clean (it caught two template-injection findings and an undocumented permission on the first pass — all fixed, values now go through `env:`), `ruff check` + `ruff format --check` clean, `mypy` clean, `lint-imports` 4/4, topology 31 passed, unit 1991 passed.

## Not in this PR

- **The promotion endpoint** and the cloud-side active-base record — separate work in `cloud-infrastructure/xorcise-ai`.
- **The first actual release.** Nothing publishes until someone pushes a `mission-base-v*` tag. Merging this changes nothing at runtime.
- **Convenience aliases** (`latest`, `2`, `2.4`) — deliberately deferred, see (4) above.
