### PR TITLE
feat(missions): adopt the mission-versioning contract (schema 3.0, artifact identity, update action)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -806,18 +806,59 @@
             ],
             "title": "Image Size Bytes"
           },
+          "index_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Digest"
+          },
           "installed": {
             "default": false,
             "title": "Installed",
             "type": "boolean"
           },
+          "mission_base_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Base Version"
+          },
           "mission_id": {
             "title": "Mission Id",
             "type": "string"
           },
+          "mission_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Version"
+          },
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "platforms": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Platforms",
+            "type": "array"
           },
           "proficiency": {
             "anyOf": [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -507,8 +507,8 @@
             "default": {
               "agent_version": 1,
               "budget_seconds": 0,
-              "intel_disclosed": 0,
-              "mission_version": 1
+              "install_revision": 1,
+              "intel_disclosed": 0
             }
           },
           "created_at": {
@@ -2653,6 +2653,11 @@
             "title": "Budget Seconds",
             "type": "integer"
           },
+          "install_revision": {
+            "default": 1,
+            "title": "Install Revision",
+            "type": "integer"
+          },
           "intel_disclosed": {
             "default": 0,
             "title": "Intel Disclosed",
@@ -2669,10 +2674,27 @@
             ],
             "title": "Judge Model"
           },
+          "mission_base_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Base Version"
+          },
           "mission_version": {
-            "default": 1,
-            "title": "Mission Version",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Version"
           },
           "model": {
             "anyOf": [
@@ -2684,6 +2706,17 @@
               }
             ],
             "title": "Model"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
           },
           "sandbox_ref": {
             "anyOf": [
@@ -2841,10 +2874,37 @@
             ],
             "title": "Completed At"
           },
+          "content_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Hash"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "index_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Digest"
+          },
+          "install_revision": {
+            "default": 1,
+            "title": "Install Revision",
+            "type": "integer"
           },
           "intel_policy": {
             "default": "all",
@@ -2867,10 +2927,27 @@
             "title": "Mission",
             "type": "string"
           },
+          "mission_base_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Base Version"
+          },
           "mission_version": {
-            "default": 1,
-            "title": "Mission Version",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Version"
           },
           "model": {
             "anyOf": [
@@ -2887,6 +2964,28 @@
             "default": "",
             "title": "Name",
             "type": "string"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "platform_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Digest"
           },
           "run_control_key": {
             "title": "Run Control Key",
@@ -2968,10 +3067,37 @@
             ],
             "title": "Completed At"
           },
+          "content_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Hash"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "index_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Digest"
+          },
+          "install_revision": {
+            "default": 1,
+            "title": "Install Revision",
+            "type": "integer"
           },
           "intel_policy": {
             "default": "all",
@@ -2994,10 +3120,27 @@
             "title": "Mission",
             "type": "string"
           },
+          "mission_base_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Base Version"
+          },
           "mission_version": {
-            "default": 1,
-            "title": "Mission Version",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mission Version"
           },
           "model": {
             "anyOf": [
@@ -3014,6 +3157,28 @@
             "default": "",
             "title": "Name",
             "type": "string"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "platform_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Digest"
           },
           "run_id": {
             "title": "Run Id",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1986,7 +1986,7 @@
       },
       "MissionManifest": {
         "additionalProperties": false,
-        "description": "The `mission.json` v2 object \u2014 the shared contract all consumers import.\n\nRequired: schema_version, metadata (incl. metadata.type \u2208 {lab, static}; the agent objective\nlives under metadata.objective). `environment` is conditional: required for lab, omitted for\nstatic (see _check_execution_contract). Everything else defaults empty/None so a minimal bundle\nvalidates (terrain/intel absent is valid; lab needs environment, static needs attachments).",
+        "description": "The `mission.json` object (schema 2.0 or 3.0) \u2014 the shared contract all consumers import.\n\nRequired: schema_version, metadata (incl. metadata.type \u2208 {lab, static}; the agent objective\nlives under metadata.objective) and \u2014 on schema 3.0 \u2014 the creator-owned SemVer `version`\n(2.0 predates the field and must not carry it; see _check_version_contract). `environment` is\nconditional: required for lab, omitted for static (see _check_execution_contract). Everything\nelse defaults empty/None so a minimal bundle validates (terrain/intel absent is valid; lab\nneeds environment, static needs attachments).",
         "properties": {
           "artifacts": {
             "default": [],
@@ -2053,7 +2053,10 @@
             "type": "array"
           },
           "schema_version": {
-            "const": "2.0",
+            "enum": [
+              "2.0",
+              "3.0"
+            ],
             "title": "Schema Version",
             "type": "string"
           },
@@ -2077,6 +2080,17 @@
                 "type": "null"
               }
             ]
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
           }
         },
         "required": [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2031,6 +2031,48 @@
         "title": "KindSupport",
         "type": "string"
       },
+      "MissionBaseView": {
+        "additionalProperties": false,
+        "description": "The mission-base picture for settings/diagnostics (contract \u00a727/\u00a736): what THIS client\nrequires (the compatibility MAJOR it was built for) beside what the catalog currently\npromotes. The promoted side is None when the catalog predates the endpoint (prod today)\nor is unreachable \u2014 unknown, never fabricated.",
+        "properties": {
+          "client_version": {
+            "default": "",
+            "title": "Client Version",
+            "type": "string"
+          },
+          "promoted_index_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promoted Index Digest"
+          },
+          "promoted_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promoted Version"
+          },
+          "required_major": {
+            "title": "Required Major",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "required_major"
+        ],
+        "title": "MissionBaseView",
+        "type": "object"
+      },
       "MissionInfo": {
         "description": "What `GET /runs/{id}/mission` returns: the run's single mission, unlocked.",
         "properties": {
@@ -3535,6 +3577,16 @@
             "default": "",
             "title": "Home",
             "type": "string"
+          },
+          "mission_base": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MissionBaseView"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "planes": {
             "items": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -773,6 +773,28 @@
             ],
             "title": "Compatible"
           },
+          "current_mission_base_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Mission Base Version"
+          },
+          "current_mission_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Mission Version"
+          },
           "download_size_bytes": {
             "anyOf": [
               {
@@ -921,6 +943,17 @@
               }
             ],
             "title": "Type"
+          },
+          "update_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Update Available"
           }
         },
         "required": [
@@ -2215,6 +2248,24 @@
           "type"
         ],
         "title": "MissionMetadata",
+        "type": "object"
+      },
+      "MissionUpdateOut": {
+        "description": "POST /{id}/update result: whether anything moved, and the row as installed now.",
+        "properties": {
+          "entry": {
+            "$ref": "#/components/schemas/CatalogEntry"
+          },
+          "updated": {
+            "title": "Updated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "updated",
+          "entry"
+        ],
+        "title": "MissionUpdateOut",
         "type": "object"
       },
       "ModelConfigUpdate": {
@@ -5174,6 +5225,49 @@
           }
         },
         "summary": "Mission Terrain",
+        "tags": [
+          "missions"
+        ]
+      }
+    },
+    "/api/missions/{mission_id}/update": {
+      "post": {
+        "description": "Update an installed library mission to the catalog's current artifact (\u00a735's ONE\nupdate action) \u2014 an in-place, atomic re-pull. updated=false \u21d2 the install already matches\nthe catalog (digest compared first) and nothing was touched.\n\n404: not installed, or gone from the catalog. 409: a your_own install owns the id (update\nit by re-ingesting), or a pull job is mid-flight. 502: the pull itself failed (nothing\nreplaced \u2014 the previous install stays byte-for-byte intact).",
+        "operationId": "update_api_missions__mission_id__update_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mission_id",
+            "required": true,
+            "schema": {
+              "title": "Mission Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MissionUpdateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update",
         "tags": [
           "missions"
         ]

--- a/frontend/src/features/live-trace/run-live.tsx
+++ b/frontend/src/features/live-trace/run-live.tsx
@@ -361,7 +361,7 @@ export function RunLive({ runId }: { runId: string | null }) {
                 href={`/missions/detail?id=${encodeURIComponent(r.mission)}`}
                 className="truncate font-mono text-dense text-foreground hover:underline"
               >
-                {r.mission} v{r.mission_version}
+                {r.mission} v{r.mission_version ?? r.install_revision}
               </Link>
             </div>
             <MetaItem label="Agent" value={`${agentName} v${r.agent_version}`} />

--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -20,6 +20,25 @@ import { DifficultyBadge } from "./difficulty-badge";
 
 const MAX_TECH = 3;
 
+/**
+ * The secondary "why" line under the single Update available status (§35/UX1): which of the
+ * two versions moved — mission, base, or both. Undefined when the catalog didn't say (the
+ * digest alone flagged the update) so the badge still renders, just without a tooltip.
+ */
+function updateReason(c: CatalogEntry): string | undefined {
+  const parts: string[] = [];
+  if (c.current_mission_version && c.current_mission_version !== c.mission_version) {
+    parts.push(`Mission ${c.mission_version ?? "?"} → ${c.current_mission_version}`);
+  }
+  if (
+    c.current_mission_base_version &&
+    c.current_mission_base_version !== c.mission_base_version
+  ) {
+    parts.push(`Mission base ${c.mission_base_version ?? "?"} → ${c.current_mission_base_version}`);
+  }
+  return parts.length ? parts.join(" · ") : undefined;
+}
+
 const ENV_TOOLTIP: Record<string, string> = {
   lab: "Lab — a live sandbox environment spins up for the run.",
   static: "Static — attachment-only; no environment is started.",
@@ -158,6 +177,13 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
             {c.compatible === false && (
               <Badge variant="warn" title={c.compat_hint ?? undefined}>
                 update required
+              </Badge>
+            )}
+            {/* §34/§35: digest-driven, ONE primary status. Suppressed while the row is
+                incompatible — "update required" already demands the same single action. */}
+            {c.compatible !== false && c.update_available === true && (
+              <Badge variant="muted" title={updateReason(c)}>
+                update available
               </Badge>
             )}
             {installed ? (

--- a/frontend/src/features/missions/mission-detail.test.tsx
+++ b/frontend/src/features/missions/mission-detail.test.tsx
@@ -25,6 +25,7 @@ const INSTALLED: CatalogEntry = {
   installed: true,
   skills: [],
   technologies: [],
+  platforms: [],
 };
 
 describe("MissionDetail delete", () => {

--- a/frontend/src/features/missions/mission-size.test.tsx
+++ b/frontend/src/features/missions/mission-size.test.tsx
@@ -24,6 +24,7 @@ const AVAILABLE: CatalogEntry = {
   installed: false,
   skills: [],
   technologies: [],
+  platforms: [],
   image_size_bytes: 260306509,
   attachments_size_bytes: 384284,
   download_size_bytes: 260690793,

--- a/frontend/src/features/missions/pull-mission.test.tsx
+++ b/frontend/src/features/missions/pull-mission.test.tsx
@@ -14,6 +14,7 @@ const LIBRARY: CatalogEntry = {
   installed: false,
   skills: [],
   technologies: [],
+  platforms: [],
 };
 const INSTALLED: CatalogEntry = { ...LIBRARY, mission_id: "idor", name: "IDOR", installed: true };
 

--- a/frontend/src/features/results/conditions-card.test.tsx
+++ b/frontend/src/features/results/conditions-card.test.tsx
@@ -11,7 +11,7 @@ const base: ResultConditions = {
   budget_seconds: 0,
   sandbox_ref: null,
   agent_version: 1,
-  mission_version: 1,
+  install_revision: 1,
   intel_disclosed: 0,
 };
 

--- a/frontend/src/features/results/results-view.tsx
+++ b/frontend/src/features/results/results-view.tsx
@@ -251,7 +251,7 @@ function RunMetaBar({ run, agentName }: { run: RunEntry; agentName: string }) {
     ? (new Date(run.completed_at).getTime() - new Date(run.created_at).getTime()) / 1000
     : null;
   const items: { label: string; value: string; mono?: boolean }[] = [
-    { label: "Mission", value: `${run.mission} v${run.mission_version}` },
+    { label: "Mission", value: `${run.mission} v${run.mission_version ?? run.install_revision}` },
     { label: "Agent", value: `${agentName} v${run.agent_version}` },
     { label: "Harness", value: run.source_agent },
     { label: "Started", value: fullTime(run.created_at), mono: true },

--- a/frontend/src/features/settings/settings-view.tsx
+++ b/frontend/src/features/settings/settings-view.tsx
@@ -514,6 +514,26 @@ function EnvironmentCard() {
                 <span className="text-foreground">{db?.label}</span>
               </span>
             </Field>
+            {/* §36 version visibility: the base MAJOR this client executes, and — when the
+                catalog serves it — the currently promoted base release. A pre-contract
+                catalog reports nothing, and the row says only what is locally true. */}
+            {s.mission_base && (
+              <Field label="Mission base">
+                <span className="text-foreground">
+                  requires major {s.mission_base.required_major}
+                  {s.mission_base.promoted_version
+                    ? ` · catalog promotes ${s.mission_base.promoted_version}`
+                    : ""}
+                </span>
+              </Field>
+            )}
+            {s.mission_base?.client_version && (
+              <Field label="Client version">
+                <span className="font-mono text-foreground">
+                  {s.mission_base.client_version}
+                </span>
+              </Field>
+            )}
           </dl>
           {s.db_url && (
             <p className="break-all font-mono text-dense text-text-tertiary">

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -1463,15 +1463,26 @@ export interface components {
             image?: string | null;
             /** Image Size Bytes */
             image_size_bytes?: number | null;
+            /** Index Digest */
+            index_digest?: string | null;
             /**
              * Installed
              * @default false
              */
             installed: boolean;
+            /** Mission Base Version */
+            mission_base_version?: string | null;
             /** Mission Id */
             mission_id: string;
+            /** Mission Version */
+            mission_version?: string | null;
             /** Name */
             name: string;
+            /**
+             * Platforms
+             * @default []
+             */
+            platforms: string[];
             /** Proficiency */
             proficiency?: string | null;
             /**

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -554,6 +554,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/missions/{mission_id}/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update
+         * @description Update an installed library mission to the catalog's current artifact (§35's ONE
+         *     update action) — an in-place, atomic re-pull. updated=false ⇒ the install already matches
+         *     the catalog (digest compared first) and nothing was touched.
+         *
+         *     404: not installed, or gone from the catalog. 409: a your_own install owns the id (update
+         *     it by re-ingesting), or a pull job is mid-flight. 502: the pull itself failed (nothing
+         *     replaced — the previous install stays byte-for-byte intact).
+         */
+        post: operations["update_api_missions__mission_id__update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs": {
         parameters: {
             query?: never;
@@ -1457,6 +1483,10 @@ export interface components {
             compat_hint?: string | null;
             /** Compatible */
             compatible?: boolean | null;
+            /** Current Mission Base Version */
+            current_mission_base_version?: string | null;
+            /** Current Mission Version */
+            current_mission_version?: string | null;
             /** Download Size Bytes */
             download_size_bytes?: number | null;
             /** Image */
@@ -1509,6 +1539,8 @@ export interface components {
             technologies: string[];
             /** Type */
             type?: string | null;
+            /** Update Available */
+            update_available?: boolean | null;
         };
         /**
          * CatalogStatus
@@ -2107,6 +2139,15 @@ export interface components {
              * @enum {string}
              */
             type: "lab" | "static";
+        };
+        /**
+         * MissionUpdateOut
+         * @description POST /{id}/update result: whether anything moved, and the row as installed now.
+         */
+        MissionUpdateOut: {
+            entry: components["schemas"]["CatalogEntry"];
+            /** Updated */
+            updated: boolean;
         };
         /**
          * ModelConfigUpdate
@@ -3732,6 +3773,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResolvedTerrainV2"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_missions__mission_id__update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                mission_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MissionUpdateOut"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -2041,6 +2041,26 @@ export interface components {
          */
         KindSupport: "supported" | "partial" | "unsupported";
         /**
+         * MissionBaseView
+         * @description The mission-base picture for settings/diagnostics (contract §27/§36): what THIS client
+         *     requires (the compatibility MAJOR it was built for) beside what the catalog currently
+         *     promotes. The promoted side is None when the catalog predates the endpoint (prod today)
+         *     or is unreachable — unknown, never fabricated.
+         */
+        MissionBaseView: {
+            /**
+             * Client Version
+             * @default
+             */
+            client_version: string;
+            /** Promoted Index Digest */
+            promoted_index_digest?: string | null;
+            /** Promoted Version */
+            promoted_version?: string | null;
+            /** Required Major */
+            required_major: number;
+        };
+        /**
          * MissionInfo
          * @description What `GET /runs/{id}/mission` returns: the run's single mission, unlocked.
          */
@@ -2709,6 +2729,7 @@ export interface components {
              * @default
              */
             home: string;
+            mission_base?: components["schemas"]["MissionBaseView"] | null;
             /** Planes */
             planes: components["schemas"]["PlaneStatus"][];
             /**

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -1334,8 +1334,8 @@ export interface components {
              * @default {
              *       "agent_version": 1,
              *       "budget_seconds": 0,
-             *       "intel_disclosed": 0,
-             *       "mission_version": 1
+             *       "install_revision": 1,
+             *       "intel_disclosed": 0
              *     }
              */
             conditions: components["schemas"]["ResultConditions"];
@@ -2288,19 +2288,25 @@ export interface components {
              */
             budget_seconds: number;
             /**
+             * Install Revision
+             * @default 1
+             */
+            install_revision: number;
+            /**
              * Intel Disclosed
              * @default 0
              */
             intel_disclosed: number;
             /** Judge Model */
             judge_model?: string | null;
-            /**
-             * Mission Version
-             * @default 1
-             */
-            mission_version: number;
+            /** Mission Base Version */
+            mission_base_version?: string | null;
+            /** Mission Version */
+            mission_version?: string | null;
             /** Model */
             model?: string | null;
+            /** Platform */
+            platform?: string | null;
             /** Sandbox Ref */
             sandbox_ref?: string | null;
         };
@@ -2371,11 +2377,20 @@ export interface components {
             budget_seconds: number;
             /** Completed At */
             completed_at?: string | null;
+            /** Content Hash */
+            content_hash?: string | null;
             /**
              * Created At
              * Format: date-time
              */
             created_at: string;
+            /** Index Digest */
+            index_digest?: string | null;
+            /**
+             * Install Revision
+             * @default 1
+             */
+            install_revision: number;
             /**
              * Intel Policy
              * @default all
@@ -2385,11 +2400,10 @@ export interface components {
             last_telemetry_at?: string | null;
             /** Mission */
             mission: string;
-            /**
-             * Mission Version
-             * @default 1
-             */
-            mission_version: number;
+            /** Mission Base Version */
+            mission_base_version?: string | null;
+            /** Mission Version */
+            mission_version?: string | null;
             /** Model */
             model?: string | null;
             /**
@@ -2397,6 +2411,10 @@ export interface components {
              * @default
              */
             name: string;
+            /** Platform */
+            platform?: string | null;
+            /** Platform Digest */
+            platform_digest?: string | null;
             /** Run Control Key */
             run_control_key: string;
             /** Run Id */
@@ -2432,11 +2450,20 @@ export interface components {
             budget_seconds: number;
             /** Completed At */
             completed_at?: string | null;
+            /** Content Hash */
+            content_hash?: string | null;
             /**
              * Created At
              * Format: date-time
              */
             created_at: string;
+            /** Index Digest */
+            index_digest?: string | null;
+            /**
+             * Install Revision
+             * @default 1
+             */
+            install_revision: number;
             /**
              * Intel Policy
              * @default all
@@ -2446,11 +2473,10 @@ export interface components {
             last_telemetry_at?: string | null;
             /** Mission */
             mission: string;
-            /**
-             * Mission Version
-             * @default 1
-             */
-            mission_version: number;
+            /** Mission Base Version */
+            mission_base_version?: string | null;
+            /** Mission Version */
+            mission_version?: string | null;
             /** Model */
             model?: string | null;
             /**
@@ -2458,6 +2484,10 @@ export interface components {
              * @default
              */
             name: string;
+            /** Platform */
+            platform?: string | null;
+            /** Platform Digest */
+            platform_digest?: string | null;
             /** Run Id */
             run_id: string;
             /** Sandbox Ref */

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -2014,12 +2014,14 @@ export interface components {
         };
         /**
          * MissionManifest
-         * @description The `mission.json` v2 object — the shared contract all consumers import.
+         * @description The `mission.json` object (schema 2.0 or 3.0) — the shared contract all consumers import.
          *
          *     Required: schema_version, metadata (incl. metadata.type ∈ {lab, static}; the agent objective
-         *     lives under metadata.objective). `environment` is conditional: required for lab, omitted for
-         *     static (see _check_execution_contract). Everything else defaults empty/None so a minimal bundle
-         *     validates (terrain/intel absent is valid; lab needs environment, static needs attachments).
+         *     lives under metadata.objective) and — on schema 3.0 — the creator-owned SemVer `version`
+         *     (2.0 predates the field and must not carry it; see _check_version_contract). `environment` is
+         *     conditional: required for lab, omitted for static (see _check_execution_contract). Everything
+         *     else defaults empty/None so a minimal bundle validates (terrain/intel absent is valid; lab
+         *     needs environment, static needs attachments).
          */
         MissionManifest: {
             /**
@@ -2053,12 +2055,14 @@ export interface components {
             rubric: components["schemas"]["RubricCriterion"][];
             /**
              * Schema Version
-             * @constant
+             * @enum {string}
              */
-            schema_version: "2.0";
+            schema_version: "2.0" | "3.0";
             /** Source */
             source?: string | null;
             terrain?: components["schemas"]["TerrainSpec"] | null;
+            /** Version */
+            version?: string | null;
         };
         /** MissionMetadata */
         MissionMetadata: {

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -19,7 +19,7 @@ export const runFixture = (over: Partial<RunEntry> = {}): RunEntry => ({
   agent_id: "agent-1",
   agent_version: 1,
   mission: "sqli-login",
-  mission_version: 1,
+  install_revision: 1,
   // Neutral default that contains no mission slug, so tests that query cards by their mission
   // (e.g. /sqli-login/i) resolve via the mission fact, not this label. Tests that assert on the
   // title set an explicit name.

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -48,5 +48,6 @@ export const missionFixture = (
   type: "ctf",
   skills: [],
   technologies: [],
+  platforms: [],
   ...over,
 });

--- a/src/xorcise/core/catalog/__init__.py
+++ b/src/xorcise/core/catalog/__init__.py
@@ -11,6 +11,8 @@ from xorcise.core.catalog.http import HttpCatalogSource
 from xorcise.core.catalog.source import (
     CatalogSource,
     LibraryItem,
+    MissionDetail,
+    PlatformImage,
     PullToken,
     StubCatalogSource,
 )
@@ -20,6 +22,8 @@ __all__ = [
     "CatalogSource",
     "HttpCatalogSource",
     "LibraryItem",
+    "MissionDetail",
+    "PlatformImage",
     "PullToken",
     "StubCatalogSource",
 ]

--- a/src/xorcise/core/catalog/__init__.py
+++ b/src/xorcise/core/catalog/__init__.py
@@ -11,6 +11,7 @@ from xorcise.core.catalog.http import HttpCatalogSource
 from xorcise.core.catalog.source import (
     CatalogSource,
     LibraryItem,
+    MissionBaseRelease,
     MissionDetail,
     PlatformImage,
     PullToken,
@@ -22,6 +23,7 @@ __all__ = [
     "CatalogSource",
     "HttpCatalogSource",
     "LibraryItem",
+    "MissionBaseRelease",
     "MissionDetail",
     "PlatformImage",
     "PullToken",

--- a/src/xorcise/core/catalog/_fixture.py
+++ b/src/xorcise/core/catalog/_fixture.py
@@ -57,7 +57,8 @@ _FREE_LIBRARY_OBJECTIVES: dict[str, str] = {
 # (rubric/checks empty — browse/pull never grades). fetch_manifest returns this on pull.
 FREE_LIBRARY_MANIFESTS: dict[str, MissionManifest] = {
     item.mission_id: MissionManifest(
-        schema_version="2.0",
+        schema_version="3.0",
+        version="1.0.0",
         metadata=MissionMetadata(
             mission_id=item.mission_id,
             name=item.name,

--- a/src/xorcise/core/catalog/http.py
+++ b/src/xorcise/core/catalog/http.py
@@ -17,6 +17,7 @@ from xorcise.core.catalog.source import (
     CatalogSource,
     DeliveryBundle,
     LibraryItem,
+    MissionBaseRelease,
     MissionDetail,
     PlatformImage,
     PullToken,
@@ -104,6 +105,31 @@ class HttpCatalogSource(CatalogSource):
                 served=served,
                 supported=SUPPORTED_SCHEMA_VERSIONS,
             ) from exc
+
+    def mission_base(self) -> MissionBaseRelease | None:
+        """GET /v1/mission-base — 404 (a pre-contract deployment) and any transport failure
+        both degrade to None: the promoted base is display/diagnostic data, and its absence
+        must never take a settings page or doctor run down."""
+        try:
+            resp = self._client.get(f"{self._base}/v1/mission-base")
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            body = resp.json()
+        except (httpx.HTTPError, ValueError):
+            return None
+        version = _opt_str(body.get("mission_base_version"))
+        if version is None:
+            return None
+        image = body.get("image") if isinstance(body.get("image"), dict) else {}
+        raw_major = body.get("required_base_major")
+        return MissionBaseRelease(
+            version=version,
+            required_base_major=int(raw_major) if isinstance(raw_major, int) else None,
+            ref=_opt_str(image.get("ref")),
+            index_digest=_opt_str(image.get("index_digest")),
+            platforms=_platform_images(image.get("platforms")),
+        )
 
     def pull_token(self, mission_id: str) -> PullToken | None:
         resp = self._client.post(f"{self._base}/v1/missions/{mission_id}/pull-token")

--- a/src/xorcise/core/catalog/http.py
+++ b/src/xorcise/core/catalog/http.py
@@ -11,6 +11,7 @@ AWS credentials (published = pullable).
 from __future__ import annotations
 
 import httpx
+from pydantic import ValidationError
 
 from xorcise.core.catalog.source import (
     CatalogSource,
@@ -19,8 +20,12 @@ from xorcise.core.catalog.source import (
     PullToken,
 )
 from xorcise.core.contracts.catalog import CatalogStatus
-from xorcise.core.contracts.errors import NotFoundError, PullError
-from xorcise.core.contracts.mission import MissionManifest
+from xorcise.core.contracts.errors import (
+    NotFoundError,
+    PullError,
+    UnsupportedManifestVersionError,
+)
+from xorcise.core.contracts.mission import SUPPORTED_SCHEMA_VERSIONS, MissionManifest
 
 _TIMEOUT = 10.0
 _DOWNLOAD_TIMEOUT = 60.0  # attachment bundles (pcaps, binaries) can be larger than JSON
@@ -44,7 +49,30 @@ class HttpCatalogSource(CatalogSource):
         if resp.status_code == 404:
             raise NotFoundError(mission_id)
         resp.raise_for_status()
-        return MissionManifest.model_validate(resp.json()["manifest"])
+        payload = resp.json()["manifest"]
+        try:
+            return MissionManifest.model_validate(payload)
+        except ValidationError as exc:
+            # Typed, actionable — never a pydantic traceback. The overwhelmingly likely cause is
+            # a catalog serving a manifest schema newer than this client (the cloud moved first);
+            # the remedy in both arms is the same: upgrade XORCISE.
+            raw = payload.get("schema_version") if isinstance(payload, dict) else None
+            served = raw if isinstance(raw, str) else None
+            if served not in SUPPORTED_SCHEMA_VERSIONS:
+                raise UnsupportedManifestVersionError(
+                    f"mission '{mission_id}' serves manifest schema {served!r}; this XORCISE "
+                    f"reads {', '.join(SUPPORTED_SCHEMA_VERSIONS)} — upgrade XORCISE "
+                    "(e.g. pip install -U xorcise) to pull it",
+                    served=served,
+                    supported=SUPPORTED_SCHEMA_VERSIONS,
+                ) from exc
+            raise UnsupportedManifestVersionError(
+                f"mission '{mission_id}' serves a schema {served} manifest this XORCISE cannot "
+                f"validate ({exc.error_count()} field error(s)) — the catalog and this client "
+                "disagree about the shape; upgrading XORCISE may resolve it",
+                served=served,
+                supported=SUPPORTED_SCHEMA_VERSIONS,
+            ) from exc
 
     def pull_token(self, mission_id: str) -> PullToken | None:
         resp = self._client.post(f"{self._base}/v1/missions/{mission_id}/pull-token")

--- a/src/xorcise/core/catalog/http.py
+++ b/src/xorcise/core/catalog/http.py
@@ -17,6 +17,8 @@ from xorcise.core.catalog.source import (
     CatalogSource,
     DeliveryBundle,
     LibraryItem,
+    MissionDetail,
+    PlatformImage,
     PullToken,
 )
 from xorcise.core.contracts.catalog import CatalogStatus
@@ -45,11 +47,40 @@ class HttpCatalogSource(CatalogSource):
         return tuple(_to_item(row) for row in resp.json().get("catalog", []))
 
     def fetch_manifest(self, mission_id: str) -> MissionManifest:
+        return self.fetch_detail(mission_id).manifest
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        """One GET serves both the manifest and the artifact-identity siblings.
+
+        A pre-contract deployment (prod today) sends only {manifest, image_ref}; every
+        identity field degrades to None/empty and the caller behaves exactly as before."""
         resp = self._client.get(f"{self._base}/v1/missions/{mission_id}")
         if resp.status_code == 404:
             raise NotFoundError(mission_id)
         resp.raise_for_status()
-        payload = resp.json()["manifest"]
+        body = resp.json()
+        manifest = self._validate_manifest(mission_id, body.get("manifest"))
+        image = body.get("image") if isinstance(body.get("image"), dict) else {}
+        base = body.get("mission_base") if isinstance(body.get("mission_base"), dict) else {}
+        digests = base.get("platform_digests")
+        return MissionDetail(
+            manifest=manifest,
+            mission_version=_opt_str(body.get("mission_version")),
+            mission_base_version=_opt_str(body.get("mission_base_version")),
+            content_hash=_opt_str(body.get("content_hash")),
+            pull_ref=_opt_str(image.get("pull_ref")),
+            release_ref=_opt_str(image.get("release_ref")),
+            index_digest=_opt_str(image.get("index_digest")),
+            platforms=_platform_images(image.get("platforms")),
+            base_index_digest=_opt_str(base.get("index_digest")),
+            base_platform_digests=(
+                {str(k): str(v) for k, v in digests.items() if v is not None}
+                if isinstance(digests, dict)
+                else {}
+            ),
+        )
+
+    def _validate_manifest(self, mission_id: str, payload: object) -> MissionManifest:
         try:
             return MissionManifest.model_validate(payload)
         except ValidationError as exc:
@@ -140,11 +171,38 @@ def _to_item(row: dict[str, object]) -> LibraryItem:
         image_size_bytes=_opt_int(row.get("image_size_bytes")),
         attachments_size_bytes=_opt_int(row.get("attachments_size_bytes")),
         download_size_bytes=_opt_int(row.get("download_size_bytes")),
+        # Artifact identity (API1). Absent on a pre-contract catalog -> None/() and the row
+        # browses exactly as before; the values power update detection and platform selection.
+        mission_version=_opt_str(row.get("mission_version")),
+        mission_base_version=_opt_str(row.get("mission_base_version")),
+        index_digest=_opt_str(row.get("index_digest")),
+        platforms=_str_tuple(row.get("platforms")),
     )
 
 
 def _str_tuple(value: object) -> tuple[str, ...]:
     return tuple(str(v) for v in value) if isinstance(value, list) else ()
+
+
+def _platform_images(value: object) -> tuple[PlatformImage, ...]:
+    """Detail-response platform entries ({os, architecture, digest, variant?}) — entries
+    missing the identifying pair are dropped, never fatal (browse/pull must survive a
+    malformed row)."""
+    if not isinstance(value, list):
+        return ()
+    out: list[PlatformImage] = []
+    for entry in value:
+        if not isinstance(entry, dict) or "os" not in entry or "architecture" not in entry:
+            continue
+        out.append(
+            PlatformImage(
+                os=str(entry["os"]),
+                architecture=str(entry["architecture"]),
+                digest=_opt_str(entry.get("digest")),
+                variant=_opt_str(entry.get("variant")),
+            )
+        )
+    return tuple(out)
 
 
 def _opt_str(value: object) -> str | None:

--- a/src/xorcise/core/catalog/source.py
+++ b/src/xorcise/core/catalog/source.py
@@ -12,7 +12,7 @@ go through the ingest/builder path (that is reserved for Your Own custom mission
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from xorcise.core.contracts.catalog import CatalogStatus
 from xorcise.core.contracts.errors import NotFoundError
@@ -35,6 +35,51 @@ class LibraryItem:
     image_size_bytes: int | None = None
     attachments_size_bytes: int | None = None
     download_size_bytes: int | None = None
+    # Artifact identity summary (mission-versioning contract API1). All optional — a
+    # pre-contract catalog (prod today) serves none of them and the row must still browse.
+    mission_version: str | None = None  # creator SemVer, e.g. "1.4.2"
+    mission_base_version: str | None = None  # base SemVer the artifact was fused on
+    index_digest: str | None = None  # current OCI index digest (update detection)
+    platforms: tuple[str, ...] = ()  # validated platforms, e.g. ("linux/amd64", "linux/arm64")
+
+
+@dataclass(frozen=True)
+class PlatformImage:
+    """One validated platform child of a mission's OCI index (detail response entry).
+
+    `variant` is present when the child manifest declares one (buildx stamps arm64 children
+    "v8") — without it linux/arm64 and linux/arm64/v8 would be indistinguishable."""
+
+    os: str
+    architecture: str
+    digest: str | None = None
+    variant: str | None = None
+
+    @property
+    def platform(self) -> str:
+        """The `os/architecture` form Docker speaks (variant deliberately excluded)."""
+        return f"{self.os}/{self.architecture}"
+
+
+@dataclass(frozen=True)
+class MissionDetail:
+    """GET /v1/missions/{id} — the manifest plus the current-delivery identity siblings.
+
+    Everything beside `manifest` is optional: a pre-contract catalog (prod today) serves only
+    the manifest and an image ref, and the client must degrade to exactly the old behaviour.
+    `platform_digests` on the base is keyed by BARE architecture ("amd64") and scoped to the
+    platforms this mission was actually fused for — deliberately different shapes upstream."""
+
+    manifest: MissionManifest
+    mission_version: str | None = None
+    mission_base_version: str | None = None
+    content_hash: str | None = None  # bare lowercase hex, never sha256:-prefixed
+    pull_ref: str | None = None  # the moving :latest pointer — convenience, never identity
+    release_ref: str | None = None  # immutable <mission-version>-base<base-version> ref
+    index_digest: str | None = None
+    platforms: tuple[PlatformImage, ...] = ()
+    base_index_digest: str | None = None
+    base_platform_digests: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -79,6 +124,14 @@ class CatalogSource(ABC):
         """The full mission.json for a library id (pulled alongside the image).
 
         Raises NotFoundError if the id is not in the catalog."""
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        """The full current-delivery contract for one mission: manifest + artifact identity.
+
+        Default wraps fetch_manifest with no identity siblings — the honest answer for a
+        source that predates the versioning contract (the stub, or any 2.0-era deployment).
+        Raises NotFoundError if the id is not in the catalog."""
+        return MissionDetail(manifest=self.fetch_manifest(mission_id))
 
     def pull_token(self, mission_id: str) -> PullToken | None:
         """Registry creds to pull this mission's image. None ⇒ the image needs no auth

--- a/src/xorcise/core/catalog/source.py
+++ b/src/xorcise/core/catalog/source.py
@@ -83,6 +83,21 @@ class MissionDetail:
 
 
 @dataclass(frozen=True)
+class MissionBaseRelease:
+    """GET /v1/mission-base — the currently promoted mission-base release (contract §27).
+
+    Version visibility for settings/diagnostics; per-mission base identity comes from the
+    detail response's mission_base block, NOT from here (the promoted base need not be the
+    base a given mission was fused on)."""
+
+    version: str  # e.g. "2.0.0"
+    required_base_major: int | None = None
+    ref: str | None = None  # ghcr.io/xorcise-ai/mission-base:<version>
+    index_digest: str | None = None
+    platforms: tuple[PlatformImage, ...] = ()
+
+
+@dataclass(frozen=True)
 class PullToken:
     """Short-lived, single-repo ECR docker-login creds minted by the catalog's pull-token broker.
 
@@ -136,6 +151,12 @@ class CatalogSource(ABC):
     def pull_token(self, mission_id: str) -> PullToken | None:
         """Registry creds to pull this mission's image. None ⇒ the image needs no auth
         (the stub's fixture images); the real HttpCatalogSource mints a scoped ECR token."""
+        return None
+
+    def mission_base(self) -> MissionBaseRelease | None:
+        """The currently promoted mission-base release, or None when this source cannot say
+        (the stub, a pre-contract deployment whose /v1/mission-base 404s, or a network
+        failure). None means UNKNOWN — callers render nothing, never a fabricated version."""
         return None
 
     def fetch_delivery(self, mission_id: str) -> DeliveryBundle | None:

--- a/src/xorcise/core/cli/_diagnostics.py
+++ b/src/xorcise/core/cli/_diagnostics.py
@@ -265,6 +265,47 @@ def control_plane(container: str = "headscale", *, timeout: float = 5.0) -> Chec
     return Check("control plane", False, f"{container!r} is not reachable", _PLANE_FIX)
 
 
+def mission_base_release() -> Check:
+    """§36 version visibility: the base MAJOR this client requires, beside the release the
+    catalog currently promotes. Informational — a pre-contract catalog (prod today) simply
+    does not serve the endpoint, which is normal and must not colour the verdict; a promoted
+    MAJOR this client cannot run is worth a warning (new pulls would be refused at run time).
+    """
+    from xorcise.core.config import get_settings
+    from xorcise.core.rest.catalog_view import build_catalog_source
+    from xorcise.core.runner.docker.build import REQUIRED_BASE_MAJOR
+
+    try:
+        promoted = build_catalog_source(get_settings()).mission_base()
+    except Exception:  # noqa: BLE001 — a remote probe must never crash `doctor`
+        promoted = None
+    if promoted is None:
+        return Check(
+            "mission base",
+            True,
+            f"client requires base major {REQUIRED_BASE_MAJOR} "
+            "(catalog reports no promoted release)",
+        )
+    try:
+        promoted_major = int(promoted.version.split(".", 1)[0])
+    except ValueError:
+        promoted_major = None
+    if promoted_major is not None and promoted_major > REQUIRED_BASE_MAJOR:
+        return Check(
+            "mission base",
+            True,
+            f"catalog promotes base {promoted.version}, but this client runs major "
+            f"{REQUIRED_BASE_MAJOR} — newly pulled missions will be refused",
+            "upgrade XORCISE (e.g. pip install -U xorcise)",
+            level="warning",
+        )
+    return Check(
+        "mission base",
+        True,
+        f"client requires major {REQUIRED_BASE_MAJOR}; catalog promotes {promoted.version}",
+    )
+
+
 def nested_containers() -> Check:
     """Can this host run a mission's containers INSIDE the run container?
 

--- a/src/xorcise/core/cli/_errors.py
+++ b/src/xorcise/core/cli/_errors.py
@@ -34,6 +34,7 @@ _EXAMPLES = {
     "xorcise agent delete": "xorcise agent delete my-agent",
     "xorcise mission show": "xorcise mission show aviary-access",
     "xorcise mission pull": "xorcise mission pull aviary-access",
+    "xorcise mission update": "xorcise mission update aviary-access",
     "xorcise mission delete": "xorcise mission delete aviary-access",
     "xorcise mission rm": "xorcise mission rm aviary-access",
     "xorcise mission ingest": "xorcise mission ingest ./my-mission-bundle",

--- a/src/xorcise/core/cli/commands/agent.py
+++ b/src/xorcise/core/cli/commands/agent.py
@@ -255,7 +255,7 @@ def agent_history(
             fmt_score(r["deterministic"]),
             fmt_score(r["judge"]),
             f"v{c.get('agent_version', 1)}",
-            f"v{c.get('mission_version', 1)}",
+            f"v{c.get('mission_version') or c.get('install_revision', 1)}",
             str(c.get("model") or "not disclosed"),
         )
     print_table(table)

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -28,6 +28,7 @@ from xorcise.core.cli._diagnostics import (
     docker_present,
     external_control_plane,
     home_present,
+    mission_base_release,
     nested_containers,
     openssl_present,
     probe_channel,
@@ -686,6 +687,8 @@ def doctor(
         )
         raise typer.Exit(1) from exc
     env_checks = _environment_checks()
+    # §36 version visibility: what base this client runs vs what the catalog promotes.
+    env_checks.append(mission_base_release())
     # Only under `doctor` — it starts a privileged container, so it must not join the check list
     # `up` runs (and `up` must work on a host that cannot nest: static missions and the UI need
     # nothing nested). Gated on the docker daemon being up, so a Docker-less host gets one

--- a/src/xorcise/core/cli/commands/mission.py
+++ b/src/xorcise/core/cli/commands/mission.py
@@ -138,7 +138,11 @@ def list_missions(
             str(c.get("mission_id") or DASH),
             str(c.get("name") or DASH),
             difficulty_label(c.get("proficiency")),
-            "Installed" if c.get("installed") else "Available",
+            # §35: ONE primary status. An installed row whose catalog artifact moved says so
+            # here; `xorcise mission update <id>` is the one action that clears it.
+            ("Update available" if c.get("update_available") else "Installed")
+            if c.get("installed")
+            else "Available",
             size_label(c.get("download_size_bytes")),
         )
     print_table(table)
@@ -267,6 +271,35 @@ def pull_mission_cmd(
         "check [value]xorcise mission list[/value]"
     )
     raise typer.Exit(3)
+
+
+@mission_app.command("update")
+def update_mission_cmd(
+    mission_id: str = typer.Argument(..., help=_MISSION_HELP),
+) -> None:
+    """Update an installed library mission to the catalog's current release (re-pull in \
+place). Already-current installs are a no-op."""
+    client = RestClient()
+    entry = resolve_mission(client, mission_id)
+    mission_id = str(entry["mission_id"])
+    name = str(entry.get("name") or mission_id)
+    if not entry.get("installed"):
+        fail(
+            f"'{name}' is not installed — nothing to update",
+            see=(f"xorcise mission pull {mission_id}",),
+        )
+    # One synchronous call: the server re-pulls in place and answers when the swap is done
+    # (or immediately, when the install already matches the catalog). Image layers shared with
+    # the previous release are already local, so an update usually moves far fewer bytes than
+    # the first pull — but a big delta can take a while, hence the generous timeout.
+    view = client.post(f"/missions/{mission_id}/update", json={}, timeout=1800.0)
+    if not view.get("updated"):
+        console.print(f"'{name}' is already up to date", markup=False)
+        return
+    e = view.get("entry") or {}
+    label = str(e.get("name") or name)
+    console.print(f"updated '{label}' ({mission_id})", markup=False)
+    next_step(f"xorcise run create --agent <name> --mission {mission_id}")
 
 
 @mission_app.command("delete")

--- a/src/xorcise/core/contracts/catalog.py
+++ b/src/xorcise/core/contracts/catalog.py
@@ -65,6 +65,15 @@ class CatalogEntry(_Frozen):
     mission_base_version: str | None = None
     index_digest: str | None = None
     platforms: tuple[str, ...] = ()
+    # Update status for an INSTALLED library row (§34): the recorded install digest vs the
+    # catalog's current one — digest first, release ref as the pre-digest fallback. None =
+    # unknown (nothing to compare: your_own, catalog unreachable, or no identity on either
+    # side); False = up to date; True = the catalog's current artifact differs. The current_*
+    # pair carries the catalog's CURRENT SemVers so the UI can explain WHY ("Mission 1.4.2 →
+    # 1.5.0 / Mission base 2.4.0 → 2.4.1") under the single primary status (§35).
+    update_available: bool | None = None
+    current_mission_version: str | None = None
+    current_mission_base_version: str | None = None
 
 
 class CatalogStatus(_Frozen):

--- a/src/xorcise/core/contracts/catalog.py
+++ b/src/xorcise/core/contracts/catalog.py
@@ -57,6 +57,14 @@ class CatalogEntry(_Frozen):
     base_major: int | None = None
     compatible: bool | None = None
     compat_hint: str | None = None
+    # Artifact identity (mission-versioning contract API1/§25): the creator-owned mission
+    # SemVer, the base SemVer the artifact was fused on, the OCI index digest (the strongest
+    # update-detection signal) and the validated platforms. All optional — a pre-contract
+    # catalog serves none of them, and an installed row carries what its install recorded.
+    mission_version: str | None = None
+    mission_base_version: str | None = None
+    index_digest: str | None = None
+    platforms: tuple[str, ...] = ()
 
 
 class CatalogStatus(_Frozen):

--- a/src/xorcise/core/contracts/config.py
+++ b/src/xorcise/core/contracts/config.py
@@ -157,6 +157,18 @@ class CatalogStatusView(_Frozen):
     last_sync: str | None = None
 
 
+class MissionBaseView(_Frozen):
+    """The mission-base picture for settings/diagnostics (contract §27/§36): what THIS client
+    requires (the compatibility MAJOR it was built for) beside what the catalog currently
+    promotes. The promoted side is None when the catalog predates the endpoint (prod today)
+    or is unreachable — unknown, never fabricated."""
+
+    required_major: int
+    client_version: str = ""  # this XORCISE client's own package version
+    promoted_version: str | None = None  # e.g. "2.0.0" — the promoted base SemVer
+    promoted_index_digest: str | None = None
+
+
 class SystemInfo(_Frozen):
     """Read-only Reflect view powering the GUI System / Modules / Catalog cards."""
 
@@ -168,3 +180,4 @@ class SystemInfo(_Frozen):
     home: str = ""  # resolved XORCISE_HOME (the install path)
     db_url: str = ""  # the active database url (sqlite path under home by default)
     topology: Literal["local", "distributed"] = "local"
+    mission_base: MissionBaseView | None = None  # §36 version visibility (None: very old server)

--- a/src/xorcise/core/contracts/control.py
+++ b/src/xorcise/core/contracts/control.py
@@ -31,6 +31,47 @@ class MissionRef(_Frozen):
     image: str  # OCI image ref, e.g. ghcr.io/xorcise/mission-xyz:1.2.3
 
 
+class InstalledImageIdentity(_Frozen):
+    """The mission-image identity of an install (mission-versioning contract §30).
+
+    `release_ref` (immutable `<mission-version>-base<base-version>` tag) and the digests are
+    identity; `pull_ref` (the moving `:latest` pointer) is delivery convenience and MUST never
+    be treated as identity. `platform`/`platform_digest` record what was ACTUALLY pulled for
+    this machine, not what the catalog offers. All optional: a pre-contract catalog serves
+    none of it."""
+
+    pull_ref: str | None = None
+    release_ref: str | None = None
+    index_digest: str | None = None  # OCI index digest — the strongest update-check signal
+    platform: str | None = None  # e.g. "linux/amd64" — the platform this install pulled
+    platform_digest: str | None = None  # per-platform manifest digest of what executes
+
+
+class InstalledBaseIdentity(_Frozen):
+    """The mission-base THIS artifact was fused onto (§30) — not the currently promoted base;
+    the two diverge the moment a newer base is promoted without a fleet backfill."""
+
+    version: str | None = None  # base SemVer, e.g. "2.0.0"
+    index_digest: str | None = None  # GHCR base index digest
+    platform_digest: str | None = None  # base child digest for the pulled platform
+
+
+class MissionInstallIdentity(_Frozen):
+    """The §30 slice of installed.json: what exactly this machine installed.
+
+    Splatted to the record's top level by InstalledMission.to_record so the on-disk shape
+    matches the contract's recommended layout. Written at pull time from the catalog detail
+    response + a post-pull image inspect; never re-resolved later (evidence copies it at run
+    create and must not depend on the future value of any floating tag)."""
+
+    mission_version: str | None = None  # creator SemVer projected by the catalog
+    mission_base_version: str | None = None
+    content_hash: str | None = None  # bare hex — identical to ai.xorcise.content.hash
+    image: InstalledImageIdentity | None = None
+    mission_base: InstalledBaseIdentity | None = None
+    pulled_at: str | None = None  # ISO-8601 UTC of the pull
+
+
 class NetworkSpec(_Frozen):
     """Per-run network spec the runner needs to fence the run.
 

--- a/src/xorcise/core/contracts/errors.py
+++ b/src/xorcise/core/contracts/errors.py
@@ -61,6 +61,21 @@ class MissionNotInCatalogError(PullError):
     """The id is not installed and not in the catalog — nothing to pull."""
 
 
+class UnsupportedManifestVersionError(PullError):
+    """The catalog served a mission manifest this XORCISE cannot validate.
+
+    Either the manifest declares a schema_version outside SUPPORTED_SCHEMA_VERSIONS (a newer
+    cloud than this client — the remedy is upgrading XORCISE), or a supported-version document
+    failed contract validation (catalog and client disagree about the shape). Typed so the
+    CLI/REST surfaces render the remedy instead of a pydantic traceback; `served`/`supported`
+    carry the versions for programmatic use. A PullError: nothing was installed."""
+
+    def __init__(self, message: str, *, served: str | None, supported: tuple[str, ...]) -> None:
+        super().__init__(message)
+        self.served = served
+        self.supported = supported
+
+
 class PullCancelled(ContractError):
     """The in-flight pull was cancelled by request before install completed. NOT a failure:
     install_pulled is the only writer (atomic), so a cancel before it leaves the mission

--- a/src/xorcise/core/contracts/mission.py
+++ b/src/xorcise/core/contracts/mission.py
@@ -15,10 +15,21 @@ Boundary notes:
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+#: Manifest schema versions this client reads. 2.0 is the pre-versioning shape — still served
+#: for history and by a pre-contract catalog (prod today) — and 3.0 adds the required
+#: creator-owned `version` (mission-versioning contract, amendment A3).
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("2.0", "3.0")
+
+#: Creator-owned mission SemVer: exactly MAJOR.MINOR.PATCH — no leading zeros, no
+#: pre-release/build suffix. This is the served pattern verbatim (contract MV1 as amended by
+#: A11); ingest refuses anything looser, so accepting more here would only defer the failure.
+MISSION_VERSION_PATTERN = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
 
 
 class _Frozen(BaseModel):
@@ -148,14 +159,20 @@ class TerrainSpec(_Frozen):
 
 
 class MissionManifest(_Frozen):
-    """The `mission.json` v2 object — the shared contract all consumers import.
+    """The `mission.json` object (schema 2.0 or 3.0) — the shared contract all consumers import.
 
     Required: schema_version, metadata (incl. metadata.type ∈ {lab, static}; the agent objective
-    lives under metadata.objective). `environment` is conditional: required for lab, omitted for
-    static (see _check_execution_contract). Everything else defaults empty/None so a minimal bundle
-    validates (terrain/intel absent is valid; lab needs environment, static needs attachments)."""
+    lives under metadata.objective) and — on schema 3.0 — the creator-owned SemVer `version`
+    (2.0 predates the field and must not carry it; see _check_version_contract). `environment` is
+    conditional: required for lab, omitted for static (see _check_execution_contract). Everything
+    else defaults empty/None so a minimal bundle validates (terrain/intel absent is valid; lab
+    needs environment, static needs attachments)."""
 
-    schema_version: Literal["2.0"]
+    schema_version: Literal["2.0", "3.0"]
+    # The creator-owned mission SemVer (contract MV1): REQUIRED on schema 3.0, absent on 2.0.
+    # Projected by the platform as the public `mission_version`; the runtime's own base SemVer
+    # travels separately as `mission_base_version` and is never authored here.
+    version: str | None = None
     metadata: MissionMetadata
     # Conditionally optional (static-mission-support): a "lab" mission REQUIRES this (the
     # deployable container/network source); a "static" mission omits it entirely. Enforced by
@@ -195,6 +212,24 @@ class MissionManifest(_Frozen):
                 "deployed — remove it from the manifest"
             )
         return None
+
+    @model_validator(mode="after")
+    def _check_version_contract(self) -> MissionManifest:
+        """Enforce the schema/version pairing: 3.0 requires the creator SemVer, 2.0 forbids it.
+
+        2.0 must refuse the field for parity with every other 2.0 consumer (`extra="forbid"`
+        everywhere): a 2.0 document carrying `version` never existed in the wild and accepting
+        one here would mint a shape no other validator reads."""
+        if self.schema_version == "3.0" and self.version is None:
+            raise ValueError("manifest schema 3.0 requires 'version' (the mission's SemVer)")
+        if self.schema_version == "2.0" and self.version is not None:
+            raise ValueError("'version' requires manifest schema 3.0 (2.0 predates the field)")
+        if self.version is not None and not re.fullmatch(MISSION_VERSION_PATTERN, self.version):
+            raise ValueError(
+                "version must be MAJOR.MINOR.PATCH with no leading zeros and no "
+                f"pre-release/build suffix (e.g. 1.4.2), got {self.version!r}"
+            )
+        return self
 
     @model_validator(mode="after")
     def _check_execution_contract(self) -> MissionManifest:

--- a/src/xorcise/core/contracts/reporting.py
+++ b/src/xorcise/core/contracts/reporting.py
@@ -23,7 +23,12 @@ class ResultConditions(BaseModel):
     budget_seconds: int = 0
     sandbox_ref: str | None = None  # the mission image the run executed against
     agent_version: int = 1  # monotonic agent version at run creation
-    mission_version: int = 1  # monotonic mission version at run creation
+    install_revision: int = 1  # the mission's monotonic local install counter at run creation
+    # Versioning-contract labels for the artifact the run executed (None ⇒ pre-contract):
+    # the creator SemVer, the base SemVer it was fused on, and the executed platform.
+    mission_version: str | None = None
+    mission_base_version: str | None = None
+    platform: str | None = None
     # Disclosure provenance: how many intel this run was disclosed (kind="intel" submissions). The
     # delivery layer counts the run-control submission store and fills this in (no results-table
     # migration — the rows already exist); grading never reads it.

--- a/src/xorcise/core/contracts/run.py
+++ b/src/xorcise/core/contracts/run.py
@@ -41,7 +41,17 @@ class RunEntry(BaseModel):
     model: str | None = None  # disclosed model (agent's declared model at create time)
     sandbox_ref: str | None = None  # disclosed sandbox (mission image at create time)
     agent_version: int = 1  # agent monotonic version at create time
-    mission_version: int = 1  # mission monotonic version at create time
+    install_revision: int = 1  # mission's monotonic LOCAL install counter at create time
+    # Artifact provenance copied from installed.json at create time (contract §31): the
+    # creator SemVer (the public mission_version — a string, per the naming contract §25),
+    # the base SemVer, the bundle hash, and what exactly this machine pulled and executed.
+    # All None for a your_own fuse or a pre-contract install.
+    mission_version: str | None = None
+    mission_base_version: str | None = None
+    content_hash: str | None = None
+    platform: str | None = None
+    index_digest: str | None = None
+    platform_digest: str | None = None
     source_agent: str = "generic"  # rendering-agent kind, snapshotted at create time
     intel_policy: str = "all"  # per-run intel disclosure policy (runcontrol.intel_policy grammar)
     # Server-side receipt time of the run's newest OTLP export (trace OR log signal). None until

--- a/src/xorcise/core/db/migrations/versions/0002_run_provenance.py
+++ b/src/xorcise/core/db/migrations/versions/0002_run_provenance.py
@@ -1,0 +1,67 @@
+"""run/result artifact provenance (mission-versioning contract §31)
+
+Revision ID: 0002_run_provenance
+Revises: 0001_initial
+Create Date: 2026-08-19
+
+Two changes, one story. The int column called `mission_version` was the mission's monotonic
+LOCAL install counter — renamed `install_revision`, because the versioning contract reserves
+`mission_version` for the creator-owned SemVer string. Then the provenance the contract wants
+copied immutably into run evidence at create time: the mission SemVer, the base SemVer it was
+fused on, the bundle content hash, and exactly what this machine pulled and executed (platform,
+index digest, per-platform digest). Results carry the labelling subset (SemVers + platform);
+the digest chain lives on the run row they share a run_id with.
+
+All new columns are nullable: pre-contract runs, and runs of your_own local fuses, have no
+artifact identity — that is a fact about the artifact, not missing data.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002_run_provenance"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Two batch blocks per table: SQLite batch mode rebuilds the table per block, and the
+    # rename must complete before a NEW column may reuse the old name.
+    with op.batch_alter_table("runs") as b:
+        b.alter_column("mission_version", new_column_name="install_revision")
+    with op.batch_alter_table("runs") as b:
+        b.add_column(sa.Column("mission_version", sa.String(length=32), nullable=True))
+        b.add_column(sa.Column("mission_base_version", sa.String(length=32), nullable=True))
+        b.add_column(sa.Column("content_hash", sa.String(length=64), nullable=True))
+        b.add_column(sa.Column("platform", sa.String(length=32), nullable=True))
+        b.add_column(sa.Column("index_digest", sa.String(length=96), nullable=True))
+        b.add_column(sa.Column("platform_digest", sa.String(length=96), nullable=True))
+
+    with op.batch_alter_table("results") as b:
+        b.alter_column("mission_version", new_column_name="install_revision")
+    with op.batch_alter_table("results") as b:
+        b.add_column(sa.Column("mission_version", sa.String(length=32), nullable=True))
+        b.add_column(sa.Column("mission_base_version", sa.String(length=32), nullable=True))
+        b.add_column(sa.Column("platform", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("results") as b:
+        b.drop_column("platform")
+        b.drop_column("mission_base_version")
+        b.drop_column("mission_version")
+    with op.batch_alter_table("results") as b:
+        b.alter_column("install_revision", new_column_name="mission_version")
+
+    with op.batch_alter_table("runs") as b:
+        b.drop_column("platform_digest")
+        b.drop_column("index_digest")
+        b.drop_column("platform")
+        b.drop_column("content_hash")
+        b.drop_column("mission_base_version")
+        b.drop_column("mission_version")
+    with op.batch_alter_table("runs") as b:
+        b.alter_column("install_revision", new_column_name="mission_version")

--- a/src/xorcise/core/missions/ingest.py
+++ b/src/xorcise/core/missions/ingest.py
@@ -13,7 +13,7 @@ import zipfile
 from collections.abc import Callable
 from pathlib import Path
 
-from xorcise.core.contracts.control import MissionRef
+from xorcise.core.contracts.control import MissionInstallIdentity, MissionRef
 from xorcise.core.contracts.mission import MissionManifest
 from xorcise.core.missions.builder import BundleBuilder
 from xorcise.core.missions.errors import (
@@ -72,6 +72,7 @@ def _atomic_install(
     install_root: Path,
     populate_staging: Callable[[Path], None],
     origin: Origin,
+    identity: MissionInstallIdentity | None = None,
 ) -> InstalledMission:
     """Shared staging → atomic swap for both install paths.
 
@@ -104,7 +105,7 @@ def _atomic_install(
     for leftover in (staging, backup):
         if leftover.exists():
             shutil.rmtree(leftover)
-    version = existing.version + 1 if existing is not None else 1  # monotonic bump
+    revision = existing.install_revision + 1 if existing is not None else 1  # monotonic bump
     try:
         populate_staging(staging)
         record = InstalledMission(
@@ -112,8 +113,9 @@ def _atomic_install(
             root=final,
             manifest=manifest,
             mission_ref=mission_ref,
-            version=version,
+            install_revision=revision,
             origin=origin,
+            identity=identity,
         )
         (staging / INSTALLED_FILE).write_text(record.to_record())
         if final.exists():
@@ -152,6 +154,7 @@ def install_pulled(
     mission_ref: MissionRef,
     install_root: Path,
     delivery_zip: bytes | None = None,
+    identity: MissionInstallIdentity | None = None,
 ) -> InstalledMission:
     """Record a pulled prebuilt-image mission — manifest from the catalog, no builder.
 
@@ -173,4 +176,5 @@ def install_pulled(
         install_root=install_root,
         populate_staging=populate,
         origin="library",  # pulled from the remote XORCISE catalog
+        identity=identity,  # §30 slice from the catalog detail + post-pull inspect
     )

--- a/src/xorcise/core/missions/preflight.py
+++ b/src/xorcise/core/missions/preflight.py
@@ -8,10 +8,8 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from xorcise.core.contracts.mission import MissionManifest
+from xorcise.core.contracts.mission import SUPPORTED_SCHEMA_VERSIONS, MissionManifest
 from xorcise.core.missions.errors import PreflightError
-
-_SUPPORTED = "2.0"
 
 
 def preflight(bundle_dir: Path) -> MissionManifest:
@@ -28,8 +26,11 @@ def preflight(bundle_dir: Path) -> MissionManifest:
     version = raw.get("schema_version")
     if version is None:
         raise PreflightError("missing required field: schema_version")
-    if version != _SUPPORTED:
-        raise PreflightError(f"unsupported schema version: {version} (supported: {_SUPPORTED})")
+    if version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise PreflightError(
+            f"unsupported schema version: {version} "
+            f"(supported: {', '.join(SUPPORTED_SCHEMA_VERSIONS)})"
+        )
 
     try:
         manifest = MissionManifest.model_validate(raw)

--- a/src/xorcise/core/missions/runtime.py
+++ b/src/xorcise/core/missions/runtime.py
@@ -16,7 +16,7 @@ from typing import Literal, cast
 
 from pydantic import ValidationError
 
-from xorcise.core.contracts.control import MissionRef
+from xorcise.core.contracts.control import MissionInstallIdentity, MissionRef
 from xorcise.core.contracts.mission import (
     Attachment,
     Check,
@@ -43,8 +43,39 @@ class InstalledMission:
     root: Path
     manifest: MissionManifest
     mission_ref: MissionRef
-    version: int = 1  # monotonic; bumped on re-install of the same slug
+    # Monotonic local install counter, bumped on re-install of the same slug. Renamed from
+    # `version`: the versioning contract reserves `mission_version` for the creator SemVer
+    # string, and an int called `version` beside it invited exactly that confusion.
+    install_revision: int = 1
     origin: Origin = "your_own"  # legacy records (no key) resolve to your_own
+    # The §30 identity slice: what exactly this machine installed (creator SemVer, base
+    # SemVer, content hash, image + base digests, pulled platform). None for a your_own
+    # local fuse and for installs from a pre-contract catalog.
+    identity: MissionInstallIdentity | None = None
+
+    @property
+    def mission_version(self) -> str | None:
+        """The creator-owned mission SemVer this install carries, or None (pre-contract)."""
+        return self.identity.mission_version if self.identity else None
+
+    @property
+    def mission_base_version(self) -> str | None:
+        """The base SemVer this artifact was fused on, or None (pre-contract)."""
+        return self.identity.mission_base_version if self.identity else None
+
+    @property
+    def index_digest(self) -> str | None:
+        """The installed artifact's OCI index digest — the strongest update-check signal."""
+        if self.identity is None or self.identity.image is None:
+            return None
+        return self.identity.image.index_digest
+
+    @property
+    def platform(self) -> str | None:
+        """The platform this install actually pulled (e.g. "linux/amd64"), or None."""
+        if self.identity is None or self.identity.image is None:
+            return None
+        return self.identity.image.platform
 
     @property
     def is_static(self) -> bool:
@@ -80,26 +111,43 @@ class InstalledMission:
         return self.manifest.checks
 
     def to_record(self) -> str:
-        return json.dumps(
-            {
-                "version": self.version,
-                "origin": self.origin,
-                "manifest": self.manifest.model_dump(mode="json"),
-                "mission_ref": self.mission_ref.model_dump(mode="json"),
-            },
-            indent=2,
-        )
+        record: dict[str, object] = {
+            "install_revision": self.install_revision,
+            "origin": self.origin,
+            "manifest": self.manifest.model_dump(mode="json"),
+            "mission_ref": self.mission_ref.model_dump(mode="json"),
+        }
+        if self.identity is not None:
+            # Splatted to the top level so the on-disk shape matches the contract's §30
+            # recommended layout; absent keys (a partial identity) are simply not written.
+            record |= self.identity.model_dump(mode="json", exclude_none=True)
+        return json.dumps(record, indent=2)
+
+    # The §30 keys that live at the record's top level beside the legacy four.
+    _IDENTITY_KEYS = (
+        "mission_version",
+        "mission_base_version",
+        "content_hash",
+        "image",
+        "mission_base",
+        "pulled_at",
+    )
 
     @classmethod
     def from_root(cls, root: Path) -> InstalledMission:
         data = json.loads((root / INSTALLED_FILE).read_text())
+        identity_data = {k: data[k] for k in cls._IDENTITY_KEYS if k in data}
         return cls(
             slug=root.name,
             root=root,
             manifest=MissionManifest.model_validate(data["manifest"]),
             mission_ref=MissionRef.model_validate(data["mission_ref"]),
-            version=int(data.get("version", 1)),  # legacy records without key → 1
+            # Records written before the rename carry the counter as "version" → read either.
+            install_revision=int(data.get("install_revision", data.get("version", 1))),
             origin=cast(Origin, data.get("origin", "your_own")),  # legacy records → your_own
+            identity=(
+                MissionInstallIdentity.model_validate(identity_data) if identity_data else None
+            ),
         )
 
 

--- a/src/xorcise/core/missions/runtime.py
+++ b/src/xorcise/core/missions/runtime.py
@@ -78,6 +78,18 @@ class InstalledMission:
         return self.identity.image.platform
 
     @property
+    def content_hash(self) -> str | None:
+        """The bundle content hash the catalog served for this artifact, or None."""
+        return self.identity.content_hash if self.identity else None
+
+    @property
+    def platform_digest(self) -> str | None:
+        """The per-platform manifest digest of what executes here, or None."""
+        if self.identity is None or self.identity.image is None:
+            return None
+        return self.identity.image.platform_digest
+
+    @property
     def is_static(self) -> bool:
         return self.manifest.is_static
 

--- a/src/xorcise/core/reporting/models.py
+++ b/src/xorcise/core/reporting/models.py
@@ -37,9 +37,17 @@ class ResultRow(Base):
     agent_version: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )
-    mission_version: Mapped[int] = mapped_column(
+    install_revision: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )
+    # Versioning-contract provenance snapshotted into the result's disclosed conditions.
+    # The full digest chain lives on the run row (shared run_id); the result carries what a
+    # report and a track record need to LABEL the artifact.
+    mission_version: Mapped[str | None] = mapped_column(String(32), nullable=True, default=None)
+    mission_base_version: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )
+    platform: Mapped[str | None] = mapped_column(String(32), nullable=True, default=None)
     partial: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="0"
     )

--- a/src/xorcise/core/reporting/render.py
+++ b/src/xorcise/core/reporting/render.py
@@ -172,7 +172,13 @@ def _metadata_rows(ctx: RunReportContext) -> list[tuple[str, str]]:
     agent = ctx.agent_name or ctx.run.agent_id
     return [
         ("Name", ctx.run.name or ctx.run.mission),
-        ("Mission", f"{ctx.run.mission} v{ctx.conditions.mission_version}"),
+        # Prefer the creator SemVer ("v1.4.2"); a pre-contract run keeps its local
+        # install-revision label ("v2"), exactly what it displayed before.
+        (
+            "Mission",
+            f"{ctx.run.mission} "
+            f"v{ctx.conditions.mission_version or ctx.conditions.install_revision}",
+        ),
         ("Agent", f"{agent} v{ctx.conditions.agent_version}"),
         ("Harness", ctx.run.source_agent or "generic"),
         ("Started", _ts(ctx.run.created_at)),

--- a/src/xorcise/core/reporting/repository.py
+++ b/src/xorcise/core/reporting/repository.py
@@ -28,7 +28,10 @@ def _to_entry(row: ResultRow) -> AgentHistoryEntry:
             budget_seconds=row.budget_seconds,
             sandbox_ref=row.sandbox_ref,
             agent_version=row.agent_version,
+            install_revision=row.install_revision,
             mission_version=row.mission_version,
+            mission_base_version=row.mission_base_version,
+            platform=row.platform,
         ),
         partial=row.partial,
         partial_trigger=row.partial_trigger,
@@ -72,7 +75,10 @@ def record_result(
             budget_seconds=conditions.budget_seconds,
             sandbox_ref=conditions.sandbox_ref,
             agent_version=conditions.agent_version,
+            install_revision=conditions.install_revision,
             mission_version=conditions.mission_version,
+            mission_base_version=conditions.mission_base_version,
+            platform=conditions.platform,
             partial=partial,
             partial_trigger=partial_trigger,
             stats_json=stats.model_dump_json() if stats is not None else "",
@@ -121,7 +127,10 @@ def result_conditions(run_id: str) -> ResultConditions | None:
             budget_seconds=row.budget_seconds,
             sandbox_ref=row.sandbox_ref,
             agent_version=row.agent_version,
+            install_revision=row.install_revision,
             mission_version=row.mission_version,
+            mission_base_version=row.mission_base_version,
+            platform=row.platform,
         )
 
 

--- a/src/xorcise/core/rest/catalog_view.py
+++ b/src/xorcise/core/rest/catalog_view.py
@@ -94,6 +94,12 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 base_major=compat.base_major,
                 compatible=compat.compatible,
                 compat_hint=compat.hint,
+                # What THIS install recorded at pull time (§30) — None for a your_own fuse or
+                # a pre-contract install; platforms stay () (the install records one platform,
+                # the catalog's offer is the library row's business).
+                mission_version=ic.mission_version,
+                mission_base_version=ic.mission_base_version,
+                index_digest=ic.index_digest,
             )
         )
 
@@ -125,6 +131,12 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 base_major=compat.base_major,
                 compatible=compat.compatible,
                 compat_hint=compat.hint,
+                # The catalog's CURRENT artifact identity (API1) — update detection compares
+                # an installed row's recorded digest against this row's.
+                mission_version=item.mission_version,
+                mission_base_version=item.mission_base_version,
+                index_digest=item.index_digest,
+                platforms=item.platforms,
             )
         )
 

--- a/src/xorcise/core/rest/catalog_view.py
+++ b/src/xorcise/core/rest/catalog_view.py
@@ -23,7 +23,8 @@ from xorcise.core.contracts.mission import MissionManifest
 if TYPE_CHECKING:
     # Type-only: keep the catalog island off the control-plane boot path (role isolation),
     # same trick as run_create.py's ports import. The concrete import is lazy, below.
-    from xorcise.core.catalog.source import CatalogSource
+    from xorcise.core.catalog.source import CatalogSource, LibraryItem
+    from xorcise.core.missions.runtime import InstalledMission
     from xorcise.core.runner.docker.build import BaseCompat
 
 
@@ -63,9 +64,29 @@ def build_catalog_view_deps(settings: Settings) -> CatalogViewDeps:
     )
 
 
+def _update_available(ic: InstalledMission, current: LibraryItem | None) -> bool | None:
+    """§34 update detection for one installed library row, against the catalog's current row.
+
+    Digest comparison is the strongest signal; a pre-digest catalog still MOVES the immutable
+    release ref whenever anything changes, so ref inequality is the honest fallback. Nothing
+    comparable ⇒ None (unknown), never a guessed False."""
+    if current is None:
+        return None
+    if ic.index_digest and current.index_digest:
+        return ic.index_digest != current.index_digest
+    if ic.mission_ref.image and current.image:
+        return ic.mission_ref.image != current.image
+    return None
+
+
 def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
     """Your Own (installed local store) + the free library, deduped by id (Your Own wins)."""
     from xorcise.core.missions import get_installed, list_installed
+
+    # One list call serves both halves: the library loop below AND the update check on
+    # installed library rows (comparing a recorded install against the catalog's CURRENT row).
+    library_items = deps.source.list_library()
+    library_by_id = {item.mission_id: item for item in library_items}
 
     installed_entries: list[CatalogEntry] = []
     installed_ids: set[str] = set()
@@ -76,6 +97,8 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
         meta = ic.manifest.metadata
         installed_ids.add(meta.mission_id)
         compat = base_compat_of(ic.mission_ref.image)
+        # Update status only makes sense for a LIBRARY install (your_own has no upstream).
+        current = library_by_id.get(meta.mission_id) if ic.origin == "library" else None
         installed_entries.append(
             CatalogEntry(
                 # origin decides the tab: a pulled library mission stays under XORCISE Remote,
@@ -100,11 +123,14 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 mission_version=ic.mission_version,
                 mission_base_version=ic.mission_base_version,
                 index_digest=ic.index_digest,
+                update_available=_update_available(ic, current),
+                current_mission_version=current.mission_version if current else None,
+                current_mission_base_version=(current.mission_base_version if current else None),
             )
         )
 
     library: list[CatalogEntry] = []
-    for item in deps.source.list_library():
+    for item in library_items:
         if item.mission_id in installed_ids:
             continue  # already an installed row (flagged there with its true origin)
         compat = base_compat_of(item.image)

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -149,6 +149,7 @@ def require_base_compatible(
     image_ref: str,
     *,
     label_lookup: Callable[[str], Mapping[str, str] | None] | None = None,
+    origin: str | None = None,
 ) -> None:
     """Raise BaseImageIncompatibleError if a fused image's base MAJOR is not what this XORCISE runs.
 
@@ -165,6 +166,16 @@ def require_base_compatible(
     # frontend renders the shorter compat.hint.
     compat = base_compat(major)
     if compat.compatible is None:
+        # CG4/LEG3: every published artifact carries the base label AND the -baseN tag suffix,
+        # so a LIBRARY install with neither predates the versioned image format — refuse with
+        # the one update action, rather than parsing legacy shapes forever. A your_own local
+        # fuse keeps the allowance: "update from the catalog" is not even the right advice.
+        if origin == "library":
+            raise BaseImageIncompatibleError(
+                f"mission image {image_ref!r} was installed using an older XORCISE image "
+                "format (it carries no base-generation metadata) — update it: "
+                "xorcise mission update <mission>"
+            )
         log.warning("could not determine the base generation of %s — allowing the run", image_ref)
         return
     if compat.compatible:

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -171,8 +171,7 @@ def require_base_compatible(
         return
     if compat.base_major is not None and compat.base_major < REQUIRED_BASE_MAJOR:
         fix = (
-            "this mission was built on an older base — update it: "
-            "xorcise mission delete <mission> && xorcise mission pull <mission>"
+            "this mission was built on an older base — update it: xorcise mission update <mission>"
         )
     else:
         fix = "this mission needs a newer XORCISE — upgrade it (e.g. pip install -U xorcise)"

--- a/src/xorcise/core/rest/mission_pull.py
+++ b/src/xorcise/core/rest/mission_pull.py
@@ -56,6 +56,7 @@ __all__ = [
     "PullProgressSink",
     "build_pull_deps",
     "pull_mission",
+    "update_mission",
 ]
 
 # Progress callback for a pull: (phase, bytes_current, bytes_total). Phases:
@@ -176,16 +177,8 @@ def pull_mission(
     mission but BEFORE the multi-GB image download — run-create wires the nesting gate here so a
     host that cannot run the mission is refused without first paying the pull. The explicit
     `xorcise mission pull` passes None: pre-staging a mission on a non-nesting host is allowed."""
-    from xorcise.core.missions import get_installed, install_pulled
+    from xorcise.core.missions import get_installed
     from xorcise.core.missions.errors import MissionCollisionError
-
-    def report(phase: str, current: int = 0, total: int = 0) -> None:
-        if progress is not None:
-            progress(phase, current, total)
-
-    def abort_if_cancelled() -> None:
-        if should_cancel is not None and should_cancel():
-            raise PullCancelled(f"pull of '{mission_id}' was cancelled")
 
     existing = get_installed(mission_id, deps.install_root)
     if existing is not None:
@@ -199,20 +192,113 @@ def pull_mission(
             )
         return existing  # already pulled (docker-pull on a present image is a no-op)
 
-    report("resolving")
-    abort_if_cancelled()
+    return _acquire_and_install(
+        mission_id, deps, progress=progress, should_cancel=should_cancel, precheck=precheck
+    )
+
+
+def update_mission(
+    mission_id: str,
+    deps: PullDeps,
+    *,
+    progress: PullProgressSink | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+) -> tuple[InstalledMission, bool]:
+    """Re-pull an installed library mission onto the catalog's CURRENT artifact, in place.
+
+    The contract's ONE update action (§35): whether the catalog moved because the creator
+    shipped a new mission version or because the fleet was re-fused onto a newer base, the
+    user-facing operation is this same re-pull. Returns (record, updated): updated=False means
+    the install already matches the catalog's current artifact — digest comparison first (§34's
+    strongest signal), immutable release ref as the pre-contract fallback — and nothing was
+    touched. The replaced image's old tag stays in the local docker store; pruning is a separate
+    concern, the same stance mission delete takes.
+
+    Raises NotFoundError when the id is not installed (nothing to update — pull it instead),
+    MissionCollisionError for a your_own install (a local bundle updates by re-ingesting), and
+    MissionNotInCatalogError when the catalog no longer lists the id."""
+    from xorcise.core.missions import get_installed
+    from xorcise.core.missions.errors import MissionCollisionError
+
+    existing = get_installed(mission_id, deps.install_root)
+    if existing is None:
+        raise NotFoundError(mission_id)
+    if existing.origin != "library":
+        raise MissionCollisionError(
+            f"'{mission_id}' is your own mission — update it by re-ingesting its bundle "
+            "(xorcise mission ingest), not from the catalog"
+        )
     try:
         detail = deps.source.fetch_detail(mission_id)
     except NotFoundError as exc:
         raise MissionNotInCatalogError(
-            f"mission '{mission_id}' is not installed and not in the catalog"
+            f"mission '{mission_id}' is installed but no longer in the catalog"
         ) from exc
-    manifest = detail.manifest
-
-    # None ⇒ an attachment-only (static) mission: no image to pull. MissionRef.image is a
-    # plain str, so record "" — the run path branches on the manifest (installed.is_static) and
-    # never reads this ref for a static run, so the empty image is inert.
     image = _image_for(deps.source, mission_id)
+    if _is_current(existing, detail, image):
+        return existing, False
+    record = _acquire_and_install(
+        mission_id,
+        deps,
+        progress=progress,
+        should_cancel=should_cancel,
+        precheck=None,
+        resolved=(detail, image),
+    )
+    return record, True
+
+
+def _is_current(existing: InstalledMission, detail: MissionDetail, image: str | None) -> bool:
+    """Whether the install already IS the catalog's current artifact.
+
+    Digest first (§34: the strongest signal); the immutable release ref second (a pre-digest
+    catalog moves the ref whenever anything changes). Neither comparable ⇒ NOT current, so
+    update re-installs rather than guessing — honest for a static mission with no digests."""
+    if existing.index_digest and detail.index_digest:
+        return existing.index_digest == detail.index_digest
+    return bool(image) and existing.mission_ref.image == image
+
+
+def _acquire_and_install(
+    mission_id: str,
+    deps: PullDeps,
+    *,
+    progress: PullProgressSink | None,
+    should_cancel: Callable[[], bool] | None,
+    precheck: Callable[[], None] | None,
+    resolved: tuple[MissionDetail, str | None] | None = None,
+) -> InstalledMission:
+    """The shared acquire spine: resolve → (precheck) → pull → bundle → atomic install.
+
+    Backs pull_mission (fresh install) and update_mission (in-place re-install; it passes the
+    (detail, image) it already fetched for its no-op check via `resolved`, so the catalog is
+    not asked twice)."""
+    from xorcise.core.missions import install_pulled
+
+    def report(phase: str, current: int = 0, total: int = 0) -> None:
+        if progress is not None:
+            progress(phase, current, total)
+
+    def abort_if_cancelled() -> None:
+        if should_cancel is not None and should_cancel():
+            raise PullCancelled(f"pull of '{mission_id}' was cancelled")
+
+    report("resolving")
+    abort_if_cancelled()
+    if resolved is not None:
+        detail, image = resolved
+    else:
+        try:
+            detail = deps.source.fetch_detail(mission_id)
+        except NotFoundError as exc:
+            raise MissionNotInCatalogError(
+                f"mission '{mission_id}' is not installed and not in the catalog"
+            ) from exc
+        # None ⇒ an attachment-only (static) mission: no image to pull. MissionRef.image is a
+        # plain str, so record "" — the run path branches on the manifest (installed.is_static)
+        # and never reads this ref for a static run, so the empty image is inert.
+        image = _image_for(deps.source, mission_id)
+    manifest = detail.manifest
     ref = MissionRef(mission_id=mission_id, image=image or "")
     if image is not None and not deps.driver.image_exists(image):
         # A lab mission with a download ahead of it — gate now (nesting), before the pull.

--- a/src/xorcise/core/rest/mission_pull.py
+++ b/src/xorcise/core/rest/mission_pull.py
@@ -15,11 +15,17 @@ import hashlib
 import importlib.util
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from xorcise.core.config import Settings
-from xorcise.core.contracts.control import MissionRef
+from xorcise.core.contracts.control import (
+    InstalledBaseIdentity,
+    InstalledImageIdentity,
+    MissionInstallIdentity,
+    MissionRef,
+)
 from xorcise.core.contracts.errors import (
     MissionNotInCatalogError,
     NotFoundError,
@@ -30,7 +36,7 @@ from xorcise.core.contracts.errors import (
 if TYPE_CHECKING:
     # Type-only: keep the part-islands off the control-plane boot path (role isolation),
     # same trick as run_create.py. Concrete island imports stay lazy, inside the functions.
-    from xorcise.core.catalog.source import CatalogSource
+    from xorcise.core.catalog.source import CatalogSource, MissionDetail
     from xorcise.core.contracts.mission import MissionManifest
     from xorcise.core.missions.runtime import InstalledMission
     from xorcise.core.runner.docker import DockerDriver, PullProgress
@@ -196,11 +202,12 @@ def pull_mission(
     report("resolving")
     abort_if_cancelled()
     try:
-        manifest = deps.source.fetch_manifest(mission_id)
+        detail = deps.source.fetch_detail(mission_id)
     except NotFoundError as exc:
         raise MissionNotInCatalogError(
             f"mission '{mission_id}' is not installed and not in the catalog"
         ) from exc
+    manifest = detail.manifest
 
     # None ⇒ an attachment-only (static) mission: no image to pull. MissionRef.image is a
     # plain str, so record "" — the run path branches on the manifest (installed.is_static) and
@@ -274,6 +281,8 @@ def pull_mission(
         mission_ref=ref,
         install_root=deps.install_root,
         delivery_zip=delivery_zip,
+        # Read AFTER the image pull so the inspect sees the local copy that actually landed.
+        identity=_install_identity(detail, deps.driver, image),
     )
 
 
@@ -295,6 +304,48 @@ def _fetch_verified_delivery(
                 f"(expected {bundle.sha256}, got {actual})"
             )
     return bundle.content
+
+
+def _install_identity(
+    detail: MissionDetail, driver: DockerDriver, image: str | None
+) -> MissionInstallIdentity | None:
+    """The §30 identity slice for this install, or None from a pre-contract catalog.
+
+    Values come from the catalog detail response — the identity of the CURRENT artifact, i.e.
+    the one just pulled — plus a post-pull inspect of the local image for the platform that
+    actually landed on this machine. Recorded once at install; run evidence copies it at create
+    time and never re-resolves it (a floating tag must not be able to rewrite history)."""
+    if (
+        detail.mission_version is None
+        and detail.index_digest is None
+        and detail.content_hash is None
+    ):
+        return None  # pre-contract catalog (prod today): keep the record legacy-shaped
+    platform = driver.image_platform(image) if image else None
+    platform_digest = next((p.digest for p in detail.platforms if p.platform == platform), None)
+    arch = platform.rsplit("/", 1)[-1] if platform else None
+    mission_base = None
+    if detail.mission_base_version is not None or detail.base_index_digest is not None:
+        mission_base = InstalledBaseIdentity(
+            version=detail.mission_base_version,
+            index_digest=detail.base_index_digest,
+            # Keyed by BARE architecture, scoped to the platforms this mission was fused for.
+            platform_digest=detail.base_platform_digests.get(arch) if arch else None,
+        )
+    return MissionInstallIdentity(
+        mission_version=detail.mission_version,
+        mission_base_version=detail.mission_base_version,
+        content_hash=detail.content_hash,
+        image=InstalledImageIdentity(
+            pull_ref=detail.pull_ref,
+            release_ref=detail.release_ref or (image or None),
+            index_digest=detail.index_digest,
+            platform=platform,
+            platform_digest=platform_digest,
+        ),
+        mission_base=mission_base,
+        pulled_at=datetime.now(UTC).isoformat(timespec="seconds"),
+    )
 
 
 def _image_for(source: CatalogSource, mission_id: str) -> str | None:

--- a/src/xorcise/core/rest/routers/missions.py
+++ b/src/xorcise/core/rest/routers/missions.py
@@ -26,6 +26,7 @@ from xorcise.core.rest.mission_pull import (
     PullProgressSink,
     build_pull_deps,
     pull_mission,
+    update_mission,
 )
 from xorcise.core.rest.pull_jobs import PullJob, pull_job_store
 
@@ -49,6 +50,13 @@ class IngestJobView(BaseModel):
     slug: str | None = None
     image: str | None = None
     detail: str | None = None
+
+
+class MissionUpdateOut(BaseModel):
+    """POST /{id}/update result: whether anything moved, and the row as installed now."""
+
+    updated: bool
+    entry: CatalogEntry
 
 
 class PullJobStarted(BaseModel):
@@ -177,6 +185,39 @@ def pull(mission_id: str) -> CatalogEntry:
     except PullError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     return _installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin)
+
+
+@router.post("/{mission_id}/update")
+def update(mission_id: str) -> MissionUpdateOut:
+    """Update an installed library mission to the catalog's current artifact (§35's ONE
+    update action) — an in-place, atomic re-pull. updated=false ⇒ the install already matches
+    the catalog (digest compared first) and nothing was touched.
+
+    404: not installed, or gone from the catalog. 409: a your_own install owns the id (update
+    it by re-ingesting), or a pull job is mid-flight. 502: the pull itself failed (nothing
+    replaced — the previous install stays byte-for-byte intact)."""
+    if pull_job_store().active_for(mission_id) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"a pull for '{mission_id}' is already in progress — wait for it to finish",
+        )
+    try:
+        ic, updated = update_mission(mission_id, build_pull_deps(get_settings()))
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"mission '{mission_id}' is not installed — pull it instead",
+        ) from exc
+    except MissionNotInCatalogError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except MissionCollisionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PullError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return MissionUpdateOut(
+        updated=updated,
+        entry=_installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin),
+    )
 
 
 def _job_progress_sink(job_id: str) -> PullProgressSink:

--- a/src/xorcise/core/rest/run_create.py
+++ b/src/xorcise/core/rest/run_create.py
@@ -784,7 +784,14 @@ def _create_run_with_cidr(
         sandbox_ref=installed.mission_ref.image,
         agent_version=agent.version,
         source_agent=source_agent,
-        mission_version=installed.install_revision,
+        install_revision=installed.install_revision,
+        # §31: artifact provenance copied from installed.json, never re-resolved later.
+        mission_version=installed.mission_version,
+        mission_base_version=installed.mission_base_version,
+        content_hash=installed.content_hash,
+        platform=installed.platform,
+        index_digest=installed.index_digest,
+        platform_digest=installed.platform_digest,
         intel_policy=intel_policy,
     )
     # the ACL was applied in create_run_network BEFORE this row persisted, so a truly
@@ -887,7 +894,14 @@ def _create_static_run(
             sandbox_ref=installed.mission_ref.image,  # "" for static (no fused image)
             agent_version=agent.version,
             source_agent=source_agent,
-            mission_version=installed.install_revision,
+            install_revision=installed.install_revision,
+            # §31: artifact provenance copied from installed.json, never re-resolved later.
+            mission_version=installed.mission_version,
+            mission_base_version=installed.mission_base_version,
+            content_hash=installed.content_hash,
+            platform=installed.platform,
+            index_digest=installed.index_digest,
+            platform_digest=installed.platform_digest,
             intel_policy=intel_policy,
         )
         return run, mission

--- a/src/xorcise/core/rest/run_create.py
+++ b/src/xorcise/core/rest/run_create.py
@@ -84,7 +84,7 @@ def _no_nested_check() -> None:
     """Default `require_nested`: the stub/unit path deploys nothing, so there is nothing to nest."""
 
 
-def _no_base_check(image_ref: str) -> None:
+def _no_base_check(image_ref: str, origin: str) -> None:
     """Default `check_base_compat`: the stub/unit path deploys no real image to gate."""
 
 
@@ -123,7 +123,7 @@ class RunCreateDeps:
     require_nested: Callable[[], None] = _no_nested_check
     # Raises BaseImageIncompatibleError if the mission's fused image was built on a base
     # generation this XORCISE cannot run. Takes the image ref; boot wires label+tag inspection.
-    check_base_compat: Callable[[str], None] = _no_base_check
+    check_base_compat: Callable[[str, str], None] = _no_base_check
 
 
 def _use_real_headscale(settings: Settings) -> bool:
@@ -211,7 +211,7 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
     live_subnets: Callable[[], set[str]] = _no_live_subnets
     # Default: the stub path deploys nothing, so nesting/base compat are not preconditions for it.
     require_nested: Callable[[], None] = _no_nested_check
-    check_base_compat: Callable[[str], None] = _no_base_check
+    check_base_compat: Callable[[str, str], None] = _no_base_check
     if control_real:
         # Real runner: _real_docker_driver fails loud if Docker/the runner extra is absent.
         from xorcise.core.headscale import overlapping_subnets
@@ -252,8 +252,8 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
         def require_nested() -> None:
             require_nested_support(settings, _client)
 
-        def check_base_compat(image_ref: str) -> None:
-            require_base_compatible(image_ref, label_lookup=driver.image_labels)
+        def check_base_compat(image_ref: str, origin: str) -> None:
+            require_base_compatible(image_ref, label_lookup=driver.image_labels, origin=origin)
     else:
         control = InProcessControlStub(api_key="local")
     ca_cert = Path(settings.headscale_ca_cert).read_text() if settings.headscale_ca_cert else ""
@@ -606,7 +606,7 @@ def create_run(
     deps.require_nested()
     # And refuse an artifact fused on a base generation this XORCISE cannot run (e.g. a stale
     # engine-27 fuse after an upgrade) — it would die at deploy with no host-daemon fallback.
-    deps.check_base_compat(installed.mission_ref.image)
+    deps.check_base_compat(installed.mission_ref.image, installed.origin)
     agent_user = _agent_user_for(run_id)
     assert installed.environment is not None  # is_lab ⇒ environment present (contract-enforced)
     entry_networks = tuple(installed.environment.entry_networks) or ("default",)

--- a/src/xorcise/core/rest/run_create.py
+++ b/src/xorcise/core/rest/run_create.py
@@ -784,7 +784,7 @@ def _create_run_with_cidr(
         sandbox_ref=installed.mission_ref.image,
         agent_version=agent.version,
         source_agent=source_agent,
-        mission_version=installed.version,
+        mission_version=installed.install_revision,
         intel_policy=intel_policy,
     )
     # the ACL was applied in create_run_network BEFORE this row persisted, so a truly
@@ -887,7 +887,7 @@ def _create_static_run(
             sandbox_ref=installed.mission_ref.image,  # "" for static (no fused image)
             agent_version=agent.version,
             source_agent=source_agent,
-            mission_version=installed.version,
+            mission_version=installed.install_revision,
             intel_policy=intel_policy,
         )
         return run, mission

--- a/src/xorcise/core/rest/run_terminate.py
+++ b/src/xorcise/core/rest/run_terminate.py
@@ -191,7 +191,10 @@ def _grade_run(run_id: str) -> None:
         budget_seconds=run.budget_seconds,
         sandbox_ref=run.sandbox_ref,
         agent_version=run.agent_version,
+        install_revision=run.install_revision,
         mission_version=run.mission_version,
+        mission_base_version=run.mission_base_version,
+        platform=run.platform,
     )
     # a run that did not end on the agent's own terms is "partial" and must not count
     # as a genuine result against the agent — a budget "timeout" or an operator's manual kill.

--- a/src/xorcise/core/rest/system_view.py
+++ b/src/xorcise/core/rest/system_view.py
@@ -16,7 +16,12 @@ from typing import Literal
 import httpx
 
 from xorcise.core.config import Settings
-from xorcise.core.contracts.config import CatalogStatusView, PlaneStatus, SystemInfo
+from xorcise.core.contracts.config import (
+    CatalogStatusView,
+    MissionBaseView,
+    PlaneStatus,
+    SystemInfo,
+)
 from xorcise.core.rest.catalog_view import build_catalog_view_deps
 
 _DB_SCHEMA = {"ready": "head", "stale": "behind", "fresh": "fresh"}
@@ -82,7 +87,13 @@ def _not_deployed(name: str) -> PlaneStatus:
 # nothing but complexity.
 # Catalog gets much longer: it is by far the priciest probe and the least volatile (a library
 # connection does not flap), and `xorcise catalog status` / the Catalog card remain the live check.
-_TTL_SECONDS: dict[str, float] = {"docker": 20.0, "headscale": 20.0, "catalog": 120.0}
+_TTL_SECONDS: dict[str, float] = {
+    "docker": 20.0,
+    "headscale": 20.0,
+    "catalog": 120.0,
+    # Same reasoning as catalog: a remote round-trip, and a promoted base changes rarely.
+    "mission_base": 120.0,
+}
 _DEFAULT_TTL = 20.0
 _probe_cache: dict[str, tuple[float, object]] = {}
 
@@ -244,7 +255,8 @@ def build_system_info(settings: Settings) -> SystemInfo:
     )
     # The single most expensive thing here (a remote round-trip) — memoised like the subprocess
     # probes. `xorcise catalog status` / the catalog card remain the live, uncached check.
-    status = _cached("catalog", lambda: build_catalog_view_deps(settings).source.status())
+    source = build_catalog_view_deps(settings).source
+    status = _cached("catalog", lambda: source.status())
     return SystemInfo(
         role=settings.role,
         planes=planes,
@@ -256,4 +268,33 @@ def build_system_info(settings: Settings) -> SystemInfo:
         home=str(xorcise_home()),
         db_url=settings.database_url,
         topology=settings.deployment_topology,
+        mission_base=_cached("mission_base", lambda: _mission_base_view(source)),
+    )
+
+
+def _mission_base_view(source: object) -> MissionBaseView:
+    """§36 version visibility: what this client requires vs what the catalog promotes.
+
+    The required MAJOR and the client's own version are local facts and always present; the
+    promoted side degrades to None on a pre-contract catalog (its /v1/mission-base 404s), the
+    stub, or any failure — unknown, never fabricated."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    # Lazy: the runner island stays off this module's import path until actually needed.
+    from xorcise.core.runner.docker.build import REQUIRED_BASE_MAJOR
+
+    try:
+        client_version = version("xorcise")
+    except PackageNotFoundError:  # editable/dev installs without metadata
+        client_version = ""
+    promoted = None
+    try:
+        promoted = source.mission_base()  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — a probe failure must never take the system view down
+        promoted = None
+    return MissionBaseView(
+        required_major=REQUIRED_BASE_MAJOR,
+        client_version=client_version,
+        promoted_version=promoted.version if promoted else None,
+        promoted_index_digest=promoted.index_digest if promoted else None,
     )

--- a/src/xorcise/core/runner/docker/__init__.py
+++ b/src/xorcise/core/runner/docker/__init__.py
@@ -121,6 +121,13 @@ class DockerDriver(ABC):
         None, which the base-compat gate reads as 'label unknown' and falls back to the tag."""
         return None
 
+    def image_platform(self, image: str) -> str | None:
+        """The `os/architecture` the local copy of the image was built for, or None.
+
+        Non-abstract None default (same reasoning as image_labels): only the real driver
+        inspects, and a None simply leaves the install record's platform unknown."""
+        return None
+
     @abstractmethod
     def reap_managed(self) -> list[str]:
         """Force-remove every xorcise-managed per-run container; return what was reaped.

--- a/src/xorcise/core/runner/docker/build.py
+++ b/src/xorcise/core/runner/docker/build.py
@@ -76,7 +76,7 @@ def base_compat(major: int | None) -> BaseCompat:
     if major == REQUIRED_BASE_MAJOR:
         return BaseCompat(major, True, None)
     if major < REQUIRED_BASE_MAJOR:
-        return BaseCompat(major, False, "Reinstall this mission to get the current base.")
+        return BaseCompat(major, False, "Update this mission to get the current base.")
     return BaseCompat(major, False, "Update XORCISE to run this mission.")
 
 

--- a/src/xorcise/core/runner/docker/driver.py
+++ b/src/xorcise/core/runner/docker/driver.py
@@ -140,6 +140,19 @@ class DockerSdkDriver(DockerDriver):
             return None
         return dict((img.attrs.get("Config") or {}).get("Labels") or {})
 
+    def image_platform(self, image: str) -> str | None:
+        """What the LOCAL copy of the image was actually built for, e.g. "linux/amd64".
+
+        Read from the image config (Os/Architecture), not from any tag or catalog claim — this
+        is the honest provenance value the install record and run evidence carry. Variant is
+        deliberately excluded (the contract's platform grammar is os/arch)."""
+        try:
+            attrs = self._client.images.get(image).attrs
+        except Exception:  # noqa: BLE001 — absent/unreadable image ⇒ unknown, never a crash
+            return None
+        os_name, arch = attrs.get("Os"), attrs.get("Architecture")
+        return f"{os_name}/{arch}" if os_name and arch else None
+
     def run(self, spec: ContainerSpec) -> ContainerHandle:
         # The fused image is local-only (no registry). containers.run auto-PULLS a missing image,
         # which for a local-only ref fails with a cryptic "pull access denied" — so fail loud

--- a/src/xorcise/core/runs/models.py
+++ b/src/xorcise/core/runs/models.py
@@ -62,9 +62,25 @@ class RunRow(Base):
     agent_version: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )
-    mission_version: Mapped[int] = mapped_column(
+    install_revision: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )
+    # Artifact provenance, copied from installed.json at create time (mission-versioning
+    # contract §31) and NEVER re-resolved: the local mission may later be updated, and a
+    # floating tag must not be able to rewrite what this run actually executed. All nullable —
+    # a your_own fuse and any pre-contract install carry none of it.
+    mission_version: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )  # creator SemVer, e.g. "1.4.2"
+    mission_base_version: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, default=None)
+    platform: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default=None
+    )  # what was pulled for THIS machine, e.g. "linux/arm64"
+    index_digest: Mapped[str | None] = mapped_column(String(96), nullable=True, default=None)
+    platform_digest: Mapped[str | None] = mapped_column(String(96), nullable=True, default=None)
     # the rendering agent's kind, snapshotted at create time — frozen, NOT a live
     # lookup through the agents registry, so a run keeps its adapter after the agent is
     # re-declared (kind change bumps version) or removed (mirrors model/agent_version above).

--- a/src/xorcise/core/runs/repository.py
+++ b/src/xorcise/core/runs/repository.py
@@ -39,7 +39,13 @@ def _to_entry(row: RunRow) -> RunEntry:
         model=row.model,
         sandbox_ref=row.sandbox_ref,
         agent_version=row.agent_version,
+        install_revision=row.install_revision,
         mission_version=row.mission_version,
+        mission_base_version=row.mission_base_version,
+        content_hash=row.content_hash,
+        platform=row.platform,
+        index_digest=row.index_digest,
+        platform_digest=row.platform_digest,
         source_agent=row.source_agent,
         intel_policy=row.intel_policy,
     )
@@ -60,7 +66,13 @@ def create_run(
     model: str | None = None,
     sandbox_ref: str | None = None,
     agent_version: int = 1,
-    mission_version: int = 1,
+    install_revision: int = 1,
+    mission_version: str | None = None,
+    mission_base_version: str | None = None,
+    content_hash: str | None = None,
+    platform: str | None = None,
+    index_digest: str | None = None,
+    platform_digest: str | None = None,
     source_agent: str = "generic",
     intel_policy: str = "all",
 ) -> RunEntry:
@@ -80,7 +92,13 @@ def create_run(
             model=model,
             sandbox_ref=sandbox_ref,
             agent_version=agent_version,
+            install_revision=install_revision,
             mission_version=mission_version,
+            mission_base_version=mission_base_version,
+            content_hash=content_hash,
+            platform=platform,
+            index_digest=index_digest,
+            platform_digest=platform_digest,
             source_agent=source_agent,
             intel_policy=intel_policy,
         )
@@ -131,7 +149,13 @@ def finalize_run(
     model: str | None = None,
     sandbox_ref: str | None = None,
     agent_version: int = 1,
-    mission_version: int = 1,
+    install_revision: int = 1,
+    mission_version: str | None = None,
+    mission_base_version: str | None = None,
+    content_hash: str | None = None,
+    platform: str | None = None,
+    index_digest: str | None = None,
+    platform_digest: str | None = None,
     source_agent: str = "generic",
     intel_policy: str = "all",
 ) -> RunEntry:
@@ -148,7 +172,13 @@ def finalize_run(
         row.model = model
         row.sandbox_ref = sandbox_ref
         row.agent_version = agent_version
+        row.install_revision = install_revision
         row.mission_version = mission_version
+        row.mission_base_version = mission_base_version
+        row.content_hash = content_hash
+        row.platform = platform
+        row.index_digest = index_digest
+        row.platform_digest = platform_digest
         row.source_agent = source_agent
         row.intel_policy = intel_policy
         s.flush()

--- a/tests/integration/test_agent_history_compare.py
+++ b/tests/integration/test_agent_history_compare.py
@@ -81,4 +81,4 @@ def test_history_single_run_returns_one_entry_cleanly(migrated_home) -> None:
     entry = entries[0]
     assert "conditions" in entry
     assert entry["conditions"]["agent_version"] >= 1
-    assert entry["conditions"]["mission_version"] >= 1
+    assert entry["conditions"]["install_revision"] >= 1

--- a/tests/integration/test_run_terminate_grades.py
+++ b/tests/integration/test_run_terminate_grades.py
@@ -118,7 +118,7 @@ def _seed_run_with_conditions(home: Path) -> tuple[str, str]:
         model=model_name,
         sandbox_ref="xorcise/mission-c2:0",
         agent_version=4,
-        mission_version=6,
+        install_revision=6,
     )
     rid = run.run_id
 
@@ -148,9 +148,9 @@ def test_terminate_records_conditions_on_result(migrated_home) -> None:
     assert rc.sandbox_ref == "xorcise/mission-c2:0"
     # No BYOM key configured in throwaway home → judge_model is None
     assert rc.judge_model is None
-    # agent_version + mission_version denormalized onto result
+    # agent_version + install_revision denormalized onto result
     assert rc.agent_version == 4
-    assert rc.mission_version == 6
+    assert rc.install_revision == 6
 
 
 def test_timeout_terminate_marks_result_partial(migrated_home) -> None:

--- a/tests/unit/test_agent_history_rest.py
+++ b/tests/unit/test_agent_history_rest.py
@@ -30,7 +30,7 @@ def test_history_lists_completed_runs(migrated_home):
 
 
 def test_history_entries_carry_conditions_with_versions(migrated_home):
-    """Each history entry must expose conditions.agent_version + conditions.mission_version."""
+    """Each history entry must expose conditions.agent_version + conditions.install_revision."""
     install_mission(migrated_home, "c1")
     c = _client()
     _register_run_done(c, "beta")
@@ -40,10 +40,10 @@ def test_history_entries_carry_conditions_with_versions(migrated_home):
     assert "conditions" in entry
     cond = entry["conditions"]
     assert "agent_version" in cond
-    assert "mission_version" in cond
+    assert "install_revision" in cond
     # versions are positive integers
     assert isinstance(cond["agent_version"], int) and cond["agent_version"] >= 1
-    assert isinstance(cond["mission_version"], int) and cond["mission_version"] >= 1
+    assert isinstance(cond["install_revision"], int) and cond["install_revision"] >= 1
 
 
 def test_history_unknown_agent_404(migrated_home):

--- a/tests/unit/test_catalog_package_size.py
+++ b/tests/unit/test_catalog_package_size.py
@@ -153,7 +153,7 @@ def test_browse_entry_exposes_base_incompatibility_to_the_ui(tmp_path: Path):
 
     assert entry.base_major == 1
     assert entry.compatible is False
-    assert entry.compat_hint and "einstall" in entry.compat_hint
+    assert entry.compat_hint and "pdate" in entry.compat_hint
 
 
 def test_browse_entry_is_compatible_for_the_current_generation(tmp_path: Path):

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -62,7 +62,7 @@ def test_head_revision_is_the_latest_migration(tmp_path, monkeypatch):
     monkeypatch.setenv("XORCISE_HOME", str(tmp_path))
     config.get_settings.cache_clear()
     db.get_engine.cache_clear()
-    assert db.head_revision() == "0001_initial"
+    assert db.head_revision() == "0002_run_provenance"
 
 
 def test_boot_state_fresh_on_empty_db(tmp_path, monkeypatch):

--- a/tests/unit/test_fused_builder_plan.py
+++ b/tests/unit/test_fused_builder_plan.py
@@ -174,7 +174,7 @@ def test_base_compat_verdict_by_generation():
 
     older = base_compat(1)
     assert older.compatible is False and older.base_major == 1
-    assert "einstall" in (older.hint or "")  # reinstall the mission
+    assert "pdate" in (older.hint or "")  # update the mission (§35's one action)
 
     newer = base_compat(9)
     assert newer.compatible is False and newer.base_major == 9

--- a/tests/unit/test_http_catalog_source.py
+++ b/tests/unit/test_http_catalog_source.py
@@ -364,3 +364,36 @@ def test_list_row_identity_absent_on_pre_contract_catalog() -> None:
     assert item.mission_base_version is None
     assert item.index_digest is None
     assert item.platforms == ()
+
+
+def test_mission_base_parses_the_promoted_release() -> None:
+    body = {
+        "mission_base_version": "2.0.0",
+        "required_base_major": 2,
+        "image": {
+            "ref": "ghcr.io/xorcise-ai/mission-base:2.0.0",
+            "index_digest": "sha256:base",
+            "platforms": [
+                {"os": "linux", "architecture": "amd64", "digest": "sha256:bamd"},
+                {"os": "linux", "architecture": "arm64", "variant": "v8", "digest": "sha256:barm"},
+            ],
+        },
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/mission-base"
+        return httpx.Response(200, json=body)
+
+    mb = _source(h).mission_base()
+    assert mb is not None
+    assert mb.version == "2.0.0"
+    assert mb.required_base_major == 2
+    assert mb.ref == "ghcr.io/xorcise-ai/mission-base:2.0.0"
+    assert mb.index_digest == "sha256:base"
+    assert [p.platform for p in mb.platforms] == ["linux/amd64", "linux/arm64"]
+
+
+def test_mission_base_404_and_errors_degrade_to_none() -> None:
+    # Prod predates the endpoint (404); an outage must be equally silent — display data only.
+    assert _source(lambda req: httpx.Response(404)).mission_base() is None
+    assert _source(lambda req: httpx.Response(500)).mission_base() is None

--- a/tests/unit/test_http_catalog_source.py
+++ b/tests/unit/test_http_catalog_source.py
@@ -276,3 +276,91 @@ def test_fetch_manifest_invalid_supported_schema_is_typed_too() -> None:
         _source(h).fetch_manifest("segmented-pivot")
     assert exc.value.served == "3.0"
     assert "cannot validate" in str(exc.value)
+
+
+_DETAIL = {
+    "manifest": {**cast("dict[str, object]", _MANIFEST["manifest"]), "version": "1.0.0"}
+    | {"schema_version": "3.0"},
+    "image_ref": _IMAGE,
+    "mission_version": "1.0.0",
+    "mission_base_version": "2.0.0",
+    "content_hash": "f401724435f303e76bae78b940f3b6166078878f3c76747b2b9a7738a5212a40",
+    "image": {
+        "release_ref": "reg/xorcise/mis-segmented-pivot:1.0.0-base2.0.0",
+        "pull_ref": "reg/xorcise/mis-segmented-pivot:latest",
+        "index_digest": "sha256:idx",
+        "platforms": [
+            {"os": "linux", "architecture": "amd64", "digest": "sha256:amd"},
+            {"os": "linux", "architecture": "arm64", "digest": "sha256:arm", "variant": "v8"},
+        ],
+    },
+    "mission_base": {
+        "version": "2.0.0",
+        "index_digest": "sha256:base",
+        "platform_digests": {"amd64": "sha256:bamd", "arm64": "sha256:barm"},
+    },
+}
+
+
+def test_fetch_detail_parses_the_contract_shape() -> None:
+    # The live test-environment detail response (handover §1.6 / contract API2 + A11).
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/missions/segmented-pivot"
+        return httpx.Response(200, json=_DETAIL)
+
+    d = _source(h).fetch_detail("segmented-pivot")
+    assert d.manifest.version == "1.0.0"
+    assert d.mission_version == "1.0.0"
+    assert d.mission_base_version == "2.0.0"
+    assert d.content_hash == _DETAIL["content_hash"]
+    assert d.release_ref == "reg/xorcise/mis-segmented-pivot:1.0.0-base2.0.0"
+    assert d.pull_ref == "reg/xorcise/mis-segmented-pivot:latest"
+    assert d.index_digest == "sha256:idx"
+    assert [p.platform for p in d.platforms] == ["linux/amd64", "linux/arm64"]
+    assert d.platforms[1].variant == "v8"  # arm64/v8 distinguishable from bare arm64
+    assert d.base_index_digest == "sha256:base"
+    assert d.base_platform_digests == {"amd64": "sha256:bamd", "arm64": "sha256:barm"}
+
+
+def test_fetch_detail_degrades_on_a_pre_contract_response() -> None:
+    # Prod today serves only {manifest, image_ref}: every identity field is None/empty and
+    # nothing raises — the client behaves exactly as before the contract.
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_MANIFEST)
+
+    d = _source(h).fetch_detail("segmented-pivot")
+    assert d.manifest.metadata.mission_id == "segmented-pivot"
+    assert d.mission_version is None
+    assert d.index_digest is None
+    assert d.platforms == ()
+    assert d.base_platform_digests == {}
+
+
+def test_list_row_carries_identity_fields() -> None:
+    row = {
+        **cast("dict[str, object]", _CATALOG["catalog"][0]),
+        "mission_version": "1.0.0",
+        "mission_base_version": "2.0.0",
+        "index_digest": "sha256:idx",
+        "platforms": ["linux/amd64", "linux/arm64"],
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"catalog": [row]})
+
+    item = _source(h).list_library()[0]
+    assert item.mission_version == "1.0.0"
+    assert item.mission_base_version == "2.0.0"
+    assert item.index_digest == "sha256:idx"
+    assert item.platforms == ("linux/amd64", "linux/arm64")
+
+
+def test_list_row_identity_absent_on_pre_contract_catalog() -> None:
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_CATALOG)
+
+    item = _source(h).list_library()[0]
+    assert item.mission_version is None
+    assert item.mission_base_version is None
+    assert item.index_digest is None
+    assert item.platforms == ()

--- a/tests/unit/test_http_catalog_source.py
+++ b/tests/unit/test_http_catalog_source.py
@@ -10,13 +10,18 @@ The live contract is mocked with httpx.MockTransport (no network in CI):
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import cast
 
 import httpx
 import pytest
 
 from xorcise.core.catalog import StubCatalogSource
 from xorcise.core.catalog.http import HttpCatalogSource
-from xorcise.core.contracts.errors import NotFoundError, PullError
+from xorcise.core.contracts.errors import (
+    NotFoundError,
+    PullError,
+    UnsupportedManifestVersionError,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -224,3 +229,50 @@ def test_list_library_carries_skills_when_the_catalog_emits_it() -> None:
 
     assert _source(with_skills).list_library()[0].skills == ("pivoting", "lateral-movement")
     assert _source(without).list_library()[0].skills == ()
+
+
+def test_fetch_manifest_deserializes_schema_3_0() -> None:
+    doc = {
+        "manifest": {**cast("dict[str, object]", _MANIFEST["manifest"]), "version": "1.0.0"}
+        | {"schema_version": "3.0"},
+        "image_ref": _IMAGE,
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=doc)
+
+    m = _source(h).fetch_manifest("segmented-pivot")
+    assert m.schema_version == "3.0"
+    assert m.version == "1.0.0"
+
+
+def test_fetch_manifest_unknown_schema_raises_typed_upgrade_error() -> None:
+    # A catalog newer than this client (e.g. a future 4.0) must surface as an actionable
+    # "upgrade XORCISE" error — never a pydantic traceback (UnsupportedManifestVersionError).
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"manifest": {"schema_version": "4.0"}})
+
+    with pytest.raises(UnsupportedManifestVersionError) as exc:
+        _source(h).fetch_manifest("segmented-pivot")
+    assert exc.value.served == "4.0"
+    assert exc.value.supported == ("2.0", "3.0")
+    assert "upgrade XORCISE" in str(exc.value)
+    assert isinstance(exc.value, PullError)  # rides the existing REST/CLI PullError mapping
+
+
+def test_fetch_manifest_invalid_supported_schema_is_typed_too() -> None:
+    # A supported-version document that fails validation (client and catalog disagree about
+    # the shape) is the same typed error, not a crash.
+    doc = {
+        "manifest": {**cast("dict[str, object]", _MANIFEST["manifest"]), "version": "01.0.0"}
+        | {"schema_version": "3.0"},
+        "image_ref": _IMAGE,
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=doc)
+
+    with pytest.raises(UnsupportedManifestVersionError) as exc:
+        _source(h).fetch_manifest("segmented-pivot")
+    assert exc.value.served == "3.0"
+    assert "cannot validate" in str(exc.value)

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -1,0 +1,248 @@
+# tests/unit/test_install_identity.py
+"""The §30 install-identity slice: recorded at pull, written to installed.json, surfaced
+on the browse row. Contract: mission-versioning §30 (installed.json), API1 (list row)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xorcise.core.catalog import LibraryItem, StubCatalogSource
+from xorcise.core.catalog.source import MissionDetail, PlatformImage
+from xorcise.core.contracts.control import (
+    InstalledBaseIdentity,
+    InstalledImageIdentity,
+    MissionInstallIdentity,
+    MissionRef,
+)
+from xorcise.core.contracts.mission import (
+    EnvironmentSpec,
+    MissionManifest,
+    MissionMetadata,
+)
+from xorcise.core.missions import get_installed
+from xorcise.core.missions.runtime import INSTALLED_FILE, InstalledMission
+from xorcise.core.rest.catalog_view import CatalogViewDeps, list_catalog
+from xorcise.core.rest.mission_pull import PullDeps, pull_mission
+from xorcise.core.runner.docker import StubDockerDriver
+
+pytestmark = pytest.mark.unit
+
+_HASH = "f401724435f303e76bae78b940f3b6166078878f3c76747b2b9a7738a5212a40"
+
+
+def _manifest(slug: str = "c1") -> MissionManifest:
+    return MissionManifest(
+        schema_version="3.0",
+        version="1.0.0",
+        metadata=MissionMetadata(mission_id=slug, name=slug, objective="obj", type="lab"),
+        environment=EnvironmentSpec(),
+    )
+
+
+def _identity() -> MissionInstallIdentity:
+    return MissionInstallIdentity(
+        mission_version="1.0.0",
+        mission_base_version="2.0.0",
+        content_hash=_HASH,
+        image=InstalledImageIdentity(
+            pull_ref="reg/xorcise/mis-c1:latest",
+            release_ref="reg/xorcise/mis-c1:1.0.0-base2.0.0",
+            index_digest="sha256:idx",
+            platform="linux/arm64",
+            platform_digest="sha256:arm",
+        ),
+        mission_base=InstalledBaseIdentity(
+            version="2.0.0", index_digest="sha256:base", platform_digest="sha256:barm"
+        ),
+        pulled_at="2026-08-19T00:00:00+00:00",
+    )
+
+
+def _write(root: Path, slug: str, record: InstalledMission) -> Path:
+    d = root / slug
+    d.mkdir(parents=True)
+    (d / INSTALLED_FILE).write_text(record.to_record())
+    return d
+
+
+# ── installed.json record shape ──────────────────────────────────────────────────────────────
+
+
+def test_record_round_trips_the_identity(tmp_path: Path) -> None:
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="reg/xorcise/mis-c1:1.0.0-base2.0.0")
+    d = _write(
+        tmp_path,
+        slug,
+        InstalledMission(slug, tmp_path / slug, _manifest(), ref, identity=_identity()),
+    )
+    loaded = InstalledMission.from_root(d)
+    assert loaded.identity == _identity()
+    # convenience projections used by browse + run evidence
+    assert loaded.mission_version == "1.0.0"
+    assert loaded.mission_base_version == "2.0.0"
+    assert loaded.index_digest == "sha256:idx"
+    assert loaded.platform == "linux/arm64"
+
+
+def test_record_lays_out_identity_at_top_level_per_contract(tmp_path: Path) -> None:
+    # §30's recommended layout: the identity keys sit BESIDE the legacy keys, not nested
+    # under some wrapper — a human or external tool reads the contract shape off disk.
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="img")
+    d = _write(
+        tmp_path,
+        slug,
+        InstalledMission(slug, tmp_path / slug, _manifest(), ref, identity=_identity()),
+    )
+    data = json.loads((d / INSTALLED_FILE).read_text())
+    assert data["mission_version"] == "1.0.0"
+    assert data["mission_base_version"] == "2.0.0"
+    assert data["content_hash"] == _HASH
+    assert data["image"]["index_digest"] == "sha256:idx"
+    assert data["image"]["platform"] == "linux/arm64"
+    assert data["mission_base"]["platform_digest"] == "sha256:barm"
+    assert data["pulled_at"] == "2026-08-19T00:00:00+00:00"
+    assert data["install_revision"] == 1
+
+
+def test_record_without_identity_writes_no_identity_keys(tmp_path: Path) -> None:
+    # A your_own fuse / pre-contract install keeps the legacy record shape — no null spam.
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="img")
+    d = _write(tmp_path, slug, InstalledMission(slug, tmp_path / slug, _manifest(), ref))
+    data = json.loads((d / INSTALLED_FILE).read_text())
+    assert "mission_version" not in data and "image" not in data
+    loaded = InstalledMission.from_root(d)
+    assert loaded.identity is None
+    assert loaded.mission_version is None
+    assert loaded.index_digest is None
+
+
+def test_legacy_version_key_reads_as_install_revision(tmp_path: Path) -> None:
+    # Records written before the rename carry the monotonic counter as "version".
+    slug = "c1"
+    d = tmp_path / slug
+    d.mkdir(parents=True)
+    legacy = {
+        "version": 3,
+        "origin": "library",
+        "manifest": _manifest().model_dump(mode="json"),
+        "mission_ref": {"mission_id": slug, "image": "img"},
+    }
+    (d / INSTALLED_FILE).write_text(json.dumps(legacy))
+    loaded = InstalledMission.from_root(d)
+    assert loaded.install_revision == 3
+    assert loaded.identity is None
+
+
+# ── pull records the identity ────────────────────────────────────────────────────────────────
+
+
+class _ContractSource(StubCatalogSource):
+    """Fixture library, but the detail response carries the contract identity siblings."""
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        return MissionDetail(
+            manifest=self.fetch_manifest(mission_id),
+            mission_version="1.0.0",
+            mission_base_version="2.0.0",
+            content_hash=_HASH,
+            pull_ref="reg/xorcise/mis-sqli-login:latest",
+            release_ref="reg/xorcise/mis-sqli-login:1.0.0-base2.0.0",
+            index_digest="sha256:idx",
+            platforms=(
+                PlatformImage(os="linux", architecture="amd64", digest="sha256:amd"),
+                PlatformImage(os="linux", architecture="arm64", digest="sha256:arm", variant="v8"),
+            ),
+            base_index_digest="sha256:base",
+            base_platform_digests={"amd64": "sha256:bamd", "arm64": "sha256:barm"},
+        )
+
+
+class _ArmDriver(StubDockerDriver):
+    def image_platform(self, image: str) -> str | None:
+        return "linux/arm64"
+
+
+def test_pull_records_the_install_identity(tmp_path: Path) -> None:
+    deps = PullDeps(
+        source=_ContractSource(enabled=True), driver=_ArmDriver(), install_root=tmp_path
+    )
+    ic = pull_mission("sqli-login", deps)
+    assert ic.identity is not None
+    assert ic.mission_version == "1.0.0"
+    assert ic.identity.content_hash == _HASH
+    img = ic.identity.image
+    assert img is not None
+    assert img.release_ref == "reg/xorcise/mis-sqli-login:1.0.0-base2.0.0"
+    assert img.index_digest == "sha256:idx"
+    # platform is what ACTUALLY landed (driver inspect), and the digests follow it
+    assert img.platform == "linux/arm64"
+    assert img.platform_digest == "sha256:arm"
+    base = ic.identity.mission_base
+    assert base is not None
+    assert base.version == "2.0.0"
+    assert base.platform_digest == "sha256:barm"  # bare-arch keyed upstream
+    assert ic.identity.pulled_at  # stamped
+    # and it survives the round trip through installed.json
+    again = get_installed("sqli-login", tmp_path)
+    assert again is not None and again.identity == ic.identity
+
+
+def test_pull_from_pre_contract_source_records_no_identity(tmp_path: Path) -> None:
+    # The stub's default fetch_detail carries no identity siblings (a 2.0-era deployment):
+    # the record must stay legacy-shaped, exactly as before this feature.
+    deps = PullDeps(
+        source=StubCatalogSource(enabled=True), driver=StubDockerDriver(), install_root=tmp_path
+    )
+    ic = pull_mission("sqli-login", deps)
+    assert ic.identity is None
+
+
+# ── browse rows carry the identity ───────────────────────────────────────────────────────────
+
+
+class _RowSource(StubCatalogSource):
+    def list_library(self) -> tuple[LibraryItem, ...]:
+        return (
+            LibraryItem(
+                mission_id="vp",
+                name="Vanishing Point",
+                image="reg/xorcise/mis-vp:1.4.2-base2.4.1",
+                mission_version="1.4.2",
+                mission_base_version="2.4.1",
+                index_digest="sha256:cat",
+                platforms=("linux/amd64", "linux/arm64"),
+            ),
+        )
+
+
+def test_library_row_carries_catalog_identity(tmp_path: Path) -> None:
+    deps = CatalogViewDeps(source=_RowSource(enabled=True), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == "vp")
+    assert row.mission_version == "1.4.2"
+    assert row.mission_base_version == "2.4.1"
+    assert row.index_digest == "sha256:cat"
+    assert row.platforms == ("linux/amd64", "linux/arm64")
+
+
+def test_installed_row_carries_recorded_identity(tmp_path: Path) -> None:
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="reg/xorcise/mis-c1:1.0.0-base2.0.0")
+    _write(
+        tmp_path,
+        slug,
+        InstalledMission(
+            slug, tmp_path / slug, _manifest(), ref, origin="library", identity=_identity()
+        ),
+    )
+    deps = CatalogViewDeps(source=StubCatalogSource(enabled=False), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == slug)
+    assert row.mission_version == "1.0.0"
+    assert row.mission_base_version == "2.0.0"
+    assert row.index_digest == "sha256:idx"
+    assert row.platforms == ()  # an install records ONE platform; the offer is the library's

--- a/tests/unit/test_install_pulled.py
+++ b/tests/unit/test_install_pulled.py
@@ -84,10 +84,10 @@ def test_install_pulled_overwrites_existing(tmp_path: Path) -> None:
 def test_install_pulled_first_install_version_is_1(tmp_path: Path) -> None:
     ref = MissionRef(mission_id="c2", image="xorcise/mission-c2:1")
     ic = install_pulled(manifest=_m("c2"), mission_ref=ref, install_root=tmp_path)
-    assert ic.version == 1
+    assert ic.install_revision == 1
     again = get_installed("c2", tmp_path)
     assert again is not None
-    assert again.version == 1
+    assert again.install_revision == 1
 
 
 def test_install_pulled_reinstall_bumps_version(tmp_path: Path) -> None:
@@ -95,10 +95,10 @@ def test_install_pulled_reinstall_bumps_version(tmp_path: Path) -> None:
     install_pulled(manifest=_m("c3"), mission_ref=ref1, install_root=tmp_path)
     ref2 = MissionRef(mission_id="c3", image="xorcise/mission-c3:2")
     ic2 = install_pulled(manifest=_m("c3"), mission_ref=ref2, install_root=tmp_path)
-    assert ic2.version == 2
+    assert ic2.install_revision == 2
     again = get_installed("c3", tmp_path)
     assert again is not None
-    assert again.version == 2
+    assert again.install_revision == 2
 
 
 # delivery-bundle attachment materialization -------------------------

--- a/tests/unit/test_manifest_schema_30.py
+++ b/tests/unit/test_manifest_schema_30.py
@@ -1,0 +1,137 @@
+# tests/unit/test_manifest_schema_30.py
+"""Schema 3.0 adoption — the mission-versioning contract's manifest half (MV1/MV7/A8/A11).
+
+3.0 adds the required creator-owned SemVer `version`; 2.0 predates the field, must not carry
+it, and must KEEP validating (prod is pre-contract and 2.0 history is served forever)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from xorcise.core.contracts.mission import MissionManifest
+from xorcise.core.missions.errors import PreflightError
+from xorcise.core.missions.preflight import preflight
+
+pytestmark = pytest.mark.unit
+
+
+def _doc(**overrides: object) -> dict[str, object]:
+    doc: dict[str, object] = {
+        "schema_version": "3.0",
+        "version": "1.4.2",
+        "metadata": {
+            "mission_id": "vanishing-point",
+            "name": "Vanishing Point",
+            "objective": "Find the flag.",
+            "type": "lab",
+        },
+        "environment": {},
+    }
+    doc.update(overrides)
+    return doc
+
+
+def test_30_manifest_validates_and_carries_the_version() -> None:
+    m = MissionManifest.model_validate(_doc())
+    assert m.schema_version == "3.0"
+    assert m.version == "1.4.2"
+
+
+def test_30_requires_version() -> None:
+    doc = _doc()
+    del doc["version"]
+    with pytest.raises(ValidationError, match="schema 3.0 requires 'version'"):
+        MissionManifest.model_validate(doc)
+
+
+def test_20_still_validates_without_version() -> None:
+    # Prod is pre-contract: 2.0 documents (no `version`) must keep reading unchanged.
+    doc = _doc(schema_version="2.0")
+    del doc["version"]
+    m = MissionManifest.model_validate(doc)
+    assert m.schema_version == "2.0"
+    assert m.version is None
+
+
+def test_20_refuses_version() -> None:
+    # A 2.0 document carrying `version` never existed in the wild; every other 2.0 consumer
+    # (extra="forbid") refuses it, so this client must too.
+    with pytest.raises(ValidationError, match="requires manifest schema 3.0"):
+        MissionManifest.model_validate(_doc(schema_version="2.0"))
+
+
+@pytest.mark.parametrize(
+    "bad", ["01.0.0", "1.0", "1", "1.0.0-rc1", "1.0.0+build.5", "v1.0.0", "1.0.00", ""]
+)
+def test_version_refuses_non_semver(bad: str) -> None:
+    # The A11 pattern verbatim: no leading zeros, no pre-release/build suffix — what ingest
+    # enforces, so a bundle that passes here can never be refused remotely on format.
+    with pytest.raises(ValidationError, match="MAJOR.MINOR.PATCH"):
+        MissionManifest.model_validate(_doc(version=bad))
+
+
+@pytest.mark.parametrize("good", ["0.0.0", "0.1.0", "1.4.2", "1.4.10", "10.20.30"])
+def test_version_accepts_semver(good: str) -> None:
+    assert MissionManifest.model_validate(_doc(version=good)).version == good
+
+
+def test_live_30_shape_validates() -> None:
+    # The exact key set the contract-era catalog serves for a published mission (the 2.0 keys
+    # plus `version`) — pins that the client reads the full wire shape, not a lucky subset.
+    doc: dict[str, object] = {
+        "schema_version": "3.0",
+        "metadata": {
+            "mission_id": "sqli-login",
+            "name": "SQLi Login",
+            "summary": "A login page.",
+            "objective": "Bypass the login.",
+            "proficiency": "Advance Beginner",
+            "specialty": "web",
+            "type": "lab",
+            "skills": ["Web Exploitation"],
+            "technologies": ["http", "postgres"],
+        },
+        "environment": {
+            "compose_file": "docker-compose.yml",
+            "entry_networks": ["default"],
+            "static_ips": {},
+        },
+        "artifacts": [],
+        "rubric": [],
+        "checks": [],
+        "intel": [],
+        "attachments": [],
+        "terrain": None,
+        "source": None,
+        "delivery": None,
+        "version": "1.0.0",
+    }
+    m = MissionManifest.model_validate(doc)
+    assert m.version == "1.0.0"
+    assert m.metadata.mission_id == "sqli-login"
+
+
+# ── preflight (local `xorcise mission ingest`) ───────────────────────────────────────────────
+
+
+def _write_bundle(tmp_path: Path, doc: dict[str, object]) -> Path:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "mission.json").write_text(json.dumps(doc))
+    (bundle / "docker-compose.yml").write_text("services: {}\n")
+    return bundle
+
+
+def test_preflight_accepts_a_30_bundle(tmp_path: Path) -> None:
+    m = preflight(_write_bundle(tmp_path, _doc()))
+    assert m.schema_version == "3.0"
+    assert m.version == "1.4.2"
+
+
+def test_preflight_names_both_supported_versions(tmp_path: Path) -> None:
+    with pytest.raises(PreflightError, match=r"supported: 2\.0, 3\.0"):
+        preflight(_write_bundle(tmp_path, _doc(schema_version="1.0")))

--- a/tests/unit/test_mission_update.py
+++ b/tests/unit/test_mission_update.py
@@ -1,0 +1,244 @@
+# tests/unit/test_mission_update.py
+"""The ONE mission-update action (contract §34/§35): digest-driven detection on the browse
+row, and an in-place atomic re-pull as the single user-facing operation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from xorcise.core.catalog import LibraryItem, StubCatalogSource
+from xorcise.core.catalog.source import MissionDetail
+from xorcise.core.contracts.errors import NotFoundError
+from xorcise.core.missions import get_installed
+from xorcise.core.missions.errors import MissionCollisionError
+from xorcise.core.rest.catalog_view import CatalogViewDeps, list_catalog
+from xorcise.core.rest.mission_pull import PullDeps, pull_mission, update_mission
+from xorcise.core.runner.docker import StubDockerDriver
+
+pytestmark = pytest.mark.unit
+
+_IMAGE_V1 = "reg/xorcise/mis-sqli-login:1.0.0-base2.0.0"
+_IMAGE_V2 = "reg/xorcise/mis-sqli-login:1.1.0-base2.0.0"
+
+
+class _Catalog(StubCatalogSource):
+    """Fixture library whose current artifact identity is adjustable per test."""
+
+    # frozen dataclass parent → configure via class attributes on subclasses/instances
+    image: str = _IMAGE_V1
+    index_digest: str | None = "sha256:one"
+    mission_version: str = "1.0.0"
+
+    def list_library(self) -> tuple[LibraryItem, ...]:
+        return (
+            LibraryItem(
+                mission_id="sqli-login",
+                name="SQLi Login",
+                image=self.image,
+                mission_version=self.mission_version,
+                mission_base_version="2.0.0",
+                index_digest=self.index_digest,
+            ),
+        )
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        return MissionDetail(
+            manifest=self.fetch_manifest(mission_id),
+            mission_version=self.mission_version,
+            mission_base_version="2.0.0",
+            content_hash="ab" * 32,
+            release_ref=self.image,
+            index_digest=self.index_digest,
+        )
+
+
+def _deps(tmp_path: Path, source: StubCatalogSource) -> PullDeps:
+    return PullDeps(source=source, driver=StubDockerDriver(), install_root=tmp_path)
+
+
+def _v2(source_cls: type[_Catalog] = _Catalog) -> _Catalog:
+    src = source_cls(enabled=True)
+    object.__setattr__(src, "image", _IMAGE_V2)
+    object.__setattr__(src, "index_digest", "sha256:two")
+    object.__setattr__(src, "mission_version", "1.1.0")
+    return src
+
+
+# ── update_mission (the spine) ───────────────────────────────────────────────────────────────
+
+
+def test_update_not_installed_raises_not_found(tmp_path: Path) -> None:
+    with pytest.raises(NotFoundError):
+        update_mission("sqli-login", _deps(tmp_path, _Catalog(enabled=True)))
+
+
+def test_update_your_own_install_is_a_collision(tmp_path: Path) -> None:
+    # A your_own install updates by re-ingesting its bundle, never from the catalog.
+    from xorcise.core.contracts.control import MissionRef
+    from xorcise.core.missions.runtime import INSTALLED_FILE, InstalledMission
+
+    d = tmp_path / "sqli-login"
+    d.mkdir(parents=True)
+    manifest = _Catalog(enabled=True).fetch_manifest("sqli-login")
+    ref = MissionRef(mission_id="sqli-login", image="xorcise/mission-sqli-login:local")
+    (d / INSTALLED_FILE).write_text(
+        InstalledMission("sqli-login", d, manifest, ref, origin="your_own").to_record()
+    )
+    with pytest.raises(MissionCollisionError):
+        update_mission("sqli-login", _deps(tmp_path, _Catalog(enabled=True)))
+
+
+def test_update_is_a_noop_when_digests_match(tmp_path: Path) -> None:
+    src = _Catalog(enabled=True)
+    pull_mission("sqli-login", _deps(tmp_path, src))
+    ic, updated = update_mission("sqli-login", _deps(tmp_path, src))
+    assert updated is False
+    assert ic.install_revision == 1  # nothing re-installed
+
+
+def test_update_reinstalls_when_the_catalog_moved(tmp_path: Path) -> None:
+    pull_mission("sqli-login", _deps(tmp_path, _Catalog(enabled=True)))
+    d = _deps(tmp_path, _v2())
+    ic, updated = update_mission("sqli-login", d)
+    assert updated is True
+    assert ic.install_revision == 2  # atomic in-place re-install bumps the counter
+    assert ic.mission_ref.image == _IMAGE_V2
+    assert ic.index_digest == "sha256:two"
+    assert ic.mission_version == "1.1.0"
+    # the record on disk is the new one
+    again = get_installed("sqli-login", tmp_path)
+    assert again is not None and again.index_digest == "sha256:two"
+
+
+def test_update_falls_back_to_the_release_ref_without_digests(tmp_path: Path) -> None:
+    # A pre-digest catalog still MOVES the immutable release ref whenever anything changes.
+    class _NoDigest(_Catalog):
+        index_digest = None
+
+    pull_mission("sqli-login", _deps(tmp_path, _NoDigest(enabled=True)))
+    ic, updated = update_mission("sqli-login", _deps(tmp_path, _NoDigest(enabled=True)))
+    assert updated is False  # same ref ⇒ current
+    moved = _v2(_NoDigest)
+    object.__setattr__(moved, "index_digest", None)
+    ic, updated = update_mission("sqli-login", _deps(tmp_path, moved))
+    assert updated is True
+    assert ic.mission_ref.image == _IMAGE_V2
+
+
+# ── browse-row detection (§34) ───────────────────────────────────────────────────────────────
+
+
+def test_installed_row_flags_update_available(tmp_path: Path) -> None:
+    pull_mission("sqli-login", _deps(tmp_path, _Catalog(enabled=True)))
+    row = next(
+        e
+        for e in list_catalog(CatalogViewDeps(source=_v2(), install_root=tmp_path))
+        if e.mission_id == "sqli-login"
+    )
+    assert row.update_available is True
+    assert row.mission_version == "1.0.0"  # what THIS install recorded
+    assert row.current_mission_version == "1.1.0"  # what the catalog serves now
+    assert row.installed is True
+
+
+def test_installed_row_up_to_date_is_false_not_none(tmp_path: Path) -> None:
+    src = _Catalog(enabled=True)
+    pull_mission("sqli-login", _deps(tmp_path, src))
+    row = next(
+        e
+        for e in list_catalog(CatalogViewDeps(source=src, install_root=tmp_path))
+        if e.mission_id == "sqli-login"
+    )
+    assert row.update_available is False
+
+
+def test_pre_contract_install_update_state_is_unknown(tmp_path: Path) -> None:
+    # The plain stub records no identity AND its fixture image never moves: with digests on
+    # neither side and an unchanged ref, ref-compare answers False (honestly current).
+    # A your_own row, by contrast, has no upstream at all ⇒ None.
+    src = StubCatalogSource(enabled=True)
+    pull_mission(
+        "sqli-login", PullDeps(source=src, driver=StubDockerDriver(), install_root=tmp_path)
+    )
+    row = next(
+        e
+        for e in list_catalog(CatalogViewDeps(source=src, install_root=tmp_path))
+        if e.mission_id == "sqli-login"
+    )
+    assert row.update_available is False
+
+
+# ── REST route ───────────────────────────────────────────────────────────────────────────────
+
+
+def test_rest_update_unknown_mission_404(migrated_home) -> None:
+    from fastapi.testclient import TestClient
+
+    from xorcise.core.roles.boot.role_all import build_rest_app
+
+    resp = TestClient(build_rest_app()).post("/api/missions/ghost/update")
+    assert resp.status_code == 404
+
+
+# ── CLI thin client ──────────────────────────────────────────────────────────────────────────
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"\x1b\[[0-9;]*m", "", text))
+
+
+def _cli_app() -> typer.Typer:
+    import xorcise.core.cli.app  # noqa: F401 — registers commands on the shared app
+    from xorcise.core.cli._shared import app
+
+    return app
+
+
+def test_cli_mission_update_posts_to_the_rest_server(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(self, path: str) -> Any:  # noqa: ANN001 — test stub
+        assert path == "/missions"
+        return [{"mission_id": "sqli-login", "name": "SQLi Login", "installed": True}]
+
+    def fake_post(self, path: str, json: Any, timeout: float | None = None) -> Any:  # noqa: ANN001
+        captured["path"] = path
+        return {"updated": True, "entry": {"name": "SQLi Login"}}
+
+    monkeypatch.setattr("xorcise.core.cli.commands.mission.RestClient.get", fake_get)
+    monkeypatch.setattr("xorcise.core.cli.commands.mission.RestClient.post", fake_post)
+    result = CliRunner().invoke(_cli_app(), ["mission", "update", "sqli-login"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/missions/sqli-login/update"
+    assert "updated 'SQLi Login' (sqli-login)" in _plain(result.output)
+
+
+def test_cli_mission_update_reports_already_current(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "xorcise.core.cli.commands.mission.RestClient.get",
+        lambda self, path: [{"mission_id": "sqli-login", "name": "SQLi Login", "installed": True}],
+    )
+    monkeypatch.setattr(
+        "xorcise.core.cli.commands.mission.RestClient.post",
+        lambda self, path, json, timeout=None: {"updated": False, "entry": {}},
+    )
+    result = CliRunner().invoke(_cli_app(), ["mission", "update", "sqli-login"])
+    assert result.exit_code == 0, result.output
+    assert "already up to date" in _plain(result.output)
+
+
+def test_cli_mission_update_not_installed_fails_with_pull_hint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "xorcise.core.cli.commands.mission.RestClient.get",
+        lambda self, path: [{"mission_id": "sqli-login", "name": "SQLi Login", "installed": False}],
+    )
+    result = CliRunner().invoke(_cli_app(), ["mission", "update", "sqli-login"])
+    assert result.exit_code == 1
+    out = _plain(result.output + str(result.exception or ""))
+    assert "not installed" in out

--- a/tests/unit/test_missions_ingestion.py
+++ b/tests/unit/test_missions_ingestion.py
@@ -249,10 +249,10 @@ def test_ingest_first_install_version_is_1(tmp_path: Path) -> None:
     bundle = _write_bundle(tmp_path)
     root = tmp_path / "installed"
     inst = ingest(bundle, builder=StubBundleBuilder(), install_root=root)
-    assert inst.version == 1
+    assert inst.install_revision == 1
     loaded = get_installed("basic-pivot", root)
     assert loaded is not None
-    assert loaded.version == 1
+    assert loaded.install_revision == 1
 
 
 def test_ingest_reinstall_bumps_version(tmp_path: Path) -> None:
@@ -260,10 +260,10 @@ def test_ingest_reinstall_bumps_version(tmp_path: Path) -> None:
     root = tmp_path / "installed"
     ingest(bundle, builder=StubBundleBuilder(), install_root=root)
     inst2 = ingest(bundle, builder=StubBundleBuilder(), install_root=root)
-    assert inst2.version == 2
+    assert inst2.install_revision == 2
     loaded = get_installed("basic-pivot", root)
     assert loaded is not None
-    assert loaded.version == 2
+    assert loaded.install_revision == 2
 
 
 def test_legacy_record_without_version_reads_as_1(tmp_path: Path) -> None:
@@ -285,7 +285,7 @@ def test_legacy_record_without_version_reads_as_1(tmp_path: Path) -> None:
     }
     (root / INSTALLED_FILE).write_text(_json.dumps(legacy_record))
     loaded = InstalledMission.from_root(root)
-    assert loaded.version == 1
+    assert loaded.install_revision == 1
 
 
 def test_record_missing_required_keys_degrades_to_not_installed(tmp_path: Path) -> None:

--- a/tests/unit/test_nested_container_support.py
+++ b/tests/unit/test_nested_container_support.py
@@ -149,3 +149,19 @@ def test_base_compat_allows_when_generation_is_undeterminable() -> None:
     # A pre-versioning local fuse: no suffix, no label. Allow rather than block on a signal we
     # cannot read — "re-pull" is not even the right advice for a local ingest.
     dr.require_base_compatible("xorcise/mission-x:local")
+
+
+def test_base_compat_refuses_a_metadata_less_library_install() -> None:
+    # CG4/LEG3: every published artifact carries the base label and the -baseN suffix, so a
+    # LIBRARY install with neither predates the versioned image format — refused with the one
+    # update action, not parsed forever.
+    with pytest.raises(BaseImageIncompatibleError) as exc:
+        dr.require_base_compatible("reg/xorcise/mis-x:oldformat", origin="library")
+    assert "older XORCISE image format" in str(exc.value)
+    assert "mission update" in str(exc.value)
+
+
+def test_base_compat_keeps_the_allowance_for_your_own_fuses() -> None:
+    # A local fuse has no catalog upstream; "update from the catalog" is not even the right
+    # advice, so the undeterminable-base allowance stays.
+    dr.require_base_compatible("xorcise/mission-x:local", origin="your_own")

--- a/tests/unit/test_nested_container_support.py
+++ b/tests/unit/test_nested_container_support.py
@@ -136,7 +136,7 @@ def test_base_compat_allows_the_supported_generation_via_label() -> None:
 def test_base_compat_refuses_an_older_artifact_with_repull_advice() -> None:
     with pytest.raises(BaseImageIncompatibleError) as exc:
         dr.require_base_compatible("reg/xorcise/mis-x:abc123-base1")
-    assert "mission pull" in str(exc.value)  # re-pull the newer artifact
+    assert "mission update" in str(exc.value)  # the ONE update action (§35)
 
 
 def test_base_compat_refuses_a_newer_artifact_with_upgrade_advice() -> None:

--- a/tests/unit/test_reporting_repository.py
+++ b/tests/unit/test_reporting_repository.py
@@ -97,36 +97,36 @@ def test_result_conditions_returns_none_for_missing_run(migrated_home):
 
 
 def test_record_result_with_versions_persists_versions(migrated_home):
-    """agent_version + mission_version in ResultConditions are persisted and round-tripped."""
+    """agent_version + install_revision in ResultConditions are persisted and round-tripped."""
     conditions = ResultConditions(
         model="gpt-4o",
         agent_version=2,
-        mission_version=3,
+        install_revision=3,
     )
     reporting.record_result("r1", "a1", _result("r1"), conditions)
     rc = reporting.result_conditions("r1")
     assert rc is not None
     assert rc.agent_version == 2
-    assert rc.mission_version == 3
+    assert rc.install_revision == 3
 
 
 def test_agent_history_entry_carries_versions(migrated_home):
-    """AgentHistoryEntry.conditions carries agent_version + mission_version."""
-    conditions = ResultConditions(agent_version=5, mission_version=7)
+    """AgentHistoryEntry.conditions carries agent_version + install_revision."""
+    conditions = ResultConditions(agent_version=5, install_revision=7)
     reporting.record_result("r1", "a1", _result("r1"), conditions)
     hist = reporting.agent_history("a1")
     assert len(hist) == 1
     assert hist[0].conditions.agent_version == 5
-    assert hist[0].conditions.mission_version == 7
+    assert hist[0].conditions.install_revision == 7
 
 
 def test_record_result_without_versions_defaults_to_1(migrated_home):
-    """Back-compat: no-conditions call yields agent_version=1 + mission_version=1."""
+    """Back-compat: no-conditions call yields agent_version=1 + install_revision=1."""
     reporting.record_result("r2", "a1", _result("r2"))
     rc = reporting.result_conditions("r2")
     assert rc is not None
     assert rc.agent_version == 1
-    assert rc.mission_version == 1
+    assert rc.install_revision == 1
 
 
 def test_record_result_marks_partial(migrated_home):

--- a/tests/unit/test_run_create_spine.py
+++ b/tests/unit/test_run_create_spine.py
@@ -389,7 +389,75 @@ def test_create_run_captures_agent_version_and_mission_version(migrated_home, in
         deps=_deps(install_root),
     )
     assert run.agent_version == agent.version
-    assert run.mission_version == installed.install_revision
+    assert run.install_revision == installed.install_revision
+
+
+def test_create_run_copies_artifact_provenance_from_installed_json(migrated_home, install_root):
+    """§31: the run row copies the installed artifact's identity at create time — the creator
+    SemVer, base SemVer, content hash, and exactly what this machine pulled (platform +
+    digests) — read from installed.json, never re-resolved from any registry."""
+    from xorcise.core.contracts.control import (
+        InstalledBaseIdentity,
+        InstalledImageIdentity,
+        MissionInstallIdentity,
+    )
+
+    slug = "sqli-login"
+    root = install_root / slug
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = MissionManifest(
+        schema_version="3.0",
+        version="1.4.2",
+        metadata=MissionMetadata(mission_id=slug, name=slug, objective="obj", type="lab"),
+        environment=EnvironmentSpec(),
+    )
+    ref = MissionRef(mission_id=slug, image=f"xorcise/mission-{slug}:0")
+    identity = MissionInstallIdentity(
+        mission_version="1.4.2",
+        mission_base_version="2.4.1",
+        content_hash="ab" * 32,
+        image=InstalledImageIdentity(
+            release_ref="reg/xorcise/mis-sqli-login:1.4.2-base2.4.1",
+            index_digest="sha256:idx",
+            platform="linux/arm64",
+            platform_digest="sha256:arm",
+        ),
+        mission_base=InstalledBaseIdentity(version="2.4.1", index_digest="sha256:base"),
+        pulled_at="2026-08-19T00:00:00+00:00",
+    )
+    (root / INSTALLED_FILE).write_text(
+        InstalledMission(slug, root, manifest, ref, identity=identity).to_record()
+    )
+    agents.register("prov-agent", endpoint="http://a")
+
+    run, _prompt = create_run(
+        agent_name="prov-agent",
+        mission_slug=slug,
+        budget_seconds=300,
+        deps=_deps(install_root),
+    )
+    assert run.mission_version == "1.4.2"
+    assert run.mission_base_version == "2.4.1"
+    assert run.content_hash == "ab" * 32
+    assert run.platform == "linux/arm64"
+    assert run.index_digest == "sha256:idx"
+    assert run.platform_digest == "sha256:arm"
+
+
+def test_create_run_provenance_none_for_pre_contract_install(migrated_home, install_root):
+    """A your_own fuse / pre-contract install has no artifact identity: the run records None,
+    not fabricated values — absence is a fact about the artifact."""
+    agents.register("legacy-agent", endpoint="http://a")
+    _write_installed(install_root, slug="sqli-login", version=1)
+    run, _prompt = create_run(
+        agent_name="legacy-agent",
+        mission_slug="sqli-login",
+        budget_seconds=300,
+        deps=_deps(install_root),
+    )
+    assert run.mission_version is None
+    assert run.index_digest is None
+    assert run.platform is None
 
 
 def test_create_run_captures_source_agent_from_kind(migrated_home, install_root):

--- a/tests/unit/test_run_create_spine.py
+++ b/tests/unit/test_run_create_spine.py
@@ -43,7 +43,7 @@ def _write_installed(install_root: Path, slug: str = "sqli-login", version: int 
     )
     ref = MissionRef(mission_id=slug, image=f"xorcise/mission-{slug}:0")
     (root / INSTALLED_FILE).write_text(
-        InstalledMission(slug, root, manifest, ref, version=version).to_record()
+        InstalledMission(slug, root, manifest, ref, install_revision=version).to_record()
     )
 
 
@@ -134,7 +134,7 @@ def test_create_run_surfaces_static_ip_target_in_prompt(migrated_home, install_r
     )
     ref = MissionRef(mission_id="sqli-login", image="xorcise/mission-sqli-login:0")
     (root / INSTALLED_FILE).write_text(
-        InstalledMission("sqli-login", root, manifest, ref, version=1).to_record()
+        InstalledMission("sqli-login", root, manifest, ref, install_revision=1).to_record()
     )
     _run, prompt = create_run(
         agent_name="alice",
@@ -170,7 +170,7 @@ def test_create_run_surfaces_attachments_in_prompt(migrated_home, install_root):
     )
     ref = MissionRef(mission_id="sqli-login", image="xorcise/mission-sqli-login:0")
     (root / INSTALLED_FILE).write_text(
-        InstalledMission("sqli-login", root, manifest, ref, version=1).to_record()
+        InstalledMission("sqli-login", root, manifest, ref, install_revision=1).to_record()
     )
     _run, prompt = create_run(
         agent_name="alice",
@@ -375,12 +375,12 @@ def test_create_run_captures_agent_version_and_mission_version(migrated_home, in
     from xorcise.core.missions.runtime import get_installed
 
     agent = agents.register("versioned-agent", endpoint="http://a")
-    # Re-install the same slug so InstalledMission.version becomes 2 (monotonic bump).
+    # Re-install the same slug so InstalledMission.install_revision becomes 2 (monotonic bump).
     _write_installed(install_root, slug="sqli-login", version=1)
     _write_installed(install_root, slug="sqli-login", version=2)
     installed = get_installed("sqli-login", install_root)
     assert installed is not None
-    assert installed.version == 2  # pin the 'version M != 1' precondition
+    assert installed.install_revision == 2  # pin the 'revision M != 1' precondition
 
     run, _prompt = create_run(
         agent_name="versioned-agent",
@@ -389,7 +389,7 @@ def test_create_run_captures_agent_version_and_mission_version(migrated_home, in
         deps=_deps(install_root),
     )
     assert run.agent_version == agent.version
-    assert run.mission_version == installed.version
+    assert run.mission_version == installed.install_revision
 
 
 def test_create_run_captures_source_agent_from_kind(migrated_home, install_root):

--- a/tests/unit/test_runs_repository.py
+++ b/tests/unit/test_runs_repository.py
@@ -187,7 +187,7 @@ def test_get_returns_run_or_none(migrated_home):
 
 
 def test_create_run_persists_versions(migrated_home):
-    """agent_version + mission_version are persisted and surfaced on create + get."""
+    """agent_version + install_revision are persisted and surfaced on create + get."""
     entry = runs.create_run(
         agent_id="ag1",
         mission="c1",
@@ -196,19 +196,19 @@ def test_create_run_persists_versions(migrated_home):
         prompt="p",
         run_control_key="k",
         agent_version=2,
-        mission_version=3,
+        install_revision=3,
     )
-    assert entry.agent_version == 2 and entry.mission_version == 3
+    assert entry.agent_version == 2 and entry.install_revision == 3
     got = runs.get("r1")
     assert got is not None
-    assert got.agent_version == 2 and got.mission_version == 3
+    assert got.agent_version == 2 and got.install_revision == 3
 
 
 def test_create_run_versions_default_one(migrated_home):
-    """agent_version + mission_version default to 1 (back-compat)."""
+    """agent_version + install_revision default to 1 (back-compat)."""
     entry = runs.create_run(agent_id="ag2", mission="c2")
     assert entry.agent_version == 1
-    assert entry.mission_version == 1
+    assert entry.install_revision == 1
 
 
 def test_delete_for_agent_removes_only_that_agent(migrated_home):


### PR DESCRIPTION
Adopts the mission-versioning contract's **versioning half** in the OSS client — everything about *identifying* artifacts. The multi-arch half (platform *choice*) stacks on top as a follow-up PR, so this PR deliberately records pinned-platform facts without changing how the platform is selected.

The blocking problem this solves: the contract-era catalog serves manifests as **schema 3.0 with a required creator SemVer `version`**, and this client (`Literal["2.0"]`, `extra="forbid"`) refused every published mission — `xorcise mission pull` died on a pydantic traceback.

## What lands, per commit

1. **Schema 3.0 adoption** — manifests validate as 2.0 (pre-contract, kept forever for prod and history) or 3.0 (requires `version`, matching the served pattern exactly: no leading zeros, no pre-release/build suffix). A manifest the client cannot validate raises the typed `UnsupportedManifestVersionError` ("upgrade XORCISE"), never a traceback.
2. **Identity plumbing** — `CatalogSource.fetch_detail` returns the manifest plus its identity siblings; `LibraryItem`/`CatalogEntry` carry the API1 list-row summary (`mission_version`, `mission_base_version`, `index_digest`, `platforms`); `installed.json` records the §30 slice at pull time (identity from the detail response + a post-pull inspect for the platform that actually landed). The monotonic int install counter is renamed `install_revision` — the contract reserves `mission_version` for the SemVer string.
3. **Run evidence (§31)** — run rows copy the artifact identity at create time (SemVers, content hash, platform, digests), filled from `installed.json` and never re-resolved. One Alembic migration (0002) carries the rename plus all new columns; verified to round-trip existing data through upgrade and downgrade.
4. **Update detection + one update action (§34/§35)** — installed rows compare their recorded index digest against the catalog's current one (release-ref fallback for pre-digest catalogs); `POST /missions/{id}/update` + `xorcise mission update <id>` re-pull in place, atomically (an already-current install is an untouched no-op). The `delete && pull` remedy is retired everywhere.
5. **Mission-base visibility (§27/§36) + CG4** — `GET /v1/mission-base` surfaces in settings and `xorcise doctor` beside the client's `REQUIRED_BASE_MAJOR`; a metadata-less **library** install is now refused with the update action (the legacy allowance stays for `your_own` local fuses).

## Rollout safety

Every new field is optional end to end: against the pre-contract production catalog (2.0 manifests, no identity fields, no `/v1/mission-base`) the client lists, pulls, and runs exactly as before — verified by tests that pin the degraded path at each layer.

## Verification

- `pytest -m unit|adapters|topology|integration`, `mypy`, `ruff check` + `format --check`, `lint-imports` — all green (the ~40 local unit failures are the known terminal-colorization artifacts, untouched; they pass in CI).
- Migration 0002 exercised against a populated 0001 database in both directions.
- OpenAPI + typed frontend schema regenerated; frontend typecheck and all 706 tests green.

Stacked follow-up: `feat-mission-multi-arch` (native-first platform selection, AMD64 fallback, post-pull verification) targets this branch.
