### PR TITLE
fix(roles): shutting down must not wait on a pre-warm nobody awaits

### DIFF
--- a/src/xorcise/core/roles/boot/role_all.py
+++ b/src/xorcise/core/roles/boot/role_all.py
@@ -155,7 +155,6 @@ def build_rest_app() -> FastAPI:
             await _readiness.stop()
 
     _prewarmed = False
-    _prewarm_task: object | None = None
 
     @app.on_event("startup")
     async def _prewarm_nested_support() -> None:
@@ -164,23 +163,27 @@ def build_rest_app() -> FastAPI:
         # made the first run appear to hang and get retried into a duplicate). Best-effort and
         # memoised: a warm-up failure just leaves it cold for the first run to recompute.
         #
-        # Fire-and-forget in a BACKGROUND task — NOT awaited. uvicorn runs the startup event
-        # before it accepts connections, so awaiting the multi-second probe here would delay
-        # readiness past `xorcise up`'s health window and fail boot. The probe warms the memo
-        # off to the side while the server serves.
-        nonlocal _prewarmed, _prewarm_task
+        # Fire-and-forget on a DAEMON THREAD — not awaited, and deliberately NOT
+        # `asyncio.to_thread`. to_thread runs on the loop's DEFAULT executor, which
+        # `asyncio.run()` joins before the process may exit, so a probe nobody awaits held
+        # `serve` open for the whole 20-40 s after every listener had already closed. Cancelling
+        # could never have helped: cancellation abandons the `await`, never the thread sitting
+        # inside the blocking call. Nothing joins a daemon thread at exit, so teardown simply
+        # walks away from the warm-up — which is precisely what its own contract says a failed
+        # warm-up costs: a cold memo the first run recomputes.
+        nonlocal _prewarmed
         if _prewarmed:
             return  # one uvicorn.Server per bind address shares this app — warm once
         _prewarmed = True
-        import asyncio
         import logging
+        import threading
 
         settings = get_settings()
         if settings.use_stubs or settings.nested_container_check == "skip":
             return  # nothing real to probe
 
-        async def _warm() -> None:
-            def _blocking() -> None:
+        def _warm() -> None:
+            try:
                 from xorcise.core.rest.docker_runtime import prewarm_nested_support
 
                 def _client() -> object:
@@ -189,24 +192,10 @@ def build_rest_app() -> FastAPI:
                     return docker.from_env()
 
                 prewarm_nested_support(settings, _client)
-
-            try:
-                await asyncio.to_thread(_blocking)
             except Exception as exc:  # noqa: BLE001 — a warm-up must never break anything
                 logging.getLogger(__name__).debug("nested-support pre-warm skipped: %s", exc)
 
-        _prewarm_task = asyncio.create_task(_warm())
-
-    @app.on_event("shutdown")
-    async def _cancel_prewarm() -> None:
-        import asyncio
-        import contextlib
-
-        task = _prewarm_task
-        if isinstance(task, asyncio.Task) and not task.done():
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        threading.Thread(target=_warm, name="nested-support-prewarm", daemon=True).start()
 
     return app
 

--- a/tests/unit/test_prewarm_never_gates_exit.py
+++ b/tests/unit/test_prewarm_never_gates_exit.py
@@ -1,0 +1,90 @@
+"""The nested-support pre-warm must never gate process exit.
+
+`serve` runs its uvicorn servers under `asyncio.run()`. When the coroutine returns, asyncio's
+Runner joins the DEFAULT executor before the process may exit — and a worker started by
+`asyncio.to_thread()` lives in exactly that executor. The pre-warm probe is documented at
+20-40 s, is deliberately fire-and-forget, and cannot be called back once it is inside the
+blocking call: cancelling the task abandons the `await`, never the thread underneath it.
+
+So the shutdown hook that cancels it returns instantly and proves nothing. Every listener
+closed in ~0.3 s and the process then sat for another 6+ s waiting on a Docker probe nobody
+was waiting for — which is how `xorcise serve` came to miss the 10 s teardown budget in
+tests/e2e/test_walking_skeleton.py::test_up_serves_ui_then_down.
+
+The probe belongs on a daemon thread, the idiom join_reconcile and terrain_catchup_v2 already
+use for their own best-effort drains: nothing joins a daemon thread at exit, so abandoning the
+warm-up costs exactly what its own docstring says it should — the memo stays cold and the
+first run recomputes it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from xorcise.core.config import get_settings
+from xorcise.core.roles.boot.role_all import build_rest_app
+
+# The real probe is documented at 20-40 s. A regression has to FAIL this test rather than hang
+# the lane, so the stand-in blocks for a bounded window — comfortably past the budget asserted
+# below, and released unconditionally in the `finally`.
+_PROBE_BLOCK_SECONDS = 15.0
+_EXIT_BUDGET_SECONDS = 5.0
+
+
+def _startup_hook(app: Any, name: str) -> Callable[[], Awaitable[None]]:
+    """The named startup handler, so this pins the pre-warm rather than the whole boot."""
+    hook = next(h for h in app.router.on_startup if h.__name__ == name)
+    return cast("Callable[[], Awaitable[None]]", hook)
+
+
+def test_the_nested_prewarm_never_gates_process_exit(migrated_home, monkeypatch) -> None:
+    # The probe is skipped under stubs or when the check is disabled, so both have to be off
+    # for this test to exercise the path at all (asserted via `entered` below).
+    monkeypatch.setenv("XORCISE_USE_STUBS", "0")
+    monkeypatch.setenv("XORCISE_NESTED_CONTAINER_CHECK", "enforce")
+    get_settings.cache_clear()
+
+    entered = threading.Event()
+    release = threading.Event()
+    ran_on: dict[str, threading.Thread] = {}
+
+    def _blocking_probe(_settings: object, _client_factory: object) -> None:
+        ran_on["thread"] = threading.current_thread()
+        entered.set()
+        release.wait(_PROBE_BLOCK_SECONDS)
+
+    monkeypatch.setattr("xorcise.core.rest.docker_runtime.prewarm_nested_support", _blocking_probe)
+
+    app = build_rest_app()
+
+    async def _lifespan() -> None:
+        await _startup_hook(app, "_prewarm_nested_support")()
+        # The bug only bites once the worker is INSIDE the blocking call, where cancellation
+        # cannot reach it. Wait for that, or the test could pass by winning a race.
+        for _ in range(50):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.1)
+
+    try:
+        start = time.monotonic()
+        # Not `await`: the whole point is the Runner teardown that `asyncio.run` performs on
+        # the way out, which is where the default executor gets joined.
+        asyncio.run(_lifespan())
+        elapsed = time.monotonic() - start
+    finally:
+        release.set()
+
+    assert entered.is_set(), "the pre-warm never ran — this test would prove nothing"
+    assert elapsed < _EXIT_BUDGET_SECONDS, (
+        f"asyncio.run() took {elapsed:.1f}s to unwind. The pre-warm probe is on the default "
+        "executor, so process exit blocks on a 20-40 s Docker probe that nothing awaits."
+    )
+    assert ran_on["thread"].daemon, (
+        "the pre-warm must run on a daemon thread: a non-daemon worker is joined at "
+        "interpreter exit, which is the same hang arriving by a different route"
+    )


### PR DESCRIPTION
`main` has been red since 19 Aug. `test-heavy (e2e)` fails on
`tests/e2e/test_walking_skeleton.py::test_up_serves_ui_then_down` with

```
subprocess.TimeoutExpired: Command '[.venv/bin/python, -m, xorcise, serve]'
timed out after 10 seconds
```

## It is not a startup failure

The traceback lands on `test_walking_skeleton.py:57` — the `finally:` block, not
the `not ok` branch at line 43. The whole test body succeeds: the server comes up
healthy, `/ui/` serves, and an agent registers and round-trips through
`/api/agents`. Only teardown fails.

## Root cause

`serve` runs its uvicorn servers under `asyncio.run()`. When the coroutine
returns, asyncio's Runner joins the loop's **default executor** before the process
may exit. `asyncio.to_thread()` puts its worker in exactly that executor — so the
nested-support pre-warm, which the code deliberately does not await, still gated
process exit.

Instrumented against a real `serve` (6 listeners = 2 apps x 3 bind addresses):

```
[+2.19s] ALL DONE                 <- every listener closed
[+8.71s] asyncio.run RETURNED     <- 6.5s later

cancel_all_tasks           0.00s
shutdown_asyncgens         0.00s
shutdown_default_executor  6.07s  <- the entire delay
```

Confirmed by single-variable test — `XORCISE_NESTED_CONTAINER_CHECK=skip`, which
short-circuits the pre-warm, takes teardown from **7.07s to 0.76s**.

`_cancel_prewarm` looked like it handled this and could not: cancelling a
`to_thread` task abandons the `await`, never the thread inside the blocking call.
It is removed rather than left misrepresenting the teardown.

## The fix

The probe moves to a daemon thread — the idiom `join_reconcile` and
`terrain_catchup_v2` already use for their own best-effort drains. Nothing joins a
daemon thread at exit, so teardown walks away from the warm-up, costing exactly
what its own docstring says a failed warm-up costs: a cold memo the first run
recomputes.

Local `serve` teardown, end to end: **8.3s -> 1.8s**.

## Not caused by #55

`git log -S _prewarm_nested_support` puts the pre-warm in **54cb624 (#41,
DinD-only)**, which passed CI on 14 Aug and stayed green for three runs. A probe
documented at 20-40s against a 10s budget was always going to lose eventually;
#55 was merely the commit standing next to it when it first did. It now fails
consistently (2/2).

## Verification

- New unit test fails without the fix (`asyncio.run() took 15.0s to unwind`) and
  passes with it.
- `unit or adapters or topology`: **2175 passed**, 0 failed.
- `mypy` clean (483 files), `ruff check` clean, `ruff format --check` clean,
  `lint-imports` 4 kept / 0 broken.
- The e2e lane itself could not be run locally: it binds :3001, which a running
  brain occupies on this host. It is also `skipping` on PRs, so **this PR cannot
  prove itself green** — the real confirmation is the first `test-heavy` run on
  `main` after merge.

## Deliberately out of scope

The same file starts `BudgetWatchdog` and `ReadinessWatchdog` once per bind
address and only ever stops the last of each, leaking the rest as
never-cancelled tasks. That is #43. It costs 0.00s at shutdown, so it is not this
bug and is left alone.
