### PR TITLE
ci(release): bump pypi-publish to v1.14.2 for metadata 2.5 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
       # No token of any kind. The Trusted Publisher must match owner + repo + this filename
       # + environment exactly, or PyPI rejects it.
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # 4. PUBLISH — last, so the announcement never precedes the package being installable.
   publish-github-release:


### PR DESCRIPTION
`v0.1.3` built, verified and drafted its GitHub Release, then failed at the upload:

```
Checking dist/xorcise-0.1.3-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

The artifact from that run is correct in every other respect — `Metadata-Version: 2.5`, `Generator: hatchling 1.32.0`, `Version: 0.1.3`. hatchling 1.32.0 emits metadata 2.5; `gh-action-pypi-publish@v1.14.1` bundles a Twine that predates it.

`v1.14.2` updates its internal Twine to v7, and its release notes name this case exactly:

> …update of Twine to v7 that we use internally (#416). This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.

## Nothing was published

PyPI still shows `0.1.2` as latest and has no `0.1.3` — the rejection happens before upload. So `0.1.3` is still free: this is a re-tag once merged, not a version bump, and the CHANGELOG entry needs no renumbering.

## Why the gate missed it

The workflow already runs `twine check --strict` before uploading, and it **passed**. That step uses the *repo's* twine (7.0.0, which accepts 2.5); the upload uses the twine bundled inside the action. Two validators for one artifact, and only one of them is visible in this repo.

This bump aligns both at Twine 7, but nothing holds them aligned as either side moves — the same divergence can reappear whenever hatchling emits a metadata version newer than whatever the pinned action ships. Worth a follow-up; not fixed here, to keep the release unblocked.