### PR TITLE
refactor(cli): route `run events export` through the REST server

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5534,6 +5534,47 @@
         ]
       }
     },
+    "/api/runs/{run_id}/events.jsonl": {
+      "get": {
+        "description": "The run's NORMALIZED AgentEvent projection as a downloadable JSONL file.\n\nA `{\"type\": \"header\", ...}` line (run + adapter metadata), then one AgentEvent per\nline \u2014 clean bodies, not raw OTLP. The same content the on-seal artifact under\n`~/.xorcise/runs/<id>/` carries; what `xorcise run events export` fetches. For the\nraw OTLP stream, use GET /runs/{run_id}/otlp.jsonl. Works mid-run as a partial\nprojection of what's been ingested so far. Unknown run \u2192 404. Content-Disposition\nis `attachment`, so a browser downloads rather than renders it.",
+        "operationId": "run_events_jsonl_api_runs__run_id__events_jsonl_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Run Events Jsonl",
+        "tags": [
+          "runs"
+        ]
+      }
+    },
     "/api/runs/{run_id}/events/{event_id}/raw": {
       "get": {
         "description": "The source RAW OTLP span(s) an event was derived from (drill-down).\n\n`{event_id:path}` \u2014 AgentEvent ids derive from base64 span ids, which may contain '/'.",

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -747,6 +747,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/runs/{run_id}/events.jsonl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Run Events Jsonl
+         * @description The run's NORMALIZED AgentEvent projection as a downloadable JSONL file.
+         *
+         *     A `{"type": "header", ...}` line (run + adapter metadata), then one AgentEvent per
+         *     line — clean bodies, not raw OTLP. The same content the on-seal artifact under
+         *     `~/.xorcise/runs/<id>/` carries; what `xorcise run events export` fetches. For the
+         *     raw OTLP stream, use GET /runs/{run_id}/otlp.jsonl. Works mid-run as a partial
+         *     projection of what's been ingested so far. Unknown run → 404. Content-Disposition
+         *     is `attachment`, so a browser downloads rather than renders it.
+         */
+        get: operations["run_events_jsonl_api_runs__run_id__events_jsonl_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs/{run_id}/events/{event_id}/raw": {
         parameters: {
             query?: never;
@@ -3980,6 +4007,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RunEventsView"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_events_jsonl_api_runs__run_id__events_jsonl_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/src/xorcise/core/cli/commands/run.py
+++ b/src/xorcise/core/cli/commands/run.py
@@ -602,49 +602,27 @@ launch-profile` for the env alone (dotenv, to pipe into a config)."""
 def run_events_export(
     run_id: str = typer.Argument(..., help=_RUN_ID_HELP),
     out: str | None = typer.Option(
-        None, "--out", help="Output path (default: ~/.xorcise/runs/<run_id>/agent-events.jsonl)."
+        None, "--out", help="Output path (default: ./xorcise-run-<id8>-events.jsonl)."
     ),
 ) -> None:
-    """Write a run's normalized AgentEvent stream to JSONL — one event per line \
-with clean bodies (debug/inspection). Local: reads the projection cache and \
-writes under ~/.xorcise.
+    """Download a run's normalized AgentEvent stream as JSONL — a header line, then \
+one event per line with clean bodies (debug/inspection). Works mid-run as a partial \
+snapshot. For the raw OTLP stream instead, see `xorcise run traces --export`.
     """
     from pathlib import Path
 
-    from xorcise.core.contracts.errors import NotFoundError
-    from xorcise.core.rest.events_export import export_run_events
-
-    out_path = Path(out) if out else None
-    if not run_id.strip():
-        resolve_run_id(RestClient(), run_id)  # raises the missing-id usage error
-
-    def _events_written(p: Path) -> int:
-        """Events in the export (the header line carries the count)."""
-        try:
-            with p.open(encoding="utf-8") as fh:
-                return int(json.loads(fh.readline() or "{}").get("event_count", 0))
-        except (OSError, ValueError):
-            return 0
-
+    client = RestClient()
+    run_id = _resolve_id(client, run_id)
+    body = client.get_text(f"/runs/{run_id}/events.jsonl")
+    path = Path(out) if out else Path(f"xorcise-run-{run_id[:8]}-events.jsonl")
     try:
-        try:
-            path = export_run_events(run_id, out_path)
-            written = _events_written(path)
-        except NotFoundError:
-            path, written = None, 0
-        if written == 0 and len(run_id) < 32:
-            # A short id is a PREFIX. Exporting it literally wrote a header-only
-            # file and exited 0 — a silent empty export. Resolve it (service
-            # needed) so the user gets the real run, or a clean not-found.
-            resolved = resolve_run_id(RestClient(), run_id)
-            path = export_run_events(resolved, out_path)
-            written = _events_written(path)
-        if path is None:
-            raise NotFoundError(f"no run '{run_id}'")
-    except NotFoundError as exc:
-        err_console.print(f"[err]error[/err]: no such run '{run_id}'")
-        raise typer.Exit(1) from exc
+        path.write_text(body, encoding="utf-8")
     except OSError as exc:
-        err_console.print(f"[err]error[/err]: cannot write the export — {exc}")
+        err_console.print(f"[err]error[/err]: cannot write {path} — {exc}")
         raise typer.Exit(1) from exc
+    try:
+        # The header line carries the authoritative count.
+        written = int(json.loads(body.split("\n", 1)[0] or "{}").get("event_count", 0))
+    except ValueError:
+        written = 0
     console.print(f"wrote {path} ({written} event{'' if written == 1 else 's'})")

--- a/src/xorcise/core/cli/commands/run.py
+++ b/src/xorcise/core/cli/commands/run.py
@@ -40,10 +40,10 @@ run_app = typer.Typer(
 )
 app.add_typer(run_app, name="run", rich_help_panel="Evaluate")
 
-# `xorcise run events …` — per-run AgentEvent projection tools. Server-local (reads the local
-# projection cache + writes under ~/.xorcise), unlike the thin REST-client commands below.
+# `xorcise run events …` — per-run AgentEvent projection tools (thin REST clients, like the
+# rest of this module).
 run_events_app = typer.Typer(
-    help="Per-run AgentEvent export (reads the local cache under ~/.xorcise).",
+    help="Per-run AgentEvent export (normalized projection, fetched from the server).",
     no_args_is_help=True,
 )
 run_app.add_typer(run_events_app, name="events")

--- a/src/xorcise/core/rest/events_export.py
+++ b/src/xorcise/core/rest/events_export.py
@@ -7,8 +7,9 @@ never canonical, always rebuildable from RAW; the grader never reads it. Reuses 
 events_view read seam (the same projection GET /runs/{id}/events serves), so the file matches the
 normalized `agent_events` cache exactly.
 
-Written server-side on run finalization (run_terminate.grade_and_record, best-effort) and on
-demand via `xorcise run events export`. The `runs/` tree is durable (not cleared by `down`).
+Written server-side on run finalization (run_terminate.grade_and_record, best-effort); served
+on demand as a download by GET /runs/{id}/events.jsonl (what `xorcise run events export`
+fetches). The `runs/` tree is durable (not cleared by `down`).
 """
 
 from __future__ import annotations
@@ -29,8 +30,8 @@ def default_export_path(run_id: str) -> Path:
     return run_dir(run_id) / "agent-events.jsonl"
 
 
-def export_run_events(run_id: str, out: Path | None = None) -> Path:
-    """Write the run's normalized AgentEvent projection to JSONL; return the path written.
+def render_run_events(run_id: str) -> str:
+    """The run's normalized AgentEvent projection as JSONL text.
 
     Rebuilt from RAW via the events_view read seam (identical to GET /runs/{id}/events). A header
     line carries run + adapter metadata; each subsequent line is one `AgentEvent` (model_dump_json).
@@ -39,8 +40,6 @@ def export_run_events(run_id: str, out: Path | None = None) -> Path:
     from xorcise.core.rest import events_view
 
     view = events_view._full_view(run_id)
-    path = out if out is not None else default_export_path(run_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
     header = {
         "type": "header",
         "run_id": view.run_id,
@@ -55,5 +54,12 @@ def export_run_events(run_id: str, out: Path | None = None) -> Path:
     }
     lines = [json.dumps(header)]
     lines.extend(event.model_dump_json() for event in view.events)
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return "\n".join(lines) + "\n"
+
+
+def export_run_events(run_id: str, out: Path | None = None) -> Path:
+    """Write the run's normalized AgentEvent projection to JSONL; return the path written."""
+    path = out if out is not None else default_export_path(run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_run_events(run_id), encoding="utf-8")
     return path

--- a/src/xorcise/core/rest/routers/runs.py
+++ b/src/xorcise/core/rest/routers/runs.py
@@ -587,6 +587,32 @@ def run_otlp_jsonl(run_id: str) -> Response:
     )
 
 
+@router.get("/{run_id}/events.jsonl")
+def run_events_jsonl(run_id: str) -> Response:
+    """The run's NORMALIZED AgentEvent projection as a downloadable JSONL file.
+
+    A `{"type": "header", ...}` line (run + adapter metadata), then one AgentEvent per
+    line — clean bodies, not raw OTLP. The same content the on-seal artifact under
+    `~/.xorcise/runs/<id>/` carries; what `xorcise run events export` fetches. For the
+    raw OTLP stream, use GET /runs/{run_id}/otlp.jsonl. Works mid-run as a partial
+    projection of what's been ingested so far. Unknown run → 404. Content-Disposition
+    is `attachment`, so a browser downloads rather than renders it.
+    """
+    run = runs.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"no run '{run_id}'")
+    # Lazy: keep the otel display plane off the module-import path (plane-isolation invariant).
+    from xorcise.core.rest.events_export import render_run_events
+
+    slug = re.sub(r"[^a-z0-9]+", "-", run.mission.lower()).strip("-") or "run"
+    filename = f"xorcise-run-{run_id[:8]}-{slug}-events.jsonl"
+    return Response(
+        content=render_run_events(run_id),
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
 @router.get("/{run_id}/events/{event_id:path}/raw")
 def run_event_raw(run_id: str, event_id: str) -> dict[str, object]:
     """The source RAW OTLP span(s) an event was derived from (drill-down).

--- a/tests/unit/test_events_export.py
+++ b/tests/unit/test_events_export.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from typing import Any
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from xorcise.core import runs
@@ -115,13 +117,96 @@ def test_export_written_on_seal_via_grade_and_record(migrated_home):
     assert header["run_id"] == "r4" and len(events) == 2
 
 
-def test_cli_run_events_export(migrated_home):
+# ── The download endpoint (GET /runs/{id}/events.jsonl) ──────────────────────────────────────
+
+
+def test_events_jsonl_download_matches_the_projection(migrated_home):
+    from fastapi.testclient import TestClient
+
+    from xorcise.core.rest import events_view
+    from xorcise.core.roles.boot.role_all import build_rest_app
+
+    _seed("r6", [(0, "s0", "shell.exec"), (1, "s1", "assistant.msg")])
+    resp = TestClient(build_rest_app()).get("/api/runs/r6/events.jsonl")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/x-ndjson")
+    assert (
+        resp.headers["content-disposition"]
+        == 'attachment; filename="xorcise-run-r6-c-events.jsonl"'
+    )
+    lines = [json.loads(ln) for ln in resp.text.splitlines() if ln.strip()]
+    header, events = lines[0], lines[1:]
+    assert header["type"] == "header" and header["run_id"] == "r6"
+    assert header["event_count"] == len(events) == 2
+    view = events_view._full_view("r6")
+    assert [e["id"] for e in events] == [e.id for e in view.events]
+
+
+def test_events_jsonl_unknown_run_404(migrated_home):
+    from fastapi.testclient import TestClient
+
+    from xorcise.core.roles.boot.role_all import build_rest_app
+
+    assert TestClient(build_rest_app()).get("/api/runs/ghost/events.jsonl").status_code == 404
+
+
+# ── The CLI thin client (`xorcise run events export`) ────────────────────────────────────────
+
+RID = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6"
+
+
+def _plain(text: str) -> str:
+    """Terminal-colour-proof: strip ANSI codes, collapse whitespace."""
+    return re.sub(r"\s+", " ", re.sub(r"\x1b\[[0-9;]*m", "", text))
+
+
+def _cli_app() -> typer.Typer:
     import xorcise.core.cli.app  # noqa: F401 — registers commands on the shared app
     from xorcise.core.cli._shared import app
-    from xorcise.core.rest.events_export import default_export_path
 
-    _seed("r5", [(0, "s0", "shell.exec")])
-    result = CliRunner().invoke(app, ["run", "events", "export", "r5"])
+    return app
+
+
+def _patch_download(monkeypatch, body: str) -> dict[str, str]:
+    """Stub the one REST call the export makes; capture the get_text path."""
+    captured: dict[str, str] = {}
+
+    def fake_get_text(self, path: str) -> str:  # noqa: ANN001 — test stub
+        captured["path"] = path
+        return body
+
+    monkeypatch.setattr("xorcise.core.cli.commands.run.RestClient.get_text", fake_get_text)
+    return captured
+
+
+def test_cli_run_events_export_downloads_via_rest(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    body = json.dumps({"type": "header", "event_count": 2}) + '\n{"kind":"a"}\n{"kind":"b"}\n'
+    captured = _patch_download(monkeypatch, body)
+    result = CliRunner().invoke(_cli_app(), ["run", "events", "export", RID])
     assert result.exit_code == 0, result.output
-    assert default_export_path("r5").exists()
-    assert "wrote" in result.output
+    assert captured["path"] == f"/runs/{RID}/events.jsonl"
+    written = tmp_path / f"xorcise-run-{RID[:8]}-events.jsonl"
+    assert written.read_text(encoding="utf-8") == body
+    assert f"wrote {written.name} (2 events)" in _plain(result.output)
+
+
+def test_cli_run_events_export_out_override(monkeypatch, tmp_path):
+    body = json.dumps({"type": "header", "event_count": 1}) + '\n{"kind":"a"}\n'
+    _patch_download(monkeypatch, body)
+    out = tmp_path / "events.jsonl"
+    result = CliRunner().invoke(_cli_app(), ["run", "events", "export", RID, "--out", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.read_text(encoding="utf-8") == body
+    assert "(1 event)" in _plain(result.output)
+
+
+def test_cli_run_events_export_resolves_short_ids(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    body = json.dumps({"type": "header", "event_count": 0}) + "\n"
+    captured = _patch_download(monkeypatch, body)
+    monkeypatch.setattr("xorcise.core.cli.commands.run.resolve_run_id", lambda client, given: RID)
+    result = CliRunner().invoke(_cli_app(), ["run", "events", "export", RID[:8]])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == f"/runs/{RID}/events.jsonl"
+    assert "(0 events)" in _plain(result.output)


### PR DESCRIPTION
Closes #54.

## What

Converts `xorcise run events export` — the last CLI command reading run evidence out of the local store in-process — into a thin REST client, mirroring the raw-OTLP export shape from #53.

- **New endpoint** `GET /runs/{run_id}/events.jsonl`: the normalized AgentEvent projection as a downloadable JSONL file — a `{"type": "header", ...}` line (run + adapter metadata), then one event per line. `application/x-ndjson`, `Content-Disposition: attachment`, 404 for an unknown run, works mid-run as a partial projection. Follows the plane-isolation invariant (otel display plane lazy-imported inside the handler).
- **`events_export` split**: `render_run_events()` (content) extracted from `export_run_events()` (file write), so the on-seal server-side artifact under `~/.xorcise/runs/<id>/` is produced by exactly the same code path the endpoint serves.
- **CLI conversion**: the command now resolves the id through the server (proper prefix resolution, replacing the old empty-export-then-retry fallback dance), downloads the JSONL, and writes it locally. No store or domain imports remain — only `RestClient`.

## Behavior change

The CLI's default output path moves from the server's home tree (`~/.xorcise/runs/<run_id>/agent-events.jsonl`) to the CWD (`./xorcise-run-<id8>-events.jsonl`), matching `run report` and `run traces --export`. Writing into the server's home from the client was only coherent while the two shared a machine; the server still materializes its own copy under `~/.xorcise/runs/<id>/` on run finalization, so the durable artifact is unaffected. `--out` continues to override.

## Tests

- Endpoint: content parity with the `events_view` projection, header/count integrity, download headers + filename, unknown-run 404.
- CLI: RestClient-stubbed — default-path download, `--out` override, short-id resolution through the server.
- OpenAPI artifacts regenerated (`frontend/openapi.json`, `schema.ts`); the only path delta is the new endpoint.
- Local: mypy (482 files), ruff check + format, lint-imports (4/4 contracts, incl. "Grader never reads the AgentEvent projection"), unit/topology/adapters lanes, frontend typecheck + 706 tests.
