### PR TITLE
feat(runner): native-first multi-arch execution (selection, fallback, verification)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -806,6 +806,17 @@
             ],
             "title": "Download Size Bytes"
           },
+          "emulated": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Emulated"
+          },
           "image": {
             "anyOf": [
               {
@@ -873,6 +884,17 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
           },
           "platforms": {
             "default": [],
@@ -3577,6 +3599,17 @@
             "default": "",
             "title": "Home",
             "type": "string"
+          },
+          "host_platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Platform"
           },
           "mission_base": {
             "anyOf": [

--- a/frontend/src/features/live-trace/run-live.tsx
+++ b/frontend/src/features/live-trace/run-live.tsx
@@ -366,6 +366,7 @@ export function RunLive({ runId }: { runId: string | null }) {
             </div>
             <MetaItem label="Agent" value={`${agentName} v${r.agent_version}`} />
             <MetaItem label="Harness" value={r.source_agent} />
+            {r.platform && <MetaItem label="Platform" value={r.platform} />}
             {r.model && <MetaItem label="Model" value={r.model} />}
             <MetaItem label="Budget" value={formatBudget(r.budget_seconds)} />
             {startedAt && <MetaItem label="Started" value={startedAt} />}

--- a/frontend/src/features/missions/mission-card.test.ts
+++ b/frontend/src/features/missions/mission-card.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { missionFixture } from "@/test/fixtures";
+
+import { platformTags } from "./mission-card";
+
+describe("platformTags", () => {
+  it("names the platforms of a mission that actually ships an image", () => {
+    const tags = platformTags(
+      missionFixture({
+        type: "lab",
+        image: "registry/mis-x:1",
+        platforms: ["linux/amd64", "linux/arm64"],
+        installed: true,
+        platform: "linux/arm64",
+      }),
+    );
+    expect(tags.map((t) => t.platform)).toEqual(["linux/amd64", "linux/arm64"]);
+    expect(tags.find((t) => t.platform === "linux/arm64")?.installed).toBe(true);
+  });
+
+  it("claims no architecture for a static mission", () => {
+    // The catalog still sends platforms: ["linux/amd64"] for attachment-only missions, which
+    // would otherwise paint an AMD64 badge on something that never runs a container.
+    const tags = platformTags(
+      missionFixture({ type: "static", image: null, platforms: ["linux/amd64"] }),
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("claims no architecture when there is no image, whatever the type says", () => {
+    const tags = platformTags(
+      missionFixture({ type: "lab", image: null, platforms: ["linux/amd64"] }),
+    );
+    expect(tags).toEqual([]);
+  });
+
+  it("still tags an uninstalled lab mission — image tracks type, not install state", () => {
+    const tags = platformTags(
+      missionFixture({
+        type: "lab",
+        image: "registry/mis-y:1",
+        installed: false,
+        platforms: ["linux/amd64", "linux/arm64"],
+      }),
+    );
+    expect(tags.map((t) => t.platform)).toEqual(["linux/amd64", "linux/arm64"]);
+    expect(tags.every((t) => !t.installed)).toBe(true);
+  });
+});

--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -43,6 +43,11 @@ export type PlatformTag = {
  * one thing a lone "installed" badge could never tell you: WHICH arch you actually have.
  */
 export function platformTags(c: CatalogEntry): PlatformTag[] {
+  // A static mission ships an attachment and no container, so it has no architecture to claim.
+  // The catalog still sends platforms: ["linux/amd64"] for those rows, which would otherwise
+  // paint an AMD64 badge on a mission that never runs an image. Keyed on the artifact as well as
+  // the type, so a tag only ever reflects something that actually exists.
+  if (c.type === "static" || !c.image) return [];
   const all =
     c.platform && !c.platforms.includes(c.platform)
       ? [...c.platforms, c.platform]

--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { Boxes, Download, FileText, FlaskConical, FolderOpen, Loader2 } from "lucide-react";
+import { Boxes, Download, FileText, FlaskConical, FolderOpen, Loader2, RefreshCw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/components/ui/cn";
 import { Progress } from "@/components/ui/progress";
 import type { CatalogEntry } from "@/lib/api/types";
+import { errorDetail } from "@/lib/api/client";
 import {
   formatBytes,
   formatEta,
   pullPhaseLabel,
   usePullMission,
+  useUpdateMission,
   type PullMissionState,
 } from "./queries";
 import { environmentLabel, titleCase } from "./labels";
@@ -20,12 +22,26 @@ import { DifficultyBadge } from "./difficulty-badge";
 
 const MAX_TECH = 3;
 
+/** Compact tag text for a validated platform: "linux/amd64" → "amd64" (the os is noise in a
+ *  catalog that is linux-only by contract; the full value rides the tooltip). */
+export function platformLabel(p: string): string {
+  return p.replace(/^linux\//, "");
+}
+
+const PLATFORMS_TOOLTIP =
+  "Validated platforms — verified by the remote build, never a creator claim. " +
+  "Individual missions may support fewer platforms than the mission-base.";
+
+const EMULATED_TOOLTIP =
+  "This install is not native to this host's architecture; it runs through Docker's " +
+  "emulation layer. Functional, but slower and not validated natively.";
+
 /**
  * The secondary "why" line under the single Update available status (§35/UX1): which of the
  * two versions moved — mission, base, or both. Undefined when the catalog didn't say (the
  * digest alone flagged the update) so the badge still renders, just without a tooltip.
  */
-function updateReason(c: CatalogEntry): string | undefined {
+export function updateReason(c: CatalogEntry): string | undefined {
   const parts: string[] = [];
   if (c.current_mission_version && c.current_mission_version !== c.mission_version) {
     parts.push(`Mission ${c.mission_version ?? "?"} → ${c.current_mission_version}`);
@@ -37,6 +53,51 @@ function updateReason(c: CatalogEntry): string | undefined {
     parts.push(`Mission base ${c.mission_base_version ?? "?"} → ${c.current_mission_base_version}`);
   }
   return parts.length ? parts.join(" · ") : undefined;
+}
+
+/**
+ * §35's one action as a button — shared by the card, the list row and the detail banner so
+ * every surface that can SAY "update available" can also DO the update. Self-contained
+ * feedback (spinner → "Updated." / "Already up to date." / the error detail) in the same
+ * caption idiom the pull block uses.
+ */
+export function UpdateMissionButton({ mission: c }: { mission: CatalogEntry }) {
+  const update = useUpdateMission();
+  return (
+    <span className="flex flex-wrap items-center gap-2">
+      <Button
+        size="sm"
+        variant="outline"
+        aria-busy={update.isPending}
+        disabled={update.isPending}
+        onClick={() => update.mutate(c.mission_id)}
+      >
+        {update.isPending ? (
+          <>
+            <Loader2 className="size-3.5 motion-safe:animate-spin" />
+            Updating…
+          </>
+        ) : (
+          <>
+            <RefreshCw className="size-3.5" />
+            Update
+          </>
+        )}
+      </Button>
+      {update.isSuccess && (
+        <span className="text-caption text-ok">
+          {update.data.updated ? "Updated to the current release." : "Already up to date."}
+        </span>
+      )}
+      {update.isError && (
+        <span className="text-caption text-err">
+          {errorDetail(update.error)
+            ? `Update failed — ${errorDetail(update.error)}`
+            : "Update failed — try again."}
+        </span>
+      )}
+    </span>
+  );
 }
 
 const ENV_TOOLTIP: Record<string, string> = {
@@ -186,6 +247,11 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
                 update available
               </Badge>
             )}
+            {c.emulated === true && (
+              <Badge variant="warn" title={EMULATED_TOOLTIP}>
+                emulated
+              </Badge>
+            )}
             {installed ? (
               <Badge variant="ok">installed</Badge>
             ) : (
@@ -211,11 +277,19 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
           )}
         </div>
 
-        {/* Classification — consistent order; omit anything missing (no empty badges) */}
-        {(c.specialty || c.proficiency) && (
+        {/* Classification — consistent order; omit anything missing (no empty badges).
+            Platform tags sit here (PV5/AS2): validated architectures are a decision input
+            like difficulty — an arm64 operator picks differently when there is no native
+            image. Absent on a pre-contract catalog. */}
+        {(c.specialty || c.proficiency || c.platforms.length > 0) && (
           <div className="flex flex-wrap items-center gap-1.5">
             {c.specialty && <Badge variant="info">{titleCase(c.specialty)}</Badge>}
             {c.proficiency && <DifficultyBadge proficiency={c.proficiency} />}
+            {c.platforms.map((p) => (
+              <Badge key={p} variant="muted" className="font-mono" title={PLATFORMS_TOOLTIP}>
+                {platformLabel(p)}
+              </Badge>
+            ))}
           </div>
         )}
 
@@ -242,10 +316,14 @@ export function MissionCard({ mission: c }: { mission: CatalogEntry }) {
            a total. */}
         <div className="relative z-20 mt-auto flex flex-col items-start gap-2 border-t border-border pt-3">
           {installed ? (
-            <Link href={detailHref} className={cn(buttonVariants({ size: "sm" }))}>
-              <FolderOpen className="size-3.5" />
-              Open
-            </Link>
+            <span className="flex flex-wrap items-center gap-2">
+              <Link href={detailHref} className={cn(buttonVariants({ size: "sm" }))}>
+                <FolderOpen className="size-3.5" />
+                Open
+              </Link>
+              {/* The badge above SAYS it; this DOES it — §35's one update action, in place. */}
+              {c.update_available === true && <UpdateMissionButton mission={c} />}
+            </span>
           ) : pull.isPulling ? (
             <div className="w-full space-y-2">
               <div className="flex items-center gap-1.5">
@@ -337,6 +415,23 @@ export function MissionRow({ mission: c }: { mission: CatalogEntry }) {
           {c.proficiency && <DifficultyBadge proficiency={c.proficiency} />}
           {c.type && <EnvironmentBadge type={c.type} />}
         </div>
+        {/* Same status badges as the card — the two layouts must not disagree about one
+            mission. Compat first (the stronger claim), then the update state, then emulation. */}
+        {c.compatible === false && (
+          <Badge variant="warn" className="hidden shrink-0 sm:inline-flex" title={c.compat_hint ?? undefined}>
+            update required
+          </Badge>
+        )}
+        {c.compatible !== false && c.update_available === true && (
+          <Badge variant="muted" className="hidden shrink-0 sm:inline-flex" title={updateReason(c)}>
+            update available
+          </Badge>
+        )}
+        {c.emulated === true && (
+          <Badge variant="warn" className="hidden shrink-0 sm:inline-flex" title={EMULATED_TOOLTIP}>
+            emulated
+          </Badge>
+        )}
         {!installed && !pull.isPulling && (
           <span className="hidden shrink-0 lg:inline-flex">
             <DownloadSize mission={c} />
@@ -345,12 +440,15 @@ export function MissionRow({ mission: c }: { mission: CatalogEntry }) {
         <Badge variant={installed ? "ok" : "muted"} className="hidden shrink-0 sm:inline-flex">
           {installed ? "installed" : "available"}
         </Badge>
-        <div className="relative z-20 shrink-0">
+        <div className="relative z-20 flex shrink-0 items-center gap-2">
           {installed ? (
-            <Link href={detailHref} className={cn(buttonVariants({ size: "sm" }))}>
-              <FolderOpen className="size-3.5" />
-              Open
-            </Link>
+            <>
+              {c.update_available === true && <UpdateMissionButton mission={c} />}
+              <Link href={detailHref} className={cn(buttonVariants({ size: "sm" }))}>
+                <FolderOpen className="size-3.5" />
+                Open
+              </Link>
+            </>
           ) : pull.isPulling ? (
             <Button size="sm" disabled aria-busy>
               <Loader2 className="size-3.5 motion-safe:animate-spin" />

--- a/frontend/src/features/missions/mission-card.tsx
+++ b/frontend/src/features/missions/mission-card.tsx
@@ -28,6 +28,35 @@ export function platformLabel(p: string): string {
   return p.replace(/^linux\//, "");
 }
 
+export type PlatformTag = {
+  platform: string;
+  installed: boolean;
+  /** Emulation verdict for the INSTALLED tag only (null elsewhere, or when unknown). */
+  emulated: boolean | null;
+};
+
+/**
+ * The platform tags to render for a mission, marking which one is the installed image.
+ *
+ * The installed platform is unioned into the validated list (and de-duplicated) so an install
+ * still names its architecture even against a pre-contract catalog that offers no list — the
+ * one thing a lone "installed" badge could never tell you: WHICH arch you actually have.
+ */
+export function platformTags(c: CatalogEntry): PlatformTag[] {
+  const all =
+    c.platform && !c.platforms.includes(c.platform)
+      ? [...c.platforms, c.platform]
+      : c.platforms;
+  return all.map((platform) => {
+    const isInstalled = c.installed === true && c.platform === platform;
+    return {
+      platform,
+      installed: isInstalled,
+      emulated: isInstalled ? (c.emulated ?? null) : null,
+    };
+  });
+}
+
 const PLATFORMS_TOOLTIP =
   "Validated platforms — verified by the remote build, never a creator claim. " +
   "Individual missions may support fewer platforms than the mission-base.";

--- a/frontend/src/features/missions/mission-detail.tsx
+++ b/frontend/src/features/missions/mission-detail.tsx
@@ -19,6 +19,7 @@ import {
   Package,
   Paperclip,
   Plus,
+  RefreshCw,
   Server,
   ShieldCheck,
   Trash2,
@@ -31,7 +32,12 @@ import { Skeleton, SkeletonRows } from "@/components/ui/skeleton";
 import { Reveal } from "@/components/ui/reveal";
 import { NotFoundState } from "@/components/layout/not-found-state";
 import type { CatalogEntry, MissionManifest } from "@/lib/api/types";
-import { PullProgressBlock } from "./mission-card";
+import {
+  PullProgressBlock,
+  UpdateMissionButton,
+  platformLabel,
+  updateReason,
+} from "./mission-card";
 import { MissionTerrain } from "./mission-terrain";
 import {
   formatBytes,
@@ -251,6 +257,32 @@ export function MissionDetail({ id }: { id: string | null }) {
             )}
             {c.proficiency && <DifficultyBadge proficiency={c.proficiency} />}
             {c.specialty && <Badge variant="info">{titleCase(c.specialty)}</Badge>}
+            {/* Artifact identity (§25/§36): the creator SemVer and the validated platforms
+                (PV5 — what the remote build verified, never a creator claim). Absent on a
+                pre-contract catalog; emulated flags an install that is non-native HERE. */}
+            {c.mission_version && (
+              <Badge variant="muted" className="font-mono">
+                v{c.mission_version}
+              </Badge>
+            )}
+            {c.platforms.map((p) => (
+              <Badge
+                key={p}
+                variant="muted"
+                className="font-mono"
+                title="Validated platforms — verified by the remote build, never a creator claim. Individual missions may support fewer platforms than the mission-base."
+              >
+                {platformLabel(p)}
+              </Badge>
+            ))}
+            {c.emulated === true && (
+              <Badge
+                variant="warn"
+                title="This install is not native to this host's architecture; it runs through Docker's emulation layer. Functional, but slower and not validated natively."
+              >
+                emulated
+              </Badge>
+            )}
             {c.installed ? (
               <Badge variant="ok">installed</Badge>
             ) : (
@@ -266,17 +298,26 @@ export function MissionDetail({ id }: { id: string | null }) {
         </div>
       </header>
 
-      {/* Validated platforms (PV5/AS2): what the remote platform actually verified and
-          published — never a creator claim. PS1: support is per mission, so the base offering
-          an architecture never implies this mission does. Absent on a pre-contract catalog. */}
-      {c.platforms.length > 0 && (
-        <p className="text-dense text-text-tertiary">
-          Validated platforms: {c.platforms.join(" · ")}
-          <span className="text-text-tertiary">
-            {" "}
-            — individual missions may support fewer platforms than the mission-base.
-          </span>
-        </p>
+      {/* Update available (§34/§35) — the info sibling of the warning banner below: same
+          placement, same shape, one action. Suppressed while incompatible ("Not runnable"
+          already demands the same action, with a stronger claim). */}
+      {c.installed && c.compatible !== false && c.update_available === true && (
+        <Card className="min-w-0 border-info/30 bg-info/[0.06]" data-testid="mission-update-banner">
+          <CardContent className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 items-start gap-3">
+              <RefreshCw className="mt-0.5 size-5 shrink-0 text-info" />
+              <div className="min-w-0 space-y-1">
+                <p className="text-body font-semibold text-heading">Update available</p>
+                <p className="max-w-full break-words text-body text-text-secondary">
+                  {updateReason(c) ??
+                    "The catalog serves a newer artifact for this mission."}{" "}
+                  One action updates it in place; runs already recorded keep their evidence.
+                </p>
+              </div>
+            </div>
+            <UpdateMissionButton mission={c} />
+          </CardContent>
+        </Card>
       )}
 
       {/* Base-generation incompatibility — surfaced here (and as a card badge) so the mismatch is

--- a/frontend/src/features/missions/mission-detail.tsx
+++ b/frontend/src/features/missions/mission-detail.tsx
@@ -266,6 +266,19 @@ export function MissionDetail({ id }: { id: string | null }) {
         </div>
       </header>
 
+      {/* Validated platforms (PV5/AS2): what the remote platform actually verified and
+          published — never a creator claim. PS1: support is per mission, so the base offering
+          an architecture never implies this mission does. Absent on a pre-contract catalog. */}
+      {c.platforms.length > 0 && (
+        <p className="text-dense text-text-tertiary">
+          Validated platforms: {c.platforms.join(" · ")}
+          <span className="text-text-tertiary">
+            {" "}
+            — individual missions may support fewer platforms than the mission-base.
+          </span>
+        </p>
+      )}
+
       {/* Base-generation incompatibility — surfaced here (and as a card badge) so the mismatch is
           seen before a run, not discovered as a failed run-create. Mirrors the Preview banner, in
           the warning treatment. `compat_hint` names the fix (reinstall the mission, or update

--- a/frontend/src/features/missions/mission-detail.tsx
+++ b/frontend/src/features/missions/mission-detail.tsx
@@ -36,6 +36,7 @@ import {
   PullProgressBlock,
   UpdateMissionButton,
   platformLabel,
+  platformTags,
   updateReason,
 } from "./mission-card";
 import { MissionTerrain } from "./mission-terrain";
@@ -265,24 +266,38 @@ export function MissionDetail({ id }: { id: string | null }) {
                 v{c.mission_version}
               </Badge>
             )}
-            {c.platforms.map((p) => (
+            {/* One tag per validated architecture; the INSTALLED image's tag is lit and
+                suffixed (native / emulated), so the page answers "which arch do I have?"
+                directly rather than listing two indistinguishable tags. A validated-but-not
+                -installed arch stays muted. The emulation state rides the installed tag itself
+                — no separate floating badge to guess the referent of. */}
+            {platformTags(c).map(({ platform, installed, emulated }) => (
               <Badge
-                key={p}
-                variant="muted"
+                key={platform}
+                variant={
+                  installed ? (emulated === true ? "warn" : emulated === false ? "ok" : "default") : "muted"
+                }
                 className="font-mono"
-                title="Validated platforms — verified by the remote build, never a creator claim. Individual missions may support fewer platforms than the mission-base."
+                title={
+                  installed
+                    ? emulated === true
+                      ? "Installed image — runs through Docker's emulation layer (not native to this host): functional, but slower and not validated natively."
+                      : emulated === false
+                        ? "Installed image — native to this host's architecture."
+                        : "Installed image."
+                    : "Validated by the remote build (not the installed image). Individual missions may support fewer platforms than the mission-base."
+                }
               >
-                {platformLabel(p)}
+                {platformLabel(platform)}
+                {installed
+                  ? emulated === true
+                    ? " · emulated"
+                    : emulated === false
+                      ? " · native"
+                      : " · installed"
+                  : ""}
               </Badge>
             ))}
-            {c.emulated === true && (
-              <Badge
-                variant="warn"
-                title="This install is not native to this host's architecture; it runs through Docker's emulation layer. Functional, but slower and not validated natively."
-              >
-                emulated
-              </Badge>
-            )}
             {c.installed ? (
               <Badge variant="ok">installed</Badge>
             ) : (

--- a/frontend/src/features/missions/queries.ts
+++ b/frontend/src/features/missions/queries.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, errorDetail } from "@/lib/api/client";
 import type {
+  MissionUpdateOut,
   CatalogEntry,
   CatalogStatus,
   MissionManifest,
@@ -221,6 +222,21 @@ export function pullPhaseLabel(phase: string | null): string {
 
 // Uninstall an installed mission — local or pulled. Refreshes the catalog so it drops
 // out of Your Own / falls back to not-installed in the library.
+/**
+ * §35's ONE update action: an in-place, atomic server-side re-pull of an installed library
+ * mission onto the catalog's current artifact. Synchronous by design — layers shared with the
+ * previous release are already local, so an update usually moves far fewer bytes than the
+ * first pull; `updated: false` means the install already matched and nothing was touched.
+ */
+export function useUpdateMission() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<MissionUpdateOut>(`/missions/${encodeURIComponent(id)}/update`, {}),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["missions"] }),
+  });
+}
+
 export function useDeleteMission() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/features/missions/update-mission.test.tsx
+++ b/frontend/src/features/missions/update-mission.test.tsx
@@ -109,6 +109,39 @@ describe("update action", () => {
   });
 });
 
+describe("installed architecture on the detail page", () => {
+  const wireDetail = (mission: CatalogEntry) =>
+    server.use(
+      http.get("*/api/missions", () => HttpResponse.json([mission])),
+      http.get("*/api/missions/sqli-login/manifest", () => HttpResponse.json(null)),
+      http.get("*/api/missions/sqli-login/terrain", () => HttpResponse.json(null)),
+    );
+
+  it("marks the installed arch native and leaves the other validated arch muted", async () => {
+    wireDetail({ ...BASE, platform: "linux/arm64", emulated: false });
+    renderWithProviders(<MissionDetail id="sqli-login" />);
+    // The installed image reads "arm64 · native"; the other stays a plain validated tag.
+    expect(await screen.findByText(/arm64 · native/i)).toBeInTheDocument();
+    expect(screen.getByText("amd64")).toBeInTheDocument();
+    expect(screen.queryByText(/amd64 ·/i)).not.toBeInTheDocument();
+  });
+
+  it("marks the installed arch emulated when it is non-native here", async () => {
+    wireDetail({ ...BASE, platform: "linux/amd64", emulated: true });
+    renderWithProviders(<MissionDetail id="sqli-login" />);
+    expect(await screen.findByText(/amd64 · emulated/i)).toBeInTheDocument();
+    // No separate floating "emulated" badge — the state lives on the tag it describes.
+    expect(screen.queryByText(/^emulated$/i)).not.toBeInTheDocument();
+  });
+
+  it("names the installed arch even when the catalog offers no platform list", async () => {
+    // A pre-record install inspected from the local image: platforms empty, platform known.
+    wireDetail({ ...BASE, platforms: [], platform: "linux/amd64", emulated: false });
+    renderWithProviders(<MissionDetail id="sqli-login" />);
+    expect(await screen.findByText(/amd64 · native/i)).toBeInTheDocument();
+  });
+});
+
 describe("platform surfacing", () => {
   it("card: validated platforms render as tags", () => {
     renderWithProviders(<MissionCard mission={{ ...BASE, update_available: false }} />);

--- a/frontend/src/features/missions/update-mission.test.tsx
+++ b/frontend/src/features/missions/update-mission.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { renderWithProviders } from "@/test/render";
+import { MissionCard, MissionRow } from "./mission-card";
+import { MissionDetail } from "./mission-detail";
+import type { CatalogEntry } from "@/lib/api/types";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+// §34/§35 surfacing: every place that SAYS "update available" must be able to DO the update.
+
+const BASE: CatalogEntry = {
+  source: "library",
+  mission_id: "sqli-login",
+  name: "SQLi Login",
+  summary: "A login bypass",
+  installed: true,
+  skills: [],
+  technologies: [],
+  platforms: ["linux/amd64", "linux/arm64"],
+  mission_version: "1.0.0",
+  mission_base_version: "2.0.0",
+  current_mission_version: "1.1.0",
+  update_available: true,
+  platform: "linux/arm64",
+  emulated: false,
+};
+
+beforeEach(() => {
+  // every mounted card resolves its active pull job (reload-resume)
+  server.use(http.get("*/api/missions/pull-jobs", () => HttpResponse.json(null)));
+});
+
+describe("update action", () => {
+  it("card: Update button posts to /missions/{id}/update and reports the result", async () => {
+    let posted = "";
+    server.use(
+      http.post("*/api/missions/sqli-login/update", () => {
+        posted = "sqli-login";
+        return HttpResponse.json({ updated: true, entry: { ...BASE, mission_version: "1.1.0" } });
+      }),
+    );
+    renderWithProviders(<MissionCard mission={BASE} />);
+    fireEvent.click(screen.getByRole("button", { name: /update/i }));
+    await waitFor(() => expect(posted).toBe("sqli-login"));
+    expect(await screen.findByText(/updated to the current release/i)).toBeInTheDocument();
+  });
+
+  it("card: an already-current install reads as such, not as a change", async () => {
+    server.use(
+      http.post("*/api/missions/sqli-login/update", () =>
+        HttpResponse.json({ updated: false, entry: BASE }),
+      ),
+    );
+    renderWithProviders(<MissionCard mission={BASE} />);
+    fireEvent.click(screen.getByRole("button", { name: /update/i }));
+    expect(await screen.findByText(/already up to date/i)).toBeInTheDocument();
+  });
+
+  it("card: a failed update surfaces the server's reason", async () => {
+    server.use(
+      http.post("*/api/missions/sqli-login/update", () =>
+        HttpResponse.json({ detail: "registry unreachable" }, { status: 502 }),
+      ),
+    );
+    renderWithProviders(<MissionCard mission={BASE} />);
+    fireEvent.click(screen.getByRole("button", { name: /update/i }));
+    expect(await screen.findByText(/update failed — registry unreachable/i)).toBeInTheDocument();
+  });
+
+  it("card: no update state ⇒ no Update button", () => {
+    renderWithProviders(
+      <MissionCard mission={{ ...BASE, update_available: false, current_mission_version: null }} />,
+    );
+    expect(screen.queryByRole("button", { name: /update/i })).not.toBeInTheDocument();
+  });
+
+  it("row: shows the update badge and the same action", async () => {
+    let posted = false;
+    server.use(
+      http.post("*/api/missions/sqli-login/update", () => {
+        posted = true;
+        return HttpResponse.json({ updated: true, entry: BASE });
+      }),
+    );
+    renderWithProviders(
+      <ul>
+        <MissionRow mission={BASE} />
+      </ul>,
+    );
+    expect(screen.getByText("update available")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /update/i }));
+    await waitFor(() => expect(posted).toBe(true));
+  });
+
+  it("detail: renders the update banner with the version delta and the action", async () => {
+    server.use(
+      http.get("*/api/missions", () => HttpResponse.json([BASE])),
+      http.get("*/api/missions/sqli-login/manifest", () => HttpResponse.json(null)),
+      http.get("*/api/missions/sqli-login/terrain", () => HttpResponse.json(null)),
+    );
+    renderWithProviders(<MissionDetail id="sqli-login" />);
+    const banner = await screen.findByTestId("mission-update-banner");
+    expect(banner).toHaveTextContent("Update available");
+    expect(banner).toHaveTextContent("Mission 1.0.0 → 1.1.0");
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+  });
+});
+
+describe("platform surfacing", () => {
+  it("card: validated platforms render as tags", () => {
+    renderWithProviders(<MissionCard mission={{ ...BASE, update_available: false }} />);
+    expect(screen.getByText("amd64")).toBeInTheDocument();
+    expect(screen.getByText("arm64")).toBeInTheDocument();
+  });
+
+  it("card + row: an emulated install is flagged", () => {
+    renderWithProviders(<MissionCard mission={{ ...BASE, emulated: true }} />);
+    expect(screen.getByText("emulated")).toBeInTheDocument();
+  });
+
+  it("card: a pre-contract row shows no platform tags and no flags", () => {
+    renderWithProviders(
+      <MissionCard
+        mission={{
+          ...BASE,
+          platforms: [],
+          platform: null,
+          emulated: null,
+          update_available: null,
+          mission_version: null,
+          current_mission_version: null,
+        }}
+      />,
+    );
+    expect(screen.queryByText("amd64")).not.toBeInTheDocument();
+    expect(screen.queryByText("emulated")).not.toBeInTheDocument();
+    expect(screen.queryByText("update available")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/missions/update-mission.test.tsx
+++ b/frontend/src/features/missions/update-mission.test.tsx
@@ -19,6 +19,9 @@ const BASE: CatalogEntry = {
   installed: true,
   skills: [],
   technologies: [],
+  // A lab mission always ships a container; platform tags are a claim about that artifact.
+  type: "lab",
+  image: "registry/mis-sqli-login:1.0.0",
   platforms: ["linux/amd64", "linux/arm64"],
   mission_version: "1.0.0",
   mission_base_version: "2.0.0",

--- a/frontend/src/features/results/conditions-card.test.tsx
+++ b/frontend/src/features/results/conditions-card.test.tsx
@@ -47,3 +47,9 @@ describe("ConditionsCard", () => {
     expect(container.querySelector("*")).toBeNull();
   });
 });
+
+it("surfaces the executed platform when the run recorded one (§43-UX8)", () => {
+  renderWithProviders(<ConditionsCard conditions={{ ...base, platform: "linux/amd64" }} />);
+  expect(screen.getByText("Platform")).toBeInTheDocument();
+  expect(screen.getByText("linux/amd64")).toBeInTheDocument();
+});

--- a/frontend/src/features/results/conditions-card.tsx
+++ b/frontend/src/features/results/conditions-card.tsx
@@ -13,6 +13,9 @@ export function ConditionsCard({ conditions }: { conditions: ResultConditions })
     rows.push({ label: "Judge model", value: conditions.judge_model });
   if (conditions.budget_seconds > 0)
     rows.push({ label: "Budget", value: `${conditions.budget_seconds}s` });
+  // §31/§43-UX8: the platform the artifact executed on is result context — an amd64 score
+  // produced under emulation on an arm host reads differently from a native one.
+  if (conditions.platform) rows.push({ label: "Platform", value: conditions.platform });
   // Assistance: surface intel disclosure per run so an assisted result reads differently from an
   // unassisted one. Shown only when intel was actually disclosed (omitted like the other fields
   // when zero, so unassisted runs stay clean).

--- a/frontend/src/features/results/results-view.tsx
+++ b/frontend/src/features/results/results-view.tsx
@@ -254,6 +254,9 @@ function RunMetaBar({ run, agentName }: { run: RunEntry; agentName: string }) {
     { label: "Mission", value: `${run.mission} v${run.mission_version ?? run.install_revision}` },
     { label: "Agent", value: `${agentName} v${run.agent_version}` },
     { label: "Harness", value: run.source_agent },
+    // The architecture the run executed on (§43-UX8) — omitted for a pre-contract run so its
+    // bar is unchanged, mono because it is a machine token (linux/arm64).
+    ...(run.platform ? [{ label: "Platform", value: run.platform, mono: true }] : []),
     { label: "Started", value: fullTime(run.created_at), mono: true },
     { label: "Duration", value: formatDuration(elapsed), mono: true },
   ];

--- a/frontend/src/features/results/results.test.tsx
+++ b/frontend/src/features/results/results.test.tsx
@@ -116,6 +116,34 @@ describe("ResultsView", () => {
     expect(screen.getByText("sqli-login v1")).toBeInTheDocument();
   });
 
+  it("surfaces the executed platform in the meta bar when the run recorded one", async () => {
+    // §31/§43-UX8: the architecture a run actually ran on belongs on the report.
+    server.use(
+      http.get("*/api/runs", () =>
+        HttpResponse.json([
+          runFixture({ run_id: "r1", mission: "sqli-login", name: "recon-run", platform: "linux/arm64" }),
+        ]),
+      ),
+      http.get("*/api/runs/r1/result", () => HttpResponse.json(resultView())),
+    );
+    renderWithProviders(<ResultsView runId="r1" />);
+    await screen.findByRole("heading", { name: "recon-run" });
+    expect(screen.getByText("Platform")).toBeInTheDocument();
+    expect(screen.getByText("linux/arm64")).toBeInTheDocument();
+  });
+
+  it("omits the platform cell for a run that recorded none (pre-contract)", async () => {
+    server.use(
+      http.get("*/api/runs", () =>
+        HttpResponse.json([runFixture({ run_id: "r1", mission: "sqli-login", name: "recon-run" })]),
+      ),
+      http.get("*/api/runs/r1/result", () => HttpResponse.json(resultView())),
+    );
+    renderWithProviders(<ResultsView runId="r1" />);
+    await screen.findByRole("heading", { name: "recon-run" });
+    expect(screen.queryByText("Platform")).not.toBeInTheDocument();
+  });
+
   it("surfaces a clear note when the judge is unavailable", async () => {
     server.use(
       http.get("*/api/runs/r1/result", () =>

--- a/frontend/src/features/runs/new-run-form.tsx
+++ b/frontend/src/features/runs/new-run-form.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { useRouter } from "next/navigation";
-import { Check, Cpu, Download, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, Cpu, Download, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -18,13 +18,14 @@ import { cn } from "@/components/ui/cn";
 import { Input } from "@/components/ui/input";
 import { Skeleton, SkeletonRows } from "@/components/ui/skeleton";
 import { useAgents } from "@/features/agents/queries";
+import { useSystem } from "@/features/settings/queries";
 import { HARNESSES } from "@/features/agents/harnesses";
 import {
   useMissions,
   useMissionManifest,
   usePullMission,
 } from "@/features/missions/queries";
-import { PullProgressBlock } from "@/features/missions/mission-card";
+import { PullProgressBlock, platformLabel } from "@/features/missions/mission-card";
 import { titleCase } from "@/features/missions/labels";
 import { errorDetail } from "@/lib/api/client";
 import type { CatalogEntry, Intel } from "@/lib/api/types";
@@ -153,7 +154,42 @@ export function NewRunForm({
 
   const pulled = pull.isSuccess; // the selected mission's pull job reports installed
   const needsPull = !!selectedMission && !selectedMission.installed && !pulled;
-  const canSubmit = !!agent && !!mission && budget > 0 && !starting;
+
+  // Platform honesty at the point of commitment (AS4/PS1). The daemon's native platform comes
+  // from the system probe; every verdict degrades to silence when a side is unknown — a
+  // pre-contract catalog or an unreachable daemon must not spray false warnings.
+  const host = useSystem().data?.host_platform ?? null;
+  const noNativePath = // nothing this host could execute at all — the server would refuse (409)
+    !!selectedMission &&
+    !selectedMission.installed &&
+    !!host &&
+    selectedMission.platforms.length > 0 &&
+    !selectedMission.platforms.includes(host) &&
+    !selectedMission.platforms.includes("linux/amd64");
+  const platformWarning = (() => {
+    const c = selectedMission;
+    if (!c || noNativePath) return null;
+    if (c.installed) {
+      // The server already compared the INSTALLED platform against the daemon (`emulated`).
+      if (c.emulated !== true) return null;
+      return (
+        `This install is ${platformLabel(c.platform ?? "non-native")}` +
+        `${host ? `, not native ${platformLabel(host)}` : ""} — the run executes through ` +
+        "Docker's emulation layer: functional, but slower and not validated natively."
+      );
+    }
+    // Not installed yet: warn BEFORE the download, from the catalog's validated platforms.
+    if (!host || c.platforms.length === 0 || c.platforms.includes(host)) return null;
+    return (
+      `No native ${platformLabel(host)} image exists for this mission (validated: ` +
+      `${c.platforms.map(platformLabel).join(", ")}) — starting will pull the amd64 image ` +
+      "and run it under emulation: functional, but slower and not validated natively here."
+    );
+  })();
+  // A base-generation mismatch is refused server-side (409) — an enabled Start would only
+  // bounce, so it is disabled WITH the reason (never silently).
+  const incompatible = selectedMission?.compatible === false;
+  const canSubmit = !!agent && !!mission && budget > 0 && !starting && !incompatible && !noNativePath;
   // Show the download panel whenever the selected mission is actually pulling (recoverable
   // across navigation), errored, or the operator has just committed to a not-yet-installed one.
   // `isCancelled` keeps the panel up after a cancel so the outcome is stated, rather than the whole
@@ -545,6 +581,46 @@ export function NewRunForm({
             />
 
             <div className="space-y-2 border-t border-border pt-3">
+            {/* Non-blocking honesty (AS4): the operator may proceed, but knowingly. */}
+            {platformWarning && !starting && (
+              <p
+                role="alert"
+                data-testid="platform-warning"
+                className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/[0.06] p-2.5 text-dense text-text-secondary"
+              >
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-warning" aria-hidden />
+                <span>{platformWarning}</span>
+              </p>
+            )}
+            {/* Blocking states carry their reason — a disabled button must never be a riddle. */}
+            {incompatible && (
+              <p
+                role="alert"
+                data-testid="incompatible-blocked"
+                className="flex items-start gap-2 rounded-md border border-err/30 bg-err/[0.06] p-2.5 text-dense text-text-secondary"
+              >
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-err" aria-hidden />
+                <span>
+                  This mission is not runnable on this XORCISE —{" "}
+                  {selectedMission?.compat_hint ??
+                    "it was built for a different base generation."}
+                </span>
+              </p>
+            )}
+            {noNativePath && (
+              <p
+                role="alert"
+                data-testid="no-platform-blocked"
+                className="flex items-start gap-2 rounded-md border border-err/30 bg-err/[0.06] p-2.5 text-dense text-text-secondary"
+              >
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-err" aria-hidden />
+                <span>
+                  This mission has no image this host can execute (validated:{" "}
+                  {selectedMission?.platforms.map(platformLabel).join(", ")}) — the server
+                  would refuse the run.
+                </span>
+              </p>
+            )}
             {showPull && (
               <div className="space-y-1.5 rounded-md border border-border bg-background p-3">
                 <div className="flex items-center gap-1.5 text-label uppercase text-text-tertiary">

--- a/frontend/src/features/runs/new-run-platform.test.tsx
+++ b/frontend/src/features/runs/new-run-platform.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { renderWithProviders } from "@/test/render";
+import { agentFixture, missionFixture } from "@/test/fixtures";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { NewRunForm } from "./new-run-form";
+
+/** Platform honesty at the point of commitment (AS4/PS1): warn on emulation, block — with the
+ *  reason — what the server would refuse anyway (base mismatch, no executable platform). */
+
+const ARM_HOST = { host_platform: "linux/arm64" };
+
+function wire(mission: ReturnType<typeof missionFixture>, system: object | null = ARM_HOST) {
+  server.use(
+    http.get("*/api/agents", () => HttpResponse.json([agentFixture({ name: "scout" })])),
+    http.get("*/api/missions", () => HttpResponse.json([mission])),
+    http.get("*/api/missions/pull-jobs", () => HttpResponse.json(null)),
+    ...(system
+      ? [http.get("*/api/system", () => HttpResponse.json(system))]
+      : []),
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("NewRunForm platform honesty", () => {
+  it("warns before pulling an amd64-only mission on an arm64 host — without blocking", async () => {
+    wire(
+      missionFixture({
+        mission_id: "breachpoint",
+        name: "BreachPoint",
+        source: "library",
+        installed: false,
+        platforms: ["linux/amd64"],
+      }),
+    );
+    renderWithProviders(<NewRunForm initialAgent="scout" initialMission="breachpoint" />);
+    const warning = await screen.findByTestId("platform-warning");
+    expect(warning).toHaveTextContent(/no native arm64 image/i);
+    expect(warning).toHaveTextContent(/emulation/i);
+    expect(await screen.findByRole("button", { name: /download & start run/i })).toBeEnabled();
+  });
+
+  it("warns when the INSTALLED mission runs emulated here", async () => {
+    wire(
+      missionFixture({
+        mission_id: "breachpoint",
+        name: "BreachPoint",
+        source: "library",
+        installed: true,
+        platforms: ["linux/amd64"],
+        platform: "linux/amd64",
+        emulated: true,
+      }),
+    );
+    renderWithProviders(<NewRunForm initialAgent="scout" initialMission="breachpoint" />);
+    const warning = await screen.findByTestId("platform-warning");
+    expect(warning).toHaveTextContent(/emulation layer/i);
+    expect(await screen.findByRole("button", { name: /start run/i })).toBeEnabled();
+  });
+
+  it("stays silent when nothing is known (pre-contract catalog, no daemon)", async () => {
+    wire(
+      missionFixture({
+        mission_id: "legacy",
+        name: "Legacy",
+        source: "library",
+        installed: true,
+        platforms: [],
+        platform: null,
+        emulated: null,
+      }),
+      { host_platform: null },
+    );
+    renderWithProviders(<NewRunForm initialAgent="scout" initialMission="legacy" />);
+    expect(await screen.findByRole("button", { name: /start run/i })).toBeEnabled();
+    expect(screen.queryByTestId("platform-warning")).not.toBeInTheDocument();
+  });
+
+  it("disables Start — with the reason — for a base-incompatible mission", async () => {
+    wire(
+      missionFixture({
+        mission_id: "old-one",
+        name: "Old One",
+        source: "library",
+        installed: true,
+        compatible: false,
+        compat_hint: "Update this mission to get the current base.",
+      }),
+    );
+    renderWithProviders(<NewRunForm initialAgent="scout" initialMission="old-one" />);
+    const blocked = await screen.findByTestId("incompatible-blocked");
+    expect(blocked).toHaveTextContent(/not runnable on this XORCISE/i);
+    expect(blocked).toHaveTextContent(/update this mission/i);
+    expect(await screen.findByRole("button", { name: /start run/i })).toBeDisabled();
+  });
+
+  it("disables Start when the host can execute none of the validated platforms", async () => {
+    wire(
+      missionFixture({
+        mission_id: "riscv-lab",
+        name: "RiscV Lab",
+        source: "library",
+        installed: false,
+        platforms: ["linux/riscv64"],
+      }),
+    );
+    renderWithProviders(<NewRunForm initialAgent="scout" initialMission="riscv-lab" />);
+    const blocked = await screen.findByTestId("no-platform-blocked");
+    expect(blocked).toHaveTextContent(/no image this host can execute/i);
+    expect(await screen.findByRole("button", { name: /start run/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -1489,6 +1489,8 @@ export interface components {
             current_mission_version?: string | null;
             /** Download Size Bytes */
             download_size_bytes?: number | null;
+            /** Emulated */
+            emulated?: boolean | null;
             /** Image */
             image?: string | null;
             /** Image Size Bytes */
@@ -1508,6 +1510,8 @@ export interface components {
             mission_version?: string | null;
             /** Name */
             name: string;
+            /** Platform */
+            platform?: string | null;
             /**
              * Platforms
              * @default []
@@ -2729,6 +2733,8 @@ export interface components {
              * @default
              */
             home: string;
+            /** Host Platform */
+            host_platform?: string | null;
             mission_base?: components["schemas"]["MissionBaseView"] | null;
             /** Planes */
             planes: components["schemas"]["PlaneStatus"][];

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -34,6 +34,7 @@ export type JudgeTestResult = S["JudgeTestResult"];
 export type MissionManifest = S["MissionManifest"];
 export type IngestStarted = S["IngestStarted"];
 export type IngestJobView = S["IngestJobView"];
+export type MissionUpdateOut = S["MissionUpdateOut"];
 export type SystemInfo = S["SystemInfo"];
 export type PlaneStatus = S["PlaneStatus"];
 export type FsListing = S["FsListing"];

--- a/src/xorcise/core/cli/_diagnostics.py
+++ b/src/xorcise/core/cli/_diagnostics.py
@@ -265,6 +265,29 @@ def control_plane(container: str = "headscale", *, timeout: float = 5.0) -> Chec
     return Check("control plane", False, f"{container!r} is not reachable", _PLANE_FIX)
 
 
+def daemon_platform() -> Check:
+    """The platform missions execute on (AS1 visibility): the DAEMON's native os/arch — which
+    may differ from this Python process (Docker Desktop VM, remote daemon). Informational."""
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return Check("host platform", True, "unknown (docker unreachable)", level="warning")
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return Check("host platform", True, "unknown (docker unreachable)", level="warning")
+    return Check(
+        "host platform",
+        True,
+        f"missions execute on {value} (native); mission support is per mission — "
+        "some missions offer fewer platforms than the base",
+    )
+
+
 def mission_base_release() -> Check:
     """§36 version visibility: the base MAJOR this client requires, beside the release the
     catalog currently promotes. Informational — a pre-contract catalog (prod today) simply

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -22,6 +22,7 @@ from xorcise import __version__
 from xorcise.core.cli._diagnostics import (
     Check,
     control_plane,
+    daemon_platform,
     disk_space,
     docker_compose_v2,
     docker_daemon,
@@ -687,8 +688,10 @@ def doctor(
         )
         raise typer.Exit(1) from exc
     env_checks = _environment_checks()
-    # §36 version visibility: what base this client runs vs what the catalog promotes.
+    # §36 version visibility: what base this client runs vs what the catalog promotes,
+    # and the platform missions execute on (per-mission support may be narrower — PS1).
     env_checks.append(mission_base_release())
+    env_checks.append(daemon_platform())
     # Only under `doctor` — it starts a privileged container, so it must not join the check list
     # `up` runs (and `up` must work on a host that cannot nest: static missions and the UI need
     # nothing nested). Gated on the docker daemon being up, so a Docker-less host gets one

--- a/src/xorcise/core/config/__init__.py
+++ b/src/xorcise/core/config/__init__.py
@@ -119,7 +119,10 @@ class Settings(BaseSettings):
     # platform passed to docker pull/run. Mission images are built amd64-only, so an
     # arm64 host (Apple Silicon) must request linux/amd64 or the pull 404s on a missing arm64
     # manifest; Docker Desktop then runs it under emulation. Empty ⇒ docker picks the host platform.
-    docker_platform: str = "linux/amd64"
+    # Execution-platform OVERRIDE (XORCISE_DOCKER_PLATFORM). "" = automatic: the pull spine
+    # selects per mission — the host-native platform when the mission validated it, AMD64 under
+    # emulation otherwise (AS3/AS4). Setting a value pins every pull/run to it, unconditionally.
+    docker_platform: str = ""
     # The mission stack ALWAYS runs inside the run's own container (DinD). The former
     # host-daemon "sibling" topology is gone — it put every mission's containers on the operator's
     # daemon, so parallel runs collided on fixed container_names and published ports.

--- a/src/xorcise/core/contracts/catalog.py
+++ b/src/xorcise/core/contracts/catalog.py
@@ -74,6 +74,13 @@ class CatalogEntry(_Frozen):
     update_available: bool | None = None
     current_mission_version: str | None = None
     current_mission_base_version: str | None = None
+    # What THIS install actually pulled (§30's image.platform), e.g. "linux/amd64" — None for
+    # a not-installed row, a your_own fuse, or a pre-contract install. `emulated` is the
+    # server's verdict of that platform against the daemon's native one: True = this install
+    # runs under emulation here; False = native; None = unknowable (either side missing).
+    # Server-computed because only the server can see the daemon.
+    platform: str | None = None
+    emulated: bool | None = None
 
 
 class CatalogStatus(_Frozen):

--- a/src/xorcise/core/contracts/config.py
+++ b/src/xorcise/core/contracts/config.py
@@ -181,3 +181,6 @@ class SystemInfo(_Frozen):
     db_url: str = ""  # the active database url (sqlite path under home by default)
     topology: Literal["local", "distributed"] = "local"
     mission_base: MissionBaseView | None = None  # §36 version visibility (None: very old server)
+    # The daemon's native os/arch (AS1) — what missions execute on natively here. None in stub
+    # mode or when docker is unreachable. The run form warns off it (emulation, no-native).
+    host_platform: str | None = None

--- a/src/xorcise/core/contracts/errors.py
+++ b/src/xorcise/core/contracts/errors.py
@@ -61,6 +61,15 @@ class MissionNotInCatalogError(PullError):
     """The id is not installed and not in the catalog — nothing to pull."""
 
 
+class PlatformUnsupportedError(PullError):
+    """No execution path exists for this mission on this host (contract AS4).
+
+    Raised BEFORE any image download, when the host's platform is not among the mission's
+    validated platforms and the AMD64 emulation fallback is not available either. A host/artifact
+    condition, not a registry fault: REST surfaces map it 409 (like BaseImageIncompatibleError),
+    and `str(exc)` carries which platforms the mission does support."""
+
+
 class UnsupportedManifestVersionError(PullError):
     """The catalog served a mission manifest this XORCISE cannot validate.
 

--- a/src/xorcise/core/reporting/render.py
+++ b/src/xorcise/core/reporting/render.py
@@ -181,6 +181,9 @@ def _metadata_rows(ctx: RunReportContext) -> list[tuple[str, str]]:
         ),
         ("Agent", f"{agent} v{ctx.conditions.agent_version}"),
         ("Harness", ctx.run.source_agent or "generic"),
+        # The architecture the run executed on (§31/§43-UX8) — present only for a run that
+        # recorded provenance, so a pre-contract run's table is unchanged.
+        *([("Platform", ctx.conditions.platform)] if ctx.conditions.platform else []),
         ("Started", _ts(ctx.run.created_at)),
         ("Duration", _duration(_elapsed_seconds(ctx))),
         ("Run ID", ctx.run.run_id),

--- a/src/xorcise/core/rest/catalog_view.py
+++ b/src/xorcise/core/rest/catalog_view.py
@@ -79,14 +79,25 @@ def _update_available(ic: InstalledMission, current: LibraryItem | None) -> bool
     return None
 
 
+def _emulated(installed_platform: str | None, host: str | None) -> bool | None:
+    """Whether this install executes under emulation HERE. None when either side is unknown —
+    never a guess; the UI renders nothing rather than a wrong "native"."""
+    if installed_platform is None or host is None:
+        return None
+    return installed_platform != host
+
+
 def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
     """Your Own (installed local store) + the free library, deduped by id (Your Own wins)."""
+    from xorcise.core.config import get_settings
     from xorcise.core.missions import get_installed, list_installed
+    from xorcise.core.rest.docker_runtime import host_platform
 
     # One list call serves both halves: the library loop below AND the update check on
     # installed library rows (comparing a recorded install against the catalog's CURRENT row).
     library_items = deps.source.list_library()
     library_by_id = {item.mission_id: item for item in library_items}
+    host = host_platform(get_settings())
 
     installed_entries: list[CatalogEntry] = []
     installed_ids: set[str] = set()
@@ -126,6 +137,11 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 update_available=_update_available(ic, current),
                 current_mission_version=current.mission_version if current else None,
                 current_mission_base_version=(current.mission_base_version if current else None),
+                # The catalog's CURRENT platform offer, so an installed row can still render
+                # the tags (the install itself records only the one platform it pulled).
+                platforms=current.platforms if current else (),
+                platform=ic.platform,
+                emulated=_emulated(ic.platform, host),
             )
         )
 

--- a/src/xorcise/core/rest/catalog_view.py
+++ b/src/xorcise/core/rest/catalog_view.py
@@ -91,7 +91,7 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
     """Your Own (installed local store) + the free library, deduped by id (Your Own wins)."""
     from xorcise.core.config import get_settings
     from xorcise.core.missions import get_installed, list_installed
-    from xorcise.core.rest.docker_runtime import host_platform
+    from xorcise.core.rest.docker_runtime import host_platform, local_image_platform
 
     # One list call serves both halves: the library loop below AND the update check on
     # installed library rows (comparing a recorded install against the catalog's CURRENT row).
@@ -110,6 +110,10 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
         compat = base_compat_of(ic.mission_ref.image)
         # Update status only makes sense for a LIBRARY install (your_own has no upstream).
         current = library_by_id.get(meta.mission_id) if ic.origin == "library" else None
+        # Installs that predate the §30 record carry no platform — inspect the LOCAL image
+        # instead (it IS what a run executes), so the emulation warning reaches every
+        # existing installation, not only post-contract pulls.
+        platform = ic.platform or local_image_platform(get_settings(), ic.mission_ref.image)
         installed_entries.append(
             CatalogEntry(
                 # origin decides the tab: a pulled library mission stays under XORCISE Remote,
@@ -140,8 +144,8 @@ def list_catalog(deps: CatalogViewDeps) -> tuple[CatalogEntry, ...]:
                 # The catalog's CURRENT platform offer, so an installed row can still render
                 # the tags (the install itself records only the one platform it pulled).
                 platforms=current.platforms if current else (),
-                platform=ic.platform,
-                emulated=_emulated(ic.platform, host),
+                platform=platform,
+                emulated=_emulated(platform, host),
             )
         )
 

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -27,7 +27,9 @@ opens a connection, and the memo builds exactly one client per (re)probe.
 from __future__ import annotations
 
 import logging
+import subprocess
 import threading
+import time
 from collections.abc import Callable, Mapping
 
 from xorcise.core.config import Settings
@@ -143,6 +145,49 @@ def require_nested_support(
         "To bypass this check on a host you know is fine, set "
         "XORCISE_NESTED_CONTAINER_CHECK=skip"
     )
+
+
+# Memoised daemon platform: the arch of a running daemon cannot change, but "docker was down,
+# try again" can — so a short TTL rather than a process-lifetime latch. Shared by the catalog
+# view (per-row `emulated`) and the system view (`host_platform`), both of which poll.
+_HOST_PLATFORM_TTL = 60.0
+_host_platform_memo: tuple[float, str | None] | None = None
+
+
+def host_platform(settings: Settings) -> str | None:
+    """The `os/arch` the local daemon executes natively (AS1), or None when unknowable.
+
+    None in stub mode (no daemon by design), when docker is absent/unreachable, and on any
+    probe failure — unknown, never guessed. A subprocess probe (not the SDK) so a browse call
+    never pays a docker client construction; memoised because every page polls the views that
+    read this."""
+    global _host_platform_memo
+    if settings.use_stubs:
+        return None
+    now = time.monotonic()
+    if _host_platform_memo is not None and now - _host_platform_memo[0] < _HOST_PLATFORM_TTL:
+        return _host_platform_memo[1]
+    value: str | None = None
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        raw = result.stdout.strip()
+        if result.returncode == 0 and "/" in raw:
+            value = raw
+    except (OSError, subprocess.SubprocessError):
+        value = None
+    _host_platform_memo = (now, value)
+    return value
+
+
+def reset_host_platform_memo() -> None:
+    """Drop the memo (tests)."""
+    global _host_platform_memo
+    _host_platform_memo = None
 
 
 def require_base_compatible(

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -185,9 +185,46 @@ def host_platform(settings: Settings) -> str | None:
 
 
 def reset_host_platform_memo() -> None:
-    """Drop the memo (tests)."""
+    """Drop the platform memos (tests)."""
     global _host_platform_memo
     _host_platform_memo = None
+    _image_platform_memo.clear()
+
+
+_IMAGE_PLATFORM_TTL = 60.0
+_image_platform_memo: dict[str, tuple[float, str | None]] = {}
+
+
+def local_image_platform(settings: Settings, image: str) -> str | None:
+    """The `os/arch` of a LOCAL image (docker image inspect), or None when unknowable.
+
+    The §30 install record normally carries the platform a pull selected — but installs that
+    predate the record (and your_own fuses) have nothing recorded, and their runs still deserve
+    the emulation warning. The local image itself is the honest fallback: it IS what a run of
+    this install executes. Memoised per ref (browse polls; an image's arch only changes when
+    its tag is re-pointed by an update/re-fuse, which the short TTL absorbs); None in stub mode
+    and on any probe failure — unknown, never guessed."""
+    if settings.use_stubs or not image:
+        return None
+    now = time.monotonic()
+    hit = _image_platform_memo.get(image)
+    if hit is not None and now - hit[0] < _IMAGE_PLATFORM_TTL:
+        return hit[1]
+    value: str | None = None
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", image],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        raw = result.stdout.strip()
+        if result.returncode == 0 and "/" in raw:
+            value = raw
+    except (OSError, subprocess.SubprocessError):
+        value = None
+    _image_platform_memo[image] = (now, value)
+    return value
 
 
 def require_base_compatible(

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -176,12 +176,26 @@ def host_platform(settings: Settings) -> str | None:
             text=True,
         )
         raw = result.stdout.strip()
-        if result.returncode == 0 and "/" in raw:
+        if result.returncode == 0 and _both_halves(raw):
             value = raw
     except (OSError, subprocess.SubprocessError):
         value = None
     _host_platform_memo = (now, value)
     return value
+
+
+def _both_halves(raw: str) -> bool:
+    """Whether `raw` is a usable `os/arch`, i.e. BOTH halves are present.
+
+    `"/" in raw` is not enough. Under the containerd snapshotter, `docker image inspect
+    --format '{{.Os}}/{{.Architecture}}'` exits 0 and prints a bare "/" for a foreign-arch local
+    image — both fields empty. That passed the old guard, so an unknown platform was recorded as
+    the literal "/" and surfaced to the operator as an architecture: the run form warned "This
+    install is /, not native ARM64", and the detail page painted a "/" tag. Unknown must stay
+    None, which the callers already render as "no claim".
+    """
+    os_, _, arch = raw.partition("/")
+    return bool(os_ and arch)
 
 
 def reset_host_platform_memo() -> None:
@@ -219,7 +233,7 @@ def local_image_platform(settings: Settings, image: str) -> str | None:
             text=True,
         )
         raw = result.stdout.strip()
-        if result.returncode == 0 and "/" in raw:
+        if result.returncode == 0 and _both_halves(raw):
             value = raw
     except (OSError, subprocess.SubprocessError):
         value = None

--- a/src/xorcise/core/rest/mission_pull.py
+++ b/src/xorcise/core/rest/mission_pull.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -29,9 +30,12 @@ from xorcise.core.contracts.control import (
 from xorcise.core.contracts.errors import (
     MissionNotInCatalogError,
     NotFoundError,
+    PlatformUnsupportedError,
     PullCancelled,
     PullError,
 )
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     # Type-only: keep the part-islands off the control-plane boot path (role isolation),
@@ -104,6 +108,9 @@ class PullDeps:
     source: CatalogSource
     driver: DockerDriver
     install_root: Path
+    # Operator platform override (XORCISE_DOCKER_PLATFORM). "" = automatic: native-first
+    # per-mission selection at pull time (AS3), AMD64 fallback under emulation (AS4).
+    platform_override: str = ""
 
 
 def _use_real_docker(settings: Settings) -> bool:
@@ -128,8 +135,8 @@ def _real_docker_driver() -> DockerDriver:
     from xorcise.core.runner.docker.driver import DockerSdkDriver
 
     try:
-        # pin the pull/run platform (default linux/amd64) so amd64-only mission images
-        # resolve on an arm64 host; overridable via XORCISE_DOCKER_PLATFORM.
+        # docker_platform is the operator OVERRIDE (XORCISE_DOCKER_PLATFORM); its "" default
+        # means automatic — the spine selects per mission (native-first) at pull time.
         return DockerSdkDriver(platform=get_settings().docker_platform)
     except Exception as exc:  # daemon unreachable / docker.from_env failure
         raise RuntimeError(
@@ -151,6 +158,7 @@ def build_pull_deps(settings: Settings, *, use_docker: bool | None = None) -> Pu
         source=build_catalog_source(settings),
         driver=driver,
         install_root=Path(settings.missions_root),
+        platform_override=settings.docker_platform,
     )
 
 
@@ -248,6 +256,37 @@ def update_mission(
     return record, True
 
 
+def _select_platform(
+    offered: tuple[str, ...], host: str | None, override: str
+) -> tuple[str | None, str | None]:
+    """The execution platform for this pull → (selection, notice). Native-first (AS3).
+
+    An operator override wins unconditionally. With no validated-platform list (a pre-contract
+    catalog) the selection is None — the driver's construction-time behaviour, exactly as
+    before this feature. Otherwise: the host-native platform when the mission validated it;
+    else AMD64 under the host's emulation layer, with a user-facing notice (AS4); else there
+    is no execution path and the typed error says which platforms the mission does support."""
+    if override:
+        return override, None
+    if not offered:
+        return None, None
+    if host and host in offered:
+        return host, None
+    if "linux/amd64" in offered:
+        notice = None
+        if host:
+            arch = host.rsplit("/", 1)[-1].upper()
+            notice = (
+                f"Native {arch} image unavailable for this mission. "
+                "Running the AMD64 mission using compatibility/emulation mode."
+            )
+        return "linux/amd64", notice
+    raise PlatformUnsupportedError(
+        f"this mission supports {', '.join(offered)}, and this host "
+        f"({host or 'unknown platform'}) has no way to execute any of them"
+    )
+
+
 def _is_current(existing: InstalledMission, detail: MissionDetail, image: str | None) -> bool:
     """Whether the install already IS the catalog's current artifact.
 
@@ -304,6 +343,17 @@ def _acquire_and_install(
         # A lab mission with a download ahead of it — gate now (nesting), before the pull.
         if precheck is not None:
             precheck()
+        # Native-first platform selection (AS1–AS5), decided BEFORE any byte moves so an
+        # impossible host/mission pairing costs one error message, not a download. None ⇒ no
+        # selection was possible (pre-contract catalog / operator made none): the driver's
+        # construction-time behaviour, exactly as before this feature.
+        selected, notice = _select_platform(
+            tuple(p.platform for p in detail.platforms),
+            deps.driver.daemon_platform(),
+            deps.platform_override,
+        )
+        if notice:
+            log.warning("%s: %s", mission_id, notice)
         token = deps.source.pull_token(mission_id)  # None ⇒ image needs no registry auth
         report(PHASE_PREPARING_IMAGE)
         # Aggregate docker's per-layer events into running totals. The sum of layer totals
@@ -348,11 +398,24 @@ def _acquire_and_install(
                 kwargs["auth"] = (token.username, token.password)
             if progress is not None or should_cancel is not None:
                 kwargs["progress"] = on_layer
+            if selected is not None:
+                # Explicit selection (AS5) — forwarded only when one was made, so fakes and
+                # subclasses predating the kwarg keep working (same convention as `progress`).
+                kwargs["platform"] = selected
             deps.driver.pull(image, **kwargs)  # real registry; nothing written yet on failure
         except PullCancelled:
             raise  # NOT a pull failure — let the worker record it as `cancelled`, not `error`
         except Exception as exc:
             raise PullError(f"could not pull {image}: {exc}") from exc
+        # §43-CL6: verify the registry served the platform that was selected. Checked before
+        # anything is written, so a mismatch leaves the mission cleanly not-installed.
+        if selected is not None:
+            actual = deps.driver.image_platform(image)
+            if actual is not None and actual != selected:
+                raise PullError(
+                    f"pulled {image} resolved to {actual}, not the selected {selected} — "
+                    "refusing to install a mismatched artifact"
+                )
 
     # Attachments travel out-of-band in the delivery bundle, not the image: fetch +
     # integrity-check the zip so install_pulled can materialize the declared files. The cloud

--- a/src/xorcise/core/rest/routers/missions.py
+++ b/src/xorcise/core/rest/routers/missions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Response
 from pydantic import BaseModel
@@ -13,9 +13,13 @@ from pydantic import BaseModel
 from xorcise.core.config import get_settings
 from xorcise.core.contracts.catalog import CatalogEntry
 from xorcise.core.contracts.errors import NotFoundError, PlatformUnsupportedError
-from xorcise.core.contracts.mission import MissionManifest, MissionMetadata
+from xorcise.core.contracts.mission import MissionManifest
 from xorcise.core.contracts.terrain import ResolvedTerrainV2
 from xorcise.core.missions.errors import MissionCollisionError
+
+if TYPE_CHECKING:
+    # Type-only: keep the missions island off the module import path (role isolation).
+    from xorcise.core.missions.runtime import InstalledMission
 from xorcise.core.rest.catalog_view import build_catalog_view_deps, fetch_manifest, list_catalog
 from xorcise.core.rest.ingest import ingest_bundle
 from xorcise.core.rest.ingest_jobs import job_store
@@ -81,16 +85,23 @@ class PullJobView(BaseModel):
     entry: CatalogEntry | None = None  # the installed entry, once status == installed
 
 
-def _installed_entry(
-    m: MissionMetadata, image: str | None, source: Literal["your_own", "library"]
-) -> CatalogEntry:
-    """A CatalogEntry from an installed manifest's metadata. `source` reflects the install
-    origin — "library" for a remote pull, "your_own" for a local ingest."""
-    from xorcise.core.rest.catalog_view import base_compat_of
+def _installed_entry(ic: InstalledMission) -> CatalogEntry:
+    """A CatalogEntry for one just-installed mission (pull/update responses).
 
+    Carries the §30 identity the install recorded — the browse view serves richer rows (update
+    state needs the whole catalog), but a pull/update answer must at least tell the UI what
+    landed: versions, digest, and the platform that was actually pulled."""
+    from xorcise.core.config import get_settings
+    from xorcise.core.rest.catalog_view import base_compat_of
+    from xorcise.core.rest.docker_runtime import host_platform
+
+    m = ic.manifest.metadata
+    image = ic.mission_ref.image or None
     compat = base_compat_of(image)
+    platform = ic.platform
+    host = host_platform(get_settings())
     return CatalogEntry(
-        source=source,
+        source=ic.origin,
         mission_id=m.mission_id,
         name=m.name,
         summary=m.summary,
@@ -104,6 +115,11 @@ def _installed_entry(
         base_major=compat.base_major,
         compatible=compat.compatible,
         compat_hint=compat.hint,
+        mission_version=ic.mission_version,
+        mission_base_version=ic.mission_base_version,
+        index_digest=ic.index_digest,
+        platform=platform,
+        emulated=(None if platform is None or host is None else platform != host),
     )
 
 
@@ -188,7 +204,7 @@ def pull(mission_id: str) -> CatalogEntry:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PullError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return _installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin)
+    return _installed_entry(ic)
 
 
 @router.post("/{mission_id}/update")
@@ -224,7 +240,7 @@ def update(mission_id: str) -> MissionUpdateOut:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     return MissionUpdateOut(
         updated=updated,
-        entry=_installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin),
+        entry=_installed_entry(ic),
     )
 
 
@@ -316,7 +332,7 @@ def _pull_job_view(job: PullJob) -> PullJobView:
 
         ic = get_installed(job.mission_id, Path(get_settings().missions_root))
         if ic is not None:
-            entry = _installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin)
+            entry = _installed_entry(ic)
     return PullJobView(
         job_id=job.job_id,
         mission_id=job.mission_id,

--- a/src/xorcise/core/rest/routers/missions.py
+++ b/src/xorcise/core/rest/routers/missions.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from xorcise.core.config import get_settings
 from xorcise.core.contracts.catalog import CatalogEntry
-from xorcise.core.contracts.errors import NotFoundError
+from xorcise.core.contracts.errors import NotFoundError, PlatformUnsupportedError
 from xorcise.core.contracts.mission import MissionManifest, MissionMetadata
 from xorcise.core.contracts.terrain import ResolvedTerrainV2
 from xorcise.core.missions.errors import MissionCollisionError
@@ -182,6 +182,10 @@ def pull(mission_id: str) -> CatalogEntry:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except MissionCollisionError as exc:  # id already owned by a your_own install
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PlatformUnsupportedError as exc:
+        # A host/artifact condition, not a registry fault (like the base-generation refusal):
+        # the mission has no platform this host can execute. 409, message names what it offers.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PullError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     return _installed_entry(ic.manifest.metadata, ic.mission_ref.image, ic.origin)
@@ -211,6 +215,10 @@ def update(mission_id: str) -> MissionUpdateOut:
     except MissionNotInCatalogError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except MissionCollisionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PlatformUnsupportedError as exc:
+        # A host/artifact condition, not a registry fault (like the base-generation refusal):
+        # the mission has no platform this host can execute. 409, message names what it offers.
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PullError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/src/xorcise/core/rest/routers/missions.py
+++ b/src/xorcise/core/rest/routers/missions.py
@@ -93,12 +93,14 @@ def _installed_entry(ic: InstalledMission) -> CatalogEntry:
     landed: versions, digest, and the platform that was actually pulled."""
     from xorcise.core.config import get_settings
     from xorcise.core.rest.catalog_view import base_compat_of
-    from xorcise.core.rest.docker_runtime import host_platform
+    from xorcise.core.rest.docker_runtime import host_platform, local_image_platform
 
     m = ic.manifest.metadata
     image = ic.mission_ref.image or None
     compat = base_compat_of(image)
-    platform = ic.platform
+    # Pre-record installs: the local image itself is the honest platform source (see
+    # catalog_view — the browse row does the same, so the two can never disagree).
+    platform = ic.platform or local_image_platform(get_settings(), image or "")
     host = host_platform(get_settings())
     return CatalogEntry(
         source=ic.origin,

--- a/src/xorcise/core/rest/routers/runs.py
+++ b/src/xorcise/core/rest/routers/runs.py
@@ -16,6 +16,7 @@ from xorcise.core.contracts.errors import (
     BaseImageIncompatibleError,
     ImageNotInstalledError,
     NestedContainersUnavailableError,
+    PlatformUnsupportedError,
 )
 from xorcise.core.contracts.grading import GradeResult
 from xorcise.core.contracts.reporting import ResultConditions, RunStats
@@ -111,6 +112,10 @@ def create_run(payload: RunCreate) -> RunCreatedEntry:
         # The mission's fused image was built on a base generation this XORCISE cannot run — a
         # client/artifact mismatch, not a server fault. 409 (like the not-installed case), and the
         # message carries the direction-aware remediation (re-pull vs upgrade XORCISE).
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PlatformUnsupportedError as exc:
+        # No platform this host can execute (AS4) — a host/artifact condition like the base
+        # refusal above, and caught BEFORE any download. 409, never a 502.
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PullError as exc:  # in-catalog but the fetch failed (e.g. registry unreachable)
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/src/xorcise/core/rest/system_view.py
+++ b/src/xorcise/core/rest/system_view.py
@@ -269,7 +269,16 @@ def build_system_info(settings: Settings) -> SystemInfo:
         db_url=settings.database_url,
         topology=settings.deployment_topology,
         mission_base=_cached("mission_base", lambda: _mission_base_view(source)),
+        host_platform=_host_platform(settings),
     )
+
+
+def _host_platform(settings: Settings) -> str | None:
+    """The daemon native platform via docker_runtime's memoised probe (lazy import: the docker
+    plane stays off this module's import path for roles that don't run it)."""
+    from xorcise.core.rest.docker_runtime import host_platform
+
+    return host_platform(settings)
 
 
 def _mission_base_view(source: object) -> MissionBaseView:

--- a/src/xorcise/core/runner/docker/__init__.py
+++ b/src/xorcise/core/runner/docker/__init__.py
@@ -24,6 +24,10 @@ class ContainerSpec:
     image: str  # OCI image ref the runner pulls
     name: str
     env: tuple[tuple[str, str], ...] = ()
+    # Explicit execution platform (AS5), e.g. "linux/arm64". None ⇒ the driver's default; with
+    # an auto ("") driver default docker then runs the LOCAL image as-is — which is the selected
+    # one by construction, because the pull was explicit.
+    platform: str | None = None
 
 
 @dataclass(frozen=True)
@@ -83,11 +87,15 @@ class DockerDriver(ABC):
         *,
         auth: tuple[str, str] | None = None,
         progress: Callable[[PullProgress], None] | None = None,
+        platform: str | None = None,
     ) -> None:
         """Pull an image into the local store. `auth` is (username, password) for a private
         registry (e.g. a broker-minted ECR token); None ⇒ anonymous pull.
         `progress` (keyword-only, default None ⇒ backward-compatible for existing call sites)
-        receives per-layer byte progress while the pull streams."""
+        receives per-layer byte progress while the pull streams.
+        `platform` (keyword-only, default None) is the explicit per-mission selection (AS5);
+        None falls back to the driver's construction-time platform. The pull spine forwards it
+        only when a selection was actually made, so pre-existing fakes keep working."""
 
     @abstractmethod
     def run(self, spec: ContainerSpec) -> ContainerHandle: ...
@@ -126,6 +134,13 @@ class DockerDriver(ABC):
 
         Non-abstract None default (same reasoning as image_labels): only the real driver
         inspects, and a None simply leaves the install record's platform unknown."""
+        return None
+
+    def daemon_platform(self) -> str | None:
+        """The `os/architecture` the DAEMON executes natively (AS1), or None when unknown.
+
+        This is deliberately the daemon's platform, not this Python process's: the daemon may
+        live in a VM (Docker Desktop) or on another host, and it is where missions execute."""
         return None
 
     @abstractmethod
@@ -192,6 +207,7 @@ class StubDockerDriver(DockerDriver):
         self.compose_projects: set[str] = set()  # test-settable projects holding a network
         self.removed_projects: list[str] = []  # projects released by remove_run_resources
         self.specs: list[ContainerSpec] = []  # every run()'s spec, for assertions
+        self.pulled_platform: str | None = None  # the last pull's explicit platform selection
         self._by_name: dict[str, str] = {}  # container name → container_id (by-name stop)
         self._counter = 0
 
@@ -201,9 +217,11 @@ class StubDockerDriver(DockerDriver):
         *,
         auth: tuple[str, str] | None = None,
         progress: Callable[[PullProgress], None] | None = None,
+        platform: str | None = None,
     ) -> None:
         self.pulled.append(image)
         self.pulled_auth = auth
+        self.pulled_platform = platform
         if progress is not None:
             # Two synthetic layer events (half, done) so stub-mode UI still animates.
             progress(PullProgress(layer_id="stub", status="Downloading", current=512, total=1024))

--- a/src/xorcise/core/runner/docker/driver.py
+++ b/src/xorcise/core/runner/docker/driver.py
@@ -87,6 +87,7 @@ class DockerSdkDriver(DockerDriver):
         *,
         auth: tuple[str, str] | None = None,
         progress: Callable[[PullProgress], None] | None = None,
+        platform: str | None = None,
     ) -> None:
         repo, tag = _split_ref(image)
         auth_config = {"username": auth[0], "password": auth[1]} if auth else None
@@ -97,7 +98,9 @@ class DockerSdkDriver(DockerDriver):
         for evt in self._client.api.pull(
             repo,
             tag=tag,
-            platform=self._platform or None,
+            # The per-mission selection (native-first, AS3) wins; the construction-time value
+            # remains for callers that made none (an override, or a pre-contract catalog).
+            platform=platform or self._platform or None,
             auth_config=auth_config,
             stream=True,
             decode=True,
@@ -140,6 +143,15 @@ class DockerSdkDriver(DockerDriver):
             return None
         return dict((img.attrs.get("Config") or {}).get("Labels") or {})
 
+    def daemon_platform(self) -> str | None:
+        """What the daemon executes natively, from its own version report (AS1)."""
+        try:
+            v = self._client.version()
+        except Exception:  # noqa: BLE001 — an unreachable daemon ⇒ unknown, never a crash
+            return None
+        os_name, arch = v.get("Os"), v.get("Arch")
+        return f"{os_name}/{arch}" if os_name and arch else None
+
     def image_platform(self, image: str) -> str | None:
         """What the LOCAL copy of the image was actually built for, e.g. "linux/amd64".
 
@@ -180,7 +192,7 @@ class DockerSdkDriver(DockerDriver):
             devices=["/dev/net/tun:/dev/net/tun"],
             environment=dict(spec.env),
             labels={MANAGED_LABEL: "true", RUN_ID_LABEL: spec.name},
-            platform=self._platform or None,  # run the amd64 image on an arm64 host
+            platform=spec.platform or self._platform or None,  # the run's selected platform
         )
         return ContainerHandle(container_id=container.id, image=spec.image)
 

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -369,3 +369,54 @@ def test_recorded_platform_wins_over_the_image_inspect(tmp_path: Path, monkeypat
     row = next(e for e in list_catalog(deps) if e.mission_id == slug)
     assert row.platform == "linux/arm64"  # the record, not the inspect
     assert calls == []  # and the fallback never ran
+
+
+# --- platform probes must not accept docker's empty-field output --------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("linux/amd64", "linux/amd64"),
+        ("/", None),  # containerd snapshotter, foreign-arch local image: both fields empty
+        ("linux/", None),
+        ("/amd64", None),
+        ("", None),
+    ],
+)
+def test_local_image_platform_rejects_half_empty_output(monkeypatch, raw, expected):
+    """`"/" in raw` accepted a bare "/" — docker exits 0 with both fields empty for a
+    foreign-arch image under the containerd snapshotter. That surfaced to the operator as an
+    architecture ("This install is /, not native ARM64"). Unknown must stay None."""
+    from xorcise.core.config import Settings
+    from xorcise.core.rest import docker_runtime
+
+    docker_runtime.reset_host_platform_memo()
+
+    class _Result:
+        returncode = 0
+        stdout = raw
+
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.subprocess.run", lambda *a, **k: _Result()
+    )
+    assert docker_runtime.local_image_platform(Settings(use_stubs=False), "img:tag") == expected
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("linux/arm64", "linux/arm64"), ("/", None)])
+def test_host_platform_rejects_half_empty_output(monkeypatch, raw, expected):
+    """Same guard, same reasoning, on the host probe."""
+    from xorcise.core.config import Settings
+    from xorcise.core.rest import docker_runtime
+
+    docker_runtime.reset_host_platform_memo()
+
+    class _Result:
+        returncode = 0
+        stdout = raw
+
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.subprocess.run", lambda *a, **k: _Result()
+    )
+    assert docker_runtime.host_platform(Settings(use_stubs=False)) == expected
+    docker_runtime.reset_host_platform_memo()

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -295,7 +295,7 @@ def test_installed_row_borrows_the_catalog_platform_offer(tmp_path: Path) -> Non
     from xorcise.core.rest.mission_pull import PullDeps, pull_mission
 
     class _Src(StubCatalogSource):
-        def list_library(self):  # type: ignore[override]
+        def list_library(self) -> tuple[LibraryItem, ...]:
             return (
                 LibraryItem(
                     mission_id="sqli-login",

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -316,3 +316,56 @@ def test_installed_row_borrows_the_catalog_platform_offer(tmp_path: Path) -> Non
     )
     assert row.installed is True
     assert row.platforms == ("linux/amd64", "linux/arm64")
+
+
+def test_pre_record_install_falls_back_to_the_local_image_platform(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # An EXISTING installation (made before installed.json recorded a platform) must still get
+    # the emulation verdict: the server inspects the local image — which IS what a run of this
+    # install executes — instead of staying silent.
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.host_platform", lambda settings: "linux/arm64"
+    )
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.local_image_platform",
+        lambda settings, image: "linux/amd64" if image else None,
+    )
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="reg/xorcise/mis-c1:abc123-base2")
+    _write(
+        tmp_path,
+        slug,
+        InstalledMission(slug, tmp_path / slug, _manifest(), ref, origin="library"),
+    )
+    deps = CatalogViewDeps(source=StubCatalogSource(enabled=False), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == slug)
+    assert row.platform == "linux/amd64"  # read off the local image, not the (absent) record
+    assert row.emulated is True  # → the run form's warning fires for this existing install
+
+
+def test_recorded_platform_wins_over_the_image_inspect(tmp_path: Path, monkeypatch) -> None:
+    # A §30 record is authoritative; the inspect is only the fallback for its absence.
+    calls: list[str] = []
+
+    def fake_inspect(settings, image):  # noqa: ANN001 — test stub
+        calls.append(image)
+        return "linux/amd64"
+
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.host_platform", lambda settings: "linux/arm64"
+    )
+    monkeypatch.setattr("xorcise.core.rest.docker_runtime.local_image_platform", fake_inspect)
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="reg/xorcise/mis-c1:1.0.0-base2.0.0")
+    _write(
+        tmp_path,
+        slug,
+        InstalledMission(
+            slug, tmp_path / slug, _manifest(), ref, origin="library", identity=_identity()
+        ),
+    )
+    deps = CatalogViewDeps(source=StubCatalogSource(enabled=False), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == slug)
+    assert row.platform == "linux/arm64"  # the record, not the inspect
+    assert calls == []  # and the fallback never ran

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -164,6 +164,11 @@ class _ContractSource(StubCatalogSource):
 
 
 class _ArmDriver(StubDockerDriver):
+    # An arm64 host whose registry serves what was asked: daemon_platform drives the native
+    # selection, image_platform is the post-pull inspect the record and verification read.
+    def daemon_platform(self) -> str | None:
+        return "linux/arm64"
+
     def image_platform(self, image: str) -> str | None:
         return "linux/arm64"
 

--- a/tests/unit/test_install_identity.py
+++ b/tests/unit/test_install_identity.py
@@ -251,3 +251,68 @@ def test_installed_row_carries_recorded_identity(tmp_path: Path) -> None:
     assert row.mission_base_version == "2.0.0"
     assert row.index_digest == "sha256:idx"
     assert row.platforms == ()  # an install records ONE platform; the offer is the library's
+
+
+# ── platform surfacing for the UI (browse row `platform`/`emulated`, host exposure) ──────────
+
+
+def test_installed_row_carries_platform_and_emulated_verdict(tmp_path: Path, monkeypatch) -> None:
+    # The install pulled arm64; the daemon is amd64 ⇒ the row says which platform landed AND
+    # that it executes under emulation here (server-computed — only the server sees the daemon).
+    monkeypatch.setattr(
+        "xorcise.core.rest.docker_runtime.host_platform", lambda settings: "linux/amd64"
+    )
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="reg/xorcise/mis-c1:1.0.0-base2.0.0")
+    _write(
+        tmp_path,
+        slug,
+        InstalledMission(
+            slug, tmp_path / slug, _manifest(), ref, origin="library", identity=_identity()
+        ),
+    )
+    deps = CatalogViewDeps(source=StubCatalogSource(enabled=False), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == slug)
+    assert row.platform == "linux/arm64"
+    assert row.emulated is True
+
+
+def test_installed_row_platform_unknowns_stay_none(tmp_path: Path, monkeypatch) -> None:
+    # No recorded platform (pre-contract install) and/or no daemon ⇒ None, never a guess.
+    monkeypatch.setattr("xorcise.core.rest.docker_runtime.host_platform", lambda settings: None)
+    slug = "c1"
+    ref = MissionRef(mission_id=slug, image="img")
+    _write(tmp_path, slug, InstalledMission(slug, tmp_path / slug, _manifest(), ref))
+    deps = CatalogViewDeps(source=StubCatalogSource(enabled=False), install_root=tmp_path)
+    row = next(e for e in list_catalog(deps) if e.mission_id == slug)
+    assert row.platform is None
+    assert row.emulated is None
+
+
+def test_installed_row_borrows_the_catalog_platform_offer(tmp_path: Path) -> None:
+    # An install records ONE platform; the browse tags still need the catalog's current offer,
+    # so an installed library row borrows `platforms` from its current catalog row.
+    from xorcise.core.rest.mission_pull import PullDeps, pull_mission
+
+    class _Src(StubCatalogSource):
+        def list_library(self):  # type: ignore[override]
+            return (
+                LibraryItem(
+                    mission_id="sqli-login",
+                    name="SQLi Login",
+                    image="xorcise/mission-sqli-login:1",
+                    platforms=("linux/amd64", "linux/arm64"),
+                ),
+            )
+
+    src = _Src(enabled=True)
+    pull_mission(
+        "sqli-login", PullDeps(source=src, driver=StubDockerDriver(), install_root=tmp_path)
+    )
+    row = next(
+        e
+        for e in list_catalog(CatalogViewDeps(source=src, install_root=tmp_path))
+        if e.mission_id == "sqli-login"
+    )
+    assert row.installed is True
+    assert row.platforms == ("linux/amd64", "linux/arm64")

--- a/tests/unit/test_mission_pull.py
+++ b/tests/unit/test_mission_pull.py
@@ -61,6 +61,7 @@ def test_pull_failure_leaves_not_installed(tmp_path: Path) -> None:
             *,
             auth: tuple[str, str] | None = None,
             progress: Callable[[PullProgress], None] | None = None,
+            platform: str | None = None,
         ) -> None:
             raise RuntimeError("no registry")
 
@@ -418,6 +419,7 @@ def test_a_fully_cached_pull_reports_preparing_not_a_stalled_download(tmp_path: 
             *,
             auth: tuple[str, str] | None = None,
             progress: Callable[[PullProgress], None] | None = None,
+            platform: str | None = None,
         ) -> None:
             self.pulled.append(image)
             if progress is not None:

--- a/tests/unit/test_platform_selection.py
+++ b/tests/unit/test_platform_selection.py
@@ -1,0 +1,155 @@
+# tests/unit/test_platform_selection.py
+"""Native-first platform selection (contract §16/AS1–AS5, §43-CL1/CL2/CL6/CL8).
+
+The pull spine decides the execution platform BEFORE any byte moves: operator override
+first, host-native when the mission validated it, AMD64 under emulation as the fallback,
+and a typed refusal when no execution path exists. After the pull, the landed architecture
+is verified against the selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xorcise.core.catalog import StubCatalogSource
+from xorcise.core.catalog.source import MissionDetail, PlatformImage
+from xorcise.core.contracts.errors import PlatformUnsupportedError, PullError
+from xorcise.core.missions import get_installed
+from xorcise.core.rest.mission_pull import PullDeps, _select_platform, pull_mission
+from xorcise.core.runner.docker import StubDockerDriver
+
+pytestmark = pytest.mark.unit
+
+_BOTH = ("linux/amd64", "linux/arm64")
+
+
+# ── the decision table (pure) ────────────────────────────────────────────────────────────────
+
+
+def test_override_wins_unconditionally() -> None:
+    assert _select_platform(_BOTH, "linux/arm64", "linux/ppc64le") == ("linux/ppc64le", None)
+
+
+def test_no_offered_list_makes_no_selection() -> None:
+    # A pre-contract catalog advertises nothing: the driver's construction-time behaviour,
+    # exactly as before this feature.
+    assert _select_platform((), "linux/arm64", "") == (None, None)
+
+
+def test_native_preferred_when_offered() -> None:
+    assert _select_platform(_BOTH, "linux/arm64", "") == ("linux/arm64", None)
+    assert _select_platform(_BOTH, "linux/amd64", "") == ("linux/amd64", None)
+
+
+def test_amd64_fallback_carries_the_notice() -> None:
+    selected, notice = _select_platform(("linux/amd64",), "linux/arm64", "")
+    assert selected == "linux/amd64"
+    assert notice is not None
+    assert "Native ARM64 image unavailable" in notice
+    assert "emulation" in notice
+
+
+def test_unknown_host_still_selects_from_the_offer() -> None:
+    selected, notice = _select_platform(("linux/amd64",), None, "")
+    assert selected == "linux/amd64"
+    assert notice is None  # nothing to warn about: we cannot claim the host is non-native
+
+
+def test_no_execution_path_raises_typed(capsys) -> None:
+    with pytest.raises(PlatformUnsupportedError) as exc:
+        _select_platform(("linux/arm64",), "linux/amd64", "")
+    assert "linux/arm64" in str(exc.value)  # names what the mission does support
+    assert isinstance(exc.value, PullError)  # rides the existing pull-error plumbing
+
+
+# ── the spine wires the decision to the driver (AS5) and verifies it (§43-CL6) ───────────────
+
+
+class _Source(StubCatalogSource):
+    platforms: tuple[str, ...] = _BOTH
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        return MissionDetail(
+            manifest=self.fetch_manifest(mission_id),
+            mission_version="1.0.0",
+            index_digest="sha256:idx",
+            platforms=tuple(
+                PlatformImage(
+                    os=p.split("/")[0], architecture=p.split("/")[1], digest=f"sha256:{p}"
+                )
+                for p in self.platforms
+            ),
+        )
+
+
+class _ArmHost(StubDockerDriver):
+    def daemon_platform(self) -> str | None:
+        return "linux/arm64"
+
+    def image_platform(self, image: str) -> str | None:
+        return self.pulled_platform  # the registry served exactly what was asked
+
+
+def test_pull_passes_the_native_selection_to_docker(tmp_path: Path) -> None:
+    driver = _ArmHost()
+    ic = pull_mission(
+        "sqli-login", PullDeps(source=_Source(enabled=True), driver=driver, install_root=tmp_path)
+    )
+    assert driver.pulled_platform == "linux/arm64"  # explicit, native-first
+    assert ic.platform == "linux/arm64"  # and the install record agrees (§30)
+    assert ic.platform_digest == "sha256:linux/arm64"
+
+
+def test_pull_override_reaches_docker(tmp_path: Path) -> None:
+    driver = _ArmHost()
+    deps = PullDeps(
+        source=_Source(enabled=True),
+        driver=driver,
+        install_root=tmp_path,
+        platform_override="linux/amd64",
+    )
+    pull_mission("sqli-login", deps)
+    assert driver.pulled_platform == "linux/amd64"
+
+
+def test_pull_refuses_before_downloading_when_no_path_exists(tmp_path: Path) -> None:
+    class _ArmOnly(_Source):
+        platforms = ("linux/arm64",)
+
+    class _Amd(StubDockerDriver):
+        def daemon_platform(self) -> str | None:
+            return "linux/amd64"
+
+    driver = _Amd()
+    with pytest.raises(PlatformUnsupportedError):
+        pull_mission(
+            "sqli-login",
+            PullDeps(source=_ArmOnly(enabled=True), driver=driver, install_root=tmp_path),
+        )
+    assert driver.pulled == []  # refused BEFORE any byte moved (CG5 analogue)
+    assert get_installed("sqli-login", tmp_path) is None
+
+
+def test_pull_verifies_the_landed_architecture(tmp_path: Path) -> None:
+    class _LyingRegistry(_ArmHost):
+        def image_platform(self, image: str) -> str | None:
+            return "linux/amd64"  # asked for arm64, got amd64
+
+    with pytest.raises(PullError, match="resolved to linux/amd64"):
+        pull_mission(
+            "sqli-login",
+            PullDeps(source=_Source(enabled=True), driver=_LyingRegistry(), install_root=tmp_path),
+        )
+    assert get_installed("sqli-login", tmp_path) is None  # nothing installed on mismatch
+
+
+def test_pre_contract_pull_is_untouched(tmp_path: Path) -> None:
+    # No platforms offered ⇒ no selection, no platform kwarg, no verification — byte-for-byte
+    # the pre-feature behaviour against prod.
+    driver = StubDockerDriver()
+    pull_mission(
+        "sqli-login",
+        PullDeps(source=StubCatalogSource(enabled=True), driver=driver, install_root=tmp_path),
+    )
+    assert driver.pulled_platform is None

--- a/tests/unit/test_reporting_render.py
+++ b/tests/unit/test_reporting_render.py
@@ -196,6 +196,25 @@ def test_markdown_metadata_covers_run_agent_harness_and_timing():
 
 
 @pytest.mark.unit
+def test_markdown_metadata_shows_the_executed_platform_when_recorded():
+    # §31/§43-UX8: a run that recorded its provenance surfaces the architecture it ran on.
+    md = render_markdown(
+        _ctx(
+            conditions=ResultConditions(
+                model="claude-opus-4", mission_version="1.0.0", platform="linux/arm64"
+            )
+        )
+    )
+    assert "| Platform | linux/arm64 |" in md
+
+
+@pytest.mark.unit
+def test_markdown_metadata_omits_platform_for_a_pre_contract_run():
+    md = render_markdown(_ctx())  # conditions carry no platform
+    assert "| Platform |" not in md
+
+
+@pytest.mark.unit
 def test_partial_judge_ranges_and_criterion_states_render_in_both_formats():
     grade = _grade(
         overall=0.55,


### PR DESCRIPTION
**Stacked on #56** (`feat-mission-versioning`) — this diff shows only the multi-arch half of the contract adoption. Merge #56 first, then retarget this PR to `main`.

The client permanently pinned `linux/amd64`, so an Apple-Silicon host emulated every mission even when the catalog published a validated native arm64 image. This PR turns the pin into a per-mission decision (contract §16/AS1–AS5), made **before any byte moves**:

- **Override first**: `XORCISE_DOCKER_PLATFORM` wins unconditionally; its default becomes `""` = automatic.
- **Pre-contract catalogs are untouched**: no validated-platform list ⇒ no selection ⇒ byte-for-byte the pre-feature behaviour (pinned by test against prod-shaped responses).
- **Native-first**: the daemon's own platform when the mission validated it (three of four test-env missions publish arm64).
- **AMD64 fallback** under the host's emulation layer, with the contract's notice ("Native ARM64 image unavailable…").
- **Typed refusal**: `PlatformUnsupportedError` (a `PullError`) when no execution path exists — raised before any download, naming what the mission does support, mapped **409** on pull, update, and run-create (like the base-generation refusal). `breachpoint` (amd64-only) is the live case.

The selection is passed to Docker explicitly (AS5) and **verified after the pull** (§43-CL6): an image resolving to a different architecture than selected is refused before anything is installed. The install record and run evidence pick the verified platform up unchanged through #56's identity plumbing — no schema change in this PR.

Visibility: `xorcise doctor` reports the daemon's native platform with the PS1 wording (missions may support fewer platforms than the base), and the mission detail page lists the validated platforms.

## Verification

- New `tests/unit/test_platform_selection.py` covers the full decision table (override / no-offer / native / fallback+notice / unknown-host / typed refusal), the driver wiring, the post-pull mismatch refusal, and the pre-contract no-op.
- All lanes + `mypy` + `ruff` + `lint-imports` green (the ~40 local unit failures are the known terminal-colorization artifacts; they pass in CI). Frontend typecheck + 706 tests green; no OpenAPI delta.


---

## UI surfacing (added after the frontend gap audit)

Three follow-up commits make the contract data actionable in the web UI, not just present on the wire:

- **`feat(rest)`: the platform facts the UI cannot compute** — `CatalogEntry.platform`/`emulated` (server-computed against the daemon), installed rows borrow the catalog's `platforms` offer, `SystemInfo.host_platform`, and pull/update responses now return the recorded identity. All computed projections — **0002 remains the stack's only DB migration.**
- **`feat(frontend)`: the update action everywhere its badge appears** — a shared Update button (card, list row, and a new detail-page banner with the version delta), badge parity between card and row, validated-platform tags with PV5/PS1 tooltips, creator-SemVer chip, and an "emulated" flag on non-native installs.
- **`feat(frontend)`: platform honesty at the point of commitment** — the new-run form warns (non-blocking) before pulling/running an emulated or non-native mission, disables Start *with the reason* for what the server would refuse anyway (base mismatch, no executable platform), and stays silent when nothing is known. The results Conditions card shows the executed platform.

Frontend: 98 test files / 721 tests green, typecheck clean; backend lanes at baseline; OpenAPI regenerated with no drift.
