### PR TITLE
feat(otel): export a run's raw OTLP stream as JSONL (REST + web UI + CLI)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5816,6 +5816,47 @@
         ]
       }
     },
+    "/api/runs/{run_id}/otlp.jsonl": {
+      "get": {
+        "description": "The run's RAW OTLP stream as a downloadable JSONL file (OTLP/JSON lines).\n\nOne line per export batch, verbatim as the agent streamed it: trace batches\n(`resourceSpans`) in seq order, then log batches (`resourceLogs`). Deliberately NO\nXORCISE framing \u2014 no header line, no envelope \u2014 every line is a plain OTLP/JSON\nobject, so the file is directly consumable by OTel tooling that reads the\nCollector's otlpjson file format (and through a Collector, any trace backend).\nWorks mid-run as a partial export of what's been ingested so far. Unknown run \u2192 404\n(the stores yield silently empty reads). Content-Disposition is `attachment`, so a\nbrowser downloads rather than renders it.",
+        "operationId": "run_otlp_jsonl_api_runs__run_id__otlp_jsonl_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Otlp Jsonl",
+        "tags": [
+          "runs"
+        ]
+      }
+    },
     "/api/runs/{run_id}/prompt": {
       "get": {
         "description": "The agent-facing mission prompt for a run. *launch_mode* rebases the run-control\nBase URL \u2014 and the container-only --add-host note \u2014 to where the agent actually runs: ``host``\n(the server's loopback bind, a terminal CLI) vs ``container`` (host.docker.internal, resolvable\nonly inside a container). Defaults to ``container`` so a non-GUI caller keeps the baked host;\nthe GUI passes the launch-mode toggle so the whole hand-off \u2014 not just the telemetry env \u2014\nfollows the operator's choice.",

--- a/frontend/src/features/results/download-traces.test.tsx
+++ b/frontend/src/features/results/download-traces.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { DownloadTraces } from "./download-traces";
+
+describe("DownloadTraces", () => {
+  it("links straight at the server's raw OTLP export endpoint", () => {
+    render(<DownloadTraces runId="run-1" />);
+    const link = screen.getByRole("link", { name: /OTLP Traces \(\.jsonl\)/ });
+    // Plain anchor — no blob plumbing; Content-Disposition drives the filename.
+    expect(link).toHaveAttribute(
+      "href",
+      `${window.location.origin}/api/runs/run-1/otlp.jsonl`,
+    );
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("encodes a run id that needs escaping", () => {
+    render(<DownloadTraces runId="run/1 2" />);
+    expect(
+      screen.getByRole("link", { name: /OTLP Traces \(\.jsonl\)/ }),
+    ).toHaveAttribute(
+      "href",
+      `${window.location.origin}/api/runs/run%2F1%202/otlp.jsonl`,
+    );
+  });
+});

--- a/frontend/src/features/results/download-traces.tsx
+++ b/frontend/src/features/results/download-traces.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { FileDown } from "lucide-react";
+import { cn } from "@/components/ui/cn";
+import { apiBaseUrl } from "@/lib/api/runtime-config";
+
+// Download the run's RAW OTLP stream as JSONL (GET /runs/{id}/otlp.jsonl) — one OTLP/JSON
+// envelope per line, verbatim as the agent streamed it, with no XORCISE framing. The file
+// feeds straight into OTel tooling that reads the Collector's otlpjson file format. Unlike
+// the report there is no grading gate: the evidence exists as soon as telemetry does.
+//
+// Same idiom as DownloadReport: a PLAIN <a download>, not a fetch → blob → object-URL dance —
+// the server sets `Content-Disposition: attachment` with a stable filename, so the browser
+// saves the file with zero JS and the link stays right-clickable from the static export at /ui.
+export function DownloadTraces({
+  runId,
+  className,
+}: {
+  runId: string;
+  className?: string;
+}) {
+  const href = `${apiBaseUrl()}/runs/${encodeURIComponent(runId)}/otlp.jsonl`;
+  return (
+    <a
+      href={href}
+      download
+      className={cn(
+        "inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-caption text-foreground transition-colors hover:border-[rgba(255,255,255,0.14)] hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      <FileDown aria-hidden className="size-3.5 shrink-0" />
+      OTLP Traces (.jsonl)
+    </a>
+  );
+}

--- a/frontend/src/features/results/results-view.tsx
+++ b/frontend/src/features/results/results-view.tsx
@@ -26,6 +26,7 @@ import { GradingDetail } from "./grading-detail";
 import { ArtifactsSection } from "./artifacts-section";
 import { ConditionsCard } from "./conditions-card";
 import { DownloadReport } from "./download-report";
+import { DownloadTraces } from "./download-traces";
 
 export function ResultsView({ runId }: { runId: string | null }) {
   const result = useRunResult(runId ?? "");
@@ -130,6 +131,9 @@ export function ResultsView({ runId }: { runId: string | null }) {
           </Button>
           {/* Shareable, offline copy of everything below (Content-Disposition drives the name). */}
           <DownloadReport runId={r.run_id} />
+          {/* The raw OTLP evidence behind the report, for external OTel tooling — always
+              available, even while grading. */}
+          <DownloadTraces runId={r.run_id} />
         </div>
       </PageHead>
 

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -856,6 +856,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/runs/{run_id}/otlp.jsonl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Run Otlp Jsonl
+         * @description The run's RAW OTLP stream as a downloadable JSONL file (OTLP/JSON lines).
+         *
+         *     One line per export batch, verbatim as the agent streamed it: trace batches
+         *     (`resourceSpans`) in seq order, then log batches (`resourceLogs`). Deliberately NO
+         *     XORCISE framing — no header line, no envelope — every line is a plain OTLP/JSON
+         *     object, so the file is directly consumable by OTel tooling that reads the
+         *     Collector's otlpjson file format (and through a Collector, any trace backend).
+         *     Works mid-run as a partial export of what's been ingested so far. Unknown run → 404
+         *     (the stores yield silently empty reads). Content-Disposition is `attachment`, so a
+         *     browser downloads rather than renders it.
+         */
+        get: operations["run_otlp_jsonl_api_runs__run_id__otlp_jsonl_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs/{run_id}/prompt": {
         parameters: {
             query?: never;
@@ -4119,6 +4148,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MissionInfo"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_otlp_jsonl_api_runs__run_id__otlp_jsonl_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/src/xorcise/core/cli/commands/run.py
+++ b/src/xorcise/core/cli/commands/run.py
@@ -478,10 +478,56 @@ def run_traces(
     as_json: bool = typer.Option(
         False, "--json", help="Emit the raw trace envelope as JSON (for scripting)."
     ),
+    export: bool = typer.Option(
+        False,
+        "--export",
+        help="Download the raw OTLP stream (spans + logs) as JSONL for OTel tooling.",
+    ),
+    out: str | None = typer.Option(
+        None,
+        "--out",
+        help="Export output path (implies --export; default: ./xorcise-run-<id8>-otlp.jsonl).",
+    ),
 ) -> None:
-    """Fetch the collected OTel trace records for a run (poll with --since for increments)."""
+    """Fetch the collected OTel trace records for a run (poll with --since for increments).
+
+    With --export (or --out), download the run's whole RAW OTLP stream instead — spans \
+then logs, one OTLP/JSON envelope per line, no XORCISE framing — the Collector's \
+otlpjson file format, ready for external OTel viz tooling. A still-active run exports \
+a partial snapshot of what has been ingested so far (and says so); once the run is \
+terminal the record is sealed and the export is final. For the normalized per-event \
+JSONL instead, see `xorcise run events export`.
+    """
+    export = export or out is not None
+    if export and as_json:
+        raise typer.BadParameter("--export writes a file; --json prints an envelope — pick one")
+    if export and since != -1:
+        raise typer.BadParameter(
+            "--since applies to the polling view; --export always takes a whole-run snapshot"
+        )
     client = RestClient()
     run_id = _resolve_id(client, run_id)
+    if export:
+        from pathlib import Path
+
+        # Conservative labeling: checked BEFORE the download, so a run that seals mid-flight
+        # can only be over-labeled partial (harmless) — never under-labeled complete.
+        active = client.get_run_result(run_id).get("status") == "active"
+        body = client.get_text(f"/runs/{run_id}/otlp.jsonl")
+        path = Path(out) if out else Path(f"xorcise-run-{run_id[:8]}-otlp.jsonl")
+        try:
+            path.write_text(body, encoding="utf-8")
+        except OSError as exc:
+            err_console.print(f"[err]error[/err]: cannot write {path} — {exc}")
+            raise typer.Exit(1) from exc
+        batches = sum(1 for ln in body.splitlines() if ln.strip())
+        note = (
+            " — run still active, partial snapshot; re-run after it finishes for the sealed record"
+            if active
+            else ""
+        )
+        console.print(f"wrote {path} ({batches} batch{'' if batches == 1 else 'es'}{note})")
+        return
     data = client.get(f"/runs/{run_id}/traces?since={since}")
     if as_json is True:
         # The full envelope (run_id + records), so a polling script keeps the context.

--- a/src/xorcise/core/rest/routers/runs.py
+++ b/src/xorcise/core/rest/routers/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Response
 from fastapi.responses import JSONResponse
@@ -552,6 +553,37 @@ def run_events(
             trace_seq=since if trace_since is None else trace_since,
             log_seq=since if log_since is None else log_since,
         ),
+    )
+
+
+@router.get("/{run_id}/otlp.jsonl")
+def run_otlp_jsonl(run_id: str) -> Response:
+    """The run's RAW OTLP stream as a downloadable JSONL file (OTLP/JSON lines).
+
+    One line per export batch, verbatim as the agent streamed it: trace batches
+    (`resourceSpans`) in seq order, then log batches (`resourceLogs`). Deliberately NO
+    XORCISE framing — no header line, no envelope — every line is a plain OTLP/JSON
+    object, so the file is directly consumable by OTel tooling that reads the
+    Collector's otlpjson file format (and through a Collector, any trace backend).
+    Works mid-run as a partial export of what's been ingested so far. Unknown run → 404
+    (the stores yield silently empty reads). Content-Disposition is `attachment`, so a
+    browser downloads rather than renders it.
+    """
+    run = runs.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"no run '{run_id}'")
+    # Lazy: keep the otel plane off the module-import path (plane-isolation invariant).
+    from xorcise.core.otel.store import SqliteLogStore, SqliteTraceStore
+
+    batches = SqliteTraceStore().read(run_id) + SqliteLogStore().read(run_id)
+    # Re-serialize compactly: exactly one envelope per line, guaranteed newline-free.
+    body = "".join(json.dumps(json.loads(b.payload), separators=(",", ":")) + "\n" for b in batches)
+    slug = re.sub(r"[^a-z0-9]+", "-", run.mission.lower()).strip("-") or "run"
+    filename = f"xorcise-run-{run_id[:8]}-{slug}-otlp.jsonl"
+    return Response(
+        content=body,
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/tests/unit/test_cli_run.py
+++ b/tests/unit/test_cli_run.py
@@ -525,6 +525,78 @@ def test_run_traces_json_dumps_records(monkeypatch):
     assert _json.loads(res.stdout) == {"run_id": RID, "records": records}
 
 
+OTLP_LINES = '{"resourceSpans":[]}\n{"resourceLogs":[]}\n'
+
+
+def _plain(text: str) -> str:
+    """Console output normalized for assertions: ANSI stripped, line-wrap collapsed."""
+    import re as _re
+
+    return " ".join(_re.sub(r"\x1b\[[0-9;]*m", "", text).split())
+
+
+def _patch_export(monkeypatch, *, active: bool = False, body: str = OTLP_LINES) -> dict[str, str]:
+    """Stub the two REST calls `--export` makes; capture the get_text path."""
+    captured: dict[str, str] = {}
+
+    def fake_get_text(self, path: str) -> str:  # noqa: ANN001 — test stub
+        captured["path"] = path
+        return body
+
+    monkeypatch.setattr("xorcise.core.cli.commands.run.RestClient.get_text", fake_get_text)
+    monkeypatch.setattr(
+        "xorcise.core.cli.commands.run.RestClient.get_run_result",
+        lambda self, rid: {"status": "active"} if active else {"status": "graded"},
+    )
+    return captured
+
+
+def test_run_traces_export_writes_default_file(monkeypatch, tmp_path):
+    """--export downloads /runs/<id>/otlp.jsonl verbatim to ./xorcise-run-<id8>-otlp.jsonl."""
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_export(monkeypatch)
+    res = runner.invoke(app, ["run", "traces", RID, "--export"])
+    assert res.exit_code == 0, res.output
+    assert captured["path"] == f"/runs/{RID}/otlp.jsonl"
+    written = tmp_path / f"xorcise-run-{RID8}-otlp.jsonl"
+    assert written.read_text(encoding="utf-8") == OTLP_LINES
+    assert f"wrote {written.name} (2 batches)" in _plain(res.stdout)
+
+
+def test_run_traces_out_implies_export(monkeypatch, tmp_path):
+    """--out alone switches to export mode and honours the explicit path."""
+    _patch_export(monkeypatch)
+    out = tmp_path / "trace.jsonl"
+    res = runner.invoke(app, ["run", "traces", RID, "--out", str(out)])
+    assert res.exit_code == 0, res.output
+    assert out.read_text(encoding="utf-8") == OTLP_LINES
+
+
+def test_run_traces_export_active_run_says_partial(monkeypatch, tmp_path):
+    """An in-progress run exports fine (exit 0) but the success line says partial."""
+    monkeypatch.chdir(tmp_path)
+    _patch_export(monkeypatch, active=True)
+    res = runner.invoke(app, ["run", "traces", RID, "--export"])
+    assert res.exit_code == 0, res.output
+    assert "partial snapshot" in _plain(res.stdout)
+
+
+def test_run_traces_export_rejects_json(monkeypatch):
+    """--export and --json are different outputs — combining them is a usage error."""
+    _patch_export(monkeypatch)
+    res = runner.invoke(app, ["run", "traces", RID, "--export", "--json"])
+    assert res.exit_code != 0
+    assert "pick one" in _plain(res.output)
+
+
+def test_run_traces_export_rejects_since(monkeypatch):
+    """--since is the polling cursor; --export is snapshot-whole — combining is a usage error."""
+    _patch_export(monkeypatch)
+    res = runner.invoke(app, ["run", "traces", RID, "--export", "--since", "3"])
+    assert res.exit_code != 0
+    assert "whole-run snapshot" in _plain(res.output)
+
+
 def test_run_traces_empty_run(monkeypatch):
     """A run with no collected trace records prints a clear empty message."""
     monkeypatch.setattr(

--- a/tests/unit/test_runs_traces_rest.py
+++ b/tests/unit/test_runs_traces_rest.py
@@ -26,3 +26,56 @@ def test_traces_endpoint_unknown_run_is_empty_200(migrated_home) -> None:
     resp = client.get("/api/runs/ghost/traces")
     assert resp.status_code == 200
     assert resp.json() == {"run_id": "ghost", "records": []}
+
+
+# ── Raw OTLP download (GET /runs/{id}/otlp.jsonl) ────────────────────────────────────────────
+
+
+def _otlp_span_batch(name: str) -> dict[str, object]:
+    return {"resourceSpans": [{"scopeSpans": [{"spans": [{"name": name}]}]}]}
+
+
+def test_otlp_jsonl_download_is_pure_otlp_lines(migrated_home) -> None:
+    from xorcise.core import runs
+    from xorcise.core.otel.store import SqliteLogStore
+
+    runs.create_run(run_id="r2", agent_id="a1", mission="c", budget_seconds=60)
+    traces = SqliteTraceStore()
+    for seq in range(2):
+        traces.append(
+            TraceRecord(run_id="r2", seq=seq, payload=json.dumps(_otlp_span_batch(f"s{seq}")))
+        )
+    SqliteLogStore().append(
+        TraceRecord(run_id="r2", seq=0, payload=json.dumps({"resourceLogs": []}))
+    )
+    resp = TestClient(build_rest_app()).get("/api/runs/r2/otlp.jsonl")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/x-ndjson")
+    assert (
+        resp.headers["content-disposition"] == 'attachment; filename="xorcise-run-r2-c-otlp.jsonl"'
+    )
+    # No header line, no XORCISE framing: every line is a plain OTLP/JSON envelope, so the
+    # file feeds the Collector's otlpjson file receiver (and from there any trace backend).
+    lines = resp.text.splitlines()
+    assert len(lines) == 3
+    envelopes = [json.loads(ln) for ln in lines]
+    assert envelopes[:2] == [_otlp_span_batch("s0"), _otlp_span_batch("s1")]
+    assert envelopes[2] == {"resourceLogs": []}
+
+
+def test_otlp_jsonl_reserializes_multiline_payloads_onto_one_line(migrated_home) -> None:
+    from xorcise.core import runs
+
+    runs.create_run(run_id="r3", agent_id="a1", mission="c", budget_seconds=60)
+    # Ingest may store pretty-printed JSON; the export must still be one envelope per line.
+    pretty = json.dumps(_otlp_span_batch("s0"), indent=2)
+    SqliteTraceStore().append(TraceRecord(run_id="r3", seq=0, payload=pretty))
+    resp = TestClient(build_rest_app()).get("/api/runs/r3/otlp.jsonl")
+    lines = resp.text.splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == _otlp_span_batch("s0")
+
+
+def test_otlp_jsonl_unknown_run_404(migrated_home) -> None:
+    resp = TestClient(build_rest_app()).get("/api/runs/ghost/otlp.jsonl")
+    assert resp.status_code == 404


### PR DESCRIPTION
## What

Adds a raw-evidence export: a run's complete OTLP stream as a JSONL file consumable by external OpenTelemetry tooling, exposed on all three surfaces.

- **REST** — `GET /api/runs/{run_id}/otlp.jsonl`: every trace batch (seq order), then every log batch, one OTLP/JSON envelope per line with **no XORCISE framing** — i.e. the Collector `otlpjson` file format, so the file feeds straight into a Collector and from there Jaeger/Tempo/etc. Payloads are re-serialized compactly so each envelope is guaranteed to occupy exactly one line. Unknown run → 404 (the stores read silently empty otherwise). `Content-Disposition: attachment` with `xorcise-run-<id8>-<mission>-otlp.jsonl`.
- **Web UI** — an "OTLP Traces (.jsonl)" button in the run result page's action row, a plain `<a download>` in the `DownloadReport` idiom. No grading gate: the evidence exists as soon as telemetry does.
- **CLI** — `xorcise run traces --export [--out PATH]`, a thin REST client of the endpoint (default `./xorcise-run-<id8>-otlp.jsonl`, `--out` implies `--export`). `--export --json` and `--export --since` are usage errors — `--json` keeps its role as the seq-framed polling envelope (the `--since` cursor lives in that framing), while `--export` is the Collector-ready snapshot.

## In-progress runs

Exports work mid-run and exit 0: the raw stores are append-only with whole-batch commits, so a partial export is always a valid prefix of the final stream. The CLI checks run state *before* downloading and annotates the success line ("partial snapshot — run still active"), so a run sealing mid-flight can only be over-labeled partial, never under-labeled complete. Once terminal, the record is sealed (ingest rejects late batches) and the export is final.

## Testing

- REST: pure-OTLP-lines shape (spans then logs, envelope round-trip, headers/filename), multiline-payload re-serialization, 404.
- CLI: default filename write, `--out` implies export, partial-snapshot annotation, both flag-conflict guards (assertions ANSI/wrap-normalized).
- Frontend: component tests for the anchor href/encoding/`download` attribute; full suite (706) + `tsc` clean.
- `mypy`, `ruff`, `lint-imports` (4/4 contracts incl. grader-never-reads-projection), topology lane all green. OpenAPI snapshot + generated schema regenerated against this base (no-drift gate).

Note: 8 pre-existing `test_cli_run.py` failures reproduce identically on clean `origin/main` in colorized terminals (ANSI codes in asserted output) — unrelated to this change.