### PR TITLE
fix(runner): probe nested containers at the mission's platform, not a hard-pinned amd64

### DIFF
--- a/src/xorcise/core/cli/_diagnostics.py
+++ b/src/xorcise/core/cli/_diagnostics.py
@@ -364,6 +364,27 @@ def nested_containers() -> Check:
     return Check("nested containers", False, clip_detail(support.detail), support.remediation)
 
 
+def nested_containers_foreign() -> list[Check]:
+    """One line per FOREIGN platform a run has asked this server about (e.g. amd64 on Apple
+    Silicon), after `nested_containers()` has re-probed them. A refused foreign platform is not
+    a blocker — native missions still run — but it is exactly the verdict the operator is trying
+    to change when they enable Rosetta and re-run `doctor`, so it must be visible here, and
+    visibly cleared, rather than discoverable only by the next `run create`."""
+    from xorcise.core.rest.docker_runtime import memoised_verdicts
+    from xorcise.core.runner.docker.rosetta import clip_detail
+
+    checks: list[Check] = []
+    for plat, support in sorted(memoised_verdicts().items()):
+        name = f"nested containers ({plat})"
+        if support.ok:
+            checks.append(Check(name, True, clip_detail(support.detail)))
+        else:
+            checks.append(
+                Check(name, True, clip_detail(support.detail), support.remediation, level="warning")
+            )
+    return checks
+
+
 def external_control_plane(url: str, *, timeout: float = 5.0) -> Check:
     """Is a CONFIGURED remote control plane actually answering?
 

--- a/src/xorcise/core/cli/_errors.py
+++ b/src/xorcise/core/cli/_errors.py
@@ -20,6 +20,7 @@ import sys
 from typing import Any
 
 from rich.console import Console
+from rich.markup import escape
 
 from xorcise.core.cli._shared import XORCISE_THEME
 from xorcise.core.cli._ux import command_path_from_argv
@@ -96,17 +97,21 @@ def _print_error(
     example: str | None = None,
     see: tuple[str, ...] = (),
 ) -> None:
+    # Everything interpolated here can carry what the user TYPED (an unknown command token, a
+    # stray argument, a mission name), and rich reads square brackets as markup: `[abc]` would
+    # silently vanish from the suggestion and `[/x]` would raise MarkupError instead of printing
+    # a usage error. Escape at the one funnel, so no renderer above has to remember.
     console = _console()
-    console.print(f"[err]error[/err]: {message}", highlight=False)
+    console.print(f"[err]error[/err]: {escape(message)}", highlight=False)
     if suggestions:
         console.print("\nDid you mean?")
         for s in suggestions:
-            console.print(f"  [value]{s}[/value]")
+            console.print(f"  [value]{escape(s)}[/value]")
     if example:
-        console.print(f"\ntry:\n  [value]{example}[/value]")
+        console.print(f"\ntry:\n  [value]{escape(example)}[/value]")
     for pointer in see:
-        console.print(f"see: [value]{pointer}[/value]")
-    console.print(f"\n[dim]run '{path} --help' for all options[/dim]")
+        console.print(f"see: [value]{escape(pointer)}[/value]")
+    console.print(f"\n[dim]run '{escape(path)} --help' for all options[/dim]")
 
 
 def _group_commands(command: Any) -> dict[str, Any]:

--- a/src/xorcise/core/cli/_errors.py
+++ b/src/xorcise/core/cli/_errors.py
@@ -48,6 +48,7 @@ _EXAMPLES = {
     "xorcise run launch-cmd": "xorcise run launch-cmd <run-id>",
     "xorcise run launch-profile": "xorcise run launch-profile <run-id>",
     "xorcise run events export": "xorcise run events export <run-id>",
+    "xorcise run events": "xorcise run events export <run-id>",
     "xorcise config set-model": "xorcise config set-model --name gpt-4o-mini --key sk-…",
 }
 
@@ -306,10 +307,39 @@ def compact_usage_error(exc: Any) -> None:
     param_opts = list(getattr(getattr(exc, "param", None), "opts", ()) or ())
     if param_opts:
         message = f"invalid value for {param_opts[0]}: {message}"
-    # Everything else (unknown command — typer already appends its own
-    # "Did you mean …?" — bad parameter values, missing option values, …):
-    # keep the text, drop the box, add the command's example when we have one.
+    unknown = _NO_SUCH_COMMAND.search(message)
+    if unknown is not None:
+        _render_no_such_command(unknown.group(1), ctx, path)
+        return
+    # Everything else (bad parameter values, missing option values, …): keep the text, drop the
+    # box, add the command's example when we have one.
     _print_error(message, path=path, example=_EXAMPLES.get(path))
+
+
+_NO_SUCH_COMMAND = re.compile(r"No such command '([^']+)'")
+
+
+def _render_no_such_command(token: str, ctx: Any, path: str) -> None:
+    """`xorcise run events <run-id>`: the group has ONE subcommand and the user skipped it, so
+    the "command" click could not find is really the argument of that subcommand. Suggest the
+    paste-and-run form with the value carried over. A token that is merely a misspelt subcommand
+    gets the close match instead; anything else, the group's example if it has one."""
+    commands = _group_commands(getattr(ctx, "command", None)) if ctx is not None else {}
+    suggestions: list[str] = []
+    from difflib import get_close_matches
+
+    for close in get_close_matches(token, list(commands), n=2, cutoff=0.6):
+        suggestions.append(f"{path} {close}")
+    if not suggestions and len(commands) == 1:
+        (only,) = commands
+        if _first_positional_of(commands[only]) is not None:
+            suggestions.append(f"{path} {only} {token}")
+    _print_error(
+        f"no such command: {token}",
+        path=path,
+        suggestions=tuple(suggestions),
+        example=None if suggestions else _EXAMPLES.get(path),
+    )
 
 
 def install_compact_errors() -> None:

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -31,6 +31,7 @@ from xorcise.core.cli._diagnostics import (
     home_present,
     mission_base_release,
     nested_containers,
+    nested_containers_foreign,
     openssl_present,
     probe_channel,
     python_version,
@@ -704,6 +705,9 @@ def doctor(
         if as_json is not True:
             console.print("  [dim]○ probing nested containers (may take a minute)…[/dim]")
         env_checks.append(nested_containers())
+        # The foreign platforms runs have asked about (re-probed by the line above), so a
+        # cleared Rosetta refusal shows up here and not only on the next run.
+        env_checks.extend(nested_containers_foreign())
     port_checks: list[Check] = []
     server_ports = _running_server_ports()
     # Probe the ports the server actually runs on (runtime overlay, same resolution

--- a/src/xorcise/core/config/__init__.py
+++ b/src/xorcise/core/config/__init__.py
@@ -116,20 +116,20 @@ class Settings(BaseSettings):
     catalog_key: str | None = None
     # force stub adapters (Docker-less dev/CI); default real — real-vs-stub also keys off `role`
     use_stubs: bool = False
-    # platform passed to docker pull/run. Mission images are built amd64-only, so an
-    # arm64 host (Apple Silicon) must request linux/amd64 or the pull 404s on a missing arm64
-    # manifest; Docker Desktop then runs it under emulation. Empty ⇒ docker picks the host platform.
-    # Execution-platform OVERRIDE (XORCISE_DOCKER_PLATFORM). "" = automatic: the pull spine
-    # selects per mission — the host-native platform when the mission validated it, AMD64 under
+    # Execution-platform OVERRIDE (XORCISE_DOCKER_PLATFORM), passed to docker pull/run. "" =
+    # automatic: the pull spine selects per mission — the host-native platform when the mission
+    # publishes a validated image for it (most catalog missions ship amd64 AND arm64), AMD64 under
     # emulation otherwise (AS3/AS4). Setting a value pins every pull/run to it, unconditionally.
     docker_platform: str = ""
     # The mission stack ALWAYS runs inside the run's own container (DinD). The former
     # host-daemon "sibling" topology is gone — it put every mission's containers on the operator's
     # daemon, so parallel runs collided on fixed container_names and published ports.
-    # "enforce" verifies the host can actually nest containers and fails run creation with a
-    # diagnosis if not. "skip" bypasses only the CHECK — for hosts where the probe itself cannot
-    # run (restricted CI, no privileged containers) but nesting is known good. It can never
-    # restore the sibling topology.
+    # "enforce" verifies the host can actually nest containers (at each mission's own platform)
+    # and fails run creation with a diagnosis if not. "skip" bypasses only the CHECK — for hosts
+    # where the probe itself cannot run (restricted CI, no privileged containers) but nesting is
+    # known good. It can never restore the sibling topology. Set as XORCISE_NESTED_CONTAINER_CHECK
+    # in the server's environment or `nested_container_check = "skip"` in config.toml; like every
+    # setting it is read once at boot, so a change needs `xorcise down && xorcise up`.
     nested_container_check: Literal["enforce", "skip"] = "enforce"
     # role + service endpoints (defaults mirror the module constants)
     role: str = "all"

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -7,12 +7,15 @@ mission, and a "no" must fail the run.
 
 Two separate questions live here:
 
-  * HOST capability — can this machine run a container inside a container at all? A behavioural
-    probe (runner/docker/rosetta.py). Expensive (~20-40 s for Tier 2), so its verdict is memoised
-    IN MEMORY for the server's lifetime (host capability does not change without a Docker restart,
-    which restarts the server). `doctor` bypasses the memo (fresh=True) to report current health.
-    There is deliberately NO on-disk cache: a persisted verdict turned a transient probe failure
-    (a registry blip) into a permanent refusal keyed on a fingerprint that never cleared.
+  * HOST capability — can this machine run a container inside a container AT A GIVEN PLATFORM?
+    A behavioural probe (runner/docker/rosetta.py), asked per execution platform: the native one
+    for a mission that pulled a native image, `linux/amd64` for one running under emulation on an
+    arm64 host. Expensive (~10-40 s for Tier 2), so each verdict is memoised IN MEMORY per
+    platform for the server's lifetime (host capability does not change without a Docker
+    restart, which restarts the server). `doctor` bypasses the memo (fresh=True) to report
+    current health. There is deliberately NO on-disk cache: a persisted verdict turned a
+    transient probe failure (a registry blip) into a permanent refusal keyed on a fingerprint
+    that never cleared.
 
   * ARTIFACT compatibility — was THIS mission's fused image built on a base generation this
     XORCISE can run? A cheap label/tag check (require_base_compatible), no container.
@@ -31,6 +34,7 @@ import subprocess
 import threading
 import time
 from collections.abc import Callable, Mapping
+from typing import Any, cast
 
 from xorcise.core.config import Settings
 from xorcise.core.contracts.errors import (
@@ -46,17 +50,19 @@ from xorcise.core.runner.docker.build import (
 from xorcise.core.runner.docker.rosetta import (
     NestedSupport,
     binfmt_signal,
+    canonical_platform,
     check_nested_support,
-    verify_nested_amd64,
+    verify_nested,
 )
 
 log = logging.getLogger(__name__)
 
-# In-memory verdict, memoised for the process lifetime. The lock serialises the (slow) probe so
-# concurrent first run-creates queue behind ONE probe instead of each launching a privileged DinD
-# and racing a cache file — the failure the removed on-disk cache used to have.
+# In-memory verdicts, one per execution platform (None = the daemon's native platform), memoised
+# for the process lifetime. The lock serialises the (slow) probe so concurrent first run-creates
+# queue behind ONE probe instead of each launching a privileged DinD and racing a cache file —
+# the failure the removed on-disk cache used to have.
 _MEMO_LOCK = threading.Lock()
-_memo: NestedSupport | None = None
+_memo: dict[str | None, NestedSupport] = {}
 #: The last verdict line logged, so a long-lived server logs only when the verdict CHANGES
 #: (a single value, not an unbounded set of every distinct failure string ever seen).
 _last_logged: str | None = None
@@ -64,22 +70,46 @@ _last_logged: str | None = None
 
 def _log_support(support: NestedSupport) -> None:
     global _last_logged
-    line = f"{'ok' if support.ok else 'unavailable'}: {support.detail}"
+    line = (
+        f"{'ok' if support.ok else 'unavailable'} [{support.platform or 'native'}]: "
+        f"{support.detail}"
+    )
     if line == _last_logged:
         return
     _last_logged = line
     (log.info if support.ok else log.warning)("nested containers — %s", line)
 
 
-def _probe(client_factory: Callable[[], object]) -> NestedSupport:
-    """Run both tiers against one client, closing it after. Never memoises — caller decides."""
+def _daemon_platform(client: object) -> str | None:
+    """What the daemon executes natively, from its own version report — or None if unknowable."""
+    try:
+        version = cast(Any, client).version() or {}
+        os_name, arch = version.get("Os"), version.get("Arch")
+    except Exception:  # noqa: BLE001 — unknown, never a crash; only sharpens the memo + message
+        return None
+    return canonical_platform(f"{os_name}/{arch}") if os_name and arch else None
+
+
+def _probe(
+    client_factory: Callable[[], object], platform: str | None
+) -> tuple[NestedSupport, str | None]:
+    """Run both tiers for `platform` against one client, closing it after. Never memoises — the
+    caller decides. Also returns the daemon's native platform, so a native verdict can be filed
+    under its explicit spelling too."""
     client = client_factory()  # may raise (daemon down); the caller wraps it into a typed error
     try:
-        return check_nested_support(
+        native = _daemon_platform(client)
+        # Probe with an EXPLICIT platform whenever one is known: "native" spelt out lets the
+        # wrapper insist on the right image when the local tag holds another platform's copy
+        # (docker keeps one per tag under overlay2), instead of silently running whatever is there.
+        support = check_nested_support(
             skip=False,
             probe_tier1=lambda: binfmt_signal(client),
-            probe_tier2=lambda _t1: verify_nested_amd64(client),
+            probe_tier2=lambda _t1: verify_nested(client, platform=platform or native),
+            platform=platform,
+            host_platform=native,
         )
+        return support, native
     finally:
         close = getattr(client, "close", None)
         if callable(close):
@@ -90,32 +120,48 @@ def nested_support(
     settings: Settings,
     client_factory: Callable[[], object],
     *,
+    platform: str | None = None,
     fresh: bool = False,
 ) -> NestedSupport:
-    """Can this host nest containers? Memoised in memory; `fresh` re-probes (doctor).
+    """Can this host nest containers at `platform`? Memoised in memory; `fresh` re-probes (doctor).
+
+    `platform` is the execution platform of the mission about to run — the one its install
+    recorded — or None for the daemon's native platform (what boot pre-warms and `doctor`
+    reports). The two spellings of "native" share one verdict: a probe made with None is also
+    filed under the platform the daemon reported, so the first run of a native mission reads the
+    pre-warmed answer instead of paying a second probe.
 
     A skipped check answers immediately without touching Docker. Otherwise the verdict is computed
-    once and held; `fresh=True` recomputes AND refreshes the memo, so an operator who fixes Rosetta
-    and re-runs `doctor` unblocks subsequent runs without restarting the server.
+    once per platform and held; `fresh=True` recomputes AND refreshes the memo, so an operator who
+    fixes Rosetta and re-runs `doctor` unblocks subsequent runs without restarting the server.
     """
+    key = canonical_platform(platform)
     if settings.nested_container_check == "skip":
-        return NestedSupport(True, "nested-container check skipped by configuration")
-    global _memo
+        return NestedSupport(
+            True, "nested-container check skipped by configuration", platform=key or ""
+        )
     with _MEMO_LOCK:
-        if _memo is not None and not fresh:
-            return _memo
-        support = _probe(client_factory)
-        _memo = support
+        hit = _memo.get(key)
+        if hit is not None and not fresh:
+            return hit
+        support, native = _probe(client_factory, key)
+        _memo[key] = support
+        if key is None and native is not None:
+            _memo[native] = support  # "native" and its explicit spelling are the same question
+        elif key is not None and key == native:
+            _memo[None] = support
         _log_support(support)
         return support
 
 
 def prewarm_nested_support(settings: Settings, client_factory: Callable[[], object]) -> None:
-    """Compute the verdict ahead of the first run-create (called at boot, best-effort).
+    """Compute the NATIVE verdict ahead of the first run-create (called at boot, best-effort).
 
     Warming the memo at startup means run-create reads it instantly instead of the first real run
-    paying the 20-40 s probe under a client timeout. Never raises: a warm-up failure just leaves
-    the memo cold, and the first run recomputes it."""
+    paying the 10-40 s probe under a client timeout. Only the native platform is warmed: it is
+    what every mission with a native image runs at, and probing a foreign platform at every boot
+    would start a privileged emulated DinD for a case most operators never hit. Never raises: a
+    warm-up failure just leaves the memo cold, and the first run recomputes it."""
     try:
         nested_support(settings, client_factory)
     except Exception as exc:  # noqa: BLE001 — a safety-net warm-up must never break boot
@@ -125,26 +171,42 @@ def prewarm_nested_support(settings: Settings, client_factory: Callable[[], obje
 def require_nested_support(
     settings: Settings,
     client_factory: Callable[[], object],
+    *,
+    platform: str | None = None,
 ) -> None:
-    """Raise NestedContainersUnavailableError unless this host can nest containers.
+    """Raise NestedContainersUnavailableError unless this host can nest containers at `platform`.
 
     Call this BEFORE anything stateful or expensive (subnet reservation, control-plane fence,
     image pull) so a host that cannot run missions costs an error message rather than a
     half-built run that has to be torn down.
     """
-    support = nested_support(settings, client_factory)
+    support = nested_support(settings, client_factory, platform=platform)
     if support.ok:
         return
     # The probe's detail often already ends in a period (it quotes a runtime error verbatim), so
     # only add one where it is missing — a stray ".." reads like a typo in the one message an
     # operator sees when nothing works.
     detail = support.detail.rstrip(". ")
+    where = f" ({support.platform})" if support.platform else ""
     raise NestedContainersUnavailableError(
-        f"this host cannot run a mission's containers inside the run container — {detail}. "
-        f"{support.remediation}. "
+        f"this host cannot run a mission's containers inside the run container{where} — "
+        f"{detail}. {support.remediation}. "
+        # Both spellings of the escape hatch, and the restart: the server reads its settings
+        # once at boot, so editing config.toml (or exporting the variable) while it runs changes
+        # nothing until `xorcise down && xorcise up`.
         "To bypass this check on a host you know is fine, set "
-        "XORCISE_NESTED_CONTAINER_CHECK=skip"
+        "XORCISE_NESTED_CONTAINER_CHECK=skip in the server's environment or "
+        'nested_container_check = "skip" in ~/.xorcise/config.toml, then restart it '
+        "(xorcise down && xorcise up)"
     )
+
+
+def reset_nested_support_memo() -> None:
+    """Drop every memoised nesting verdict (tests)."""
+    global _last_logged
+    with _MEMO_LOCK:
+        _memo.clear()
+    _last_logged = None
 
 
 # Memoised daemon platform: the arch of a running daemon cannot change, but "docker was down,

--- a/src/xorcise/core/rest/docker_runtime.py
+++ b/src/xorcise/core/rest/docker_runtime.py
@@ -52,6 +52,7 @@ from xorcise.core.runner.docker.rosetta import (
     binfmt_signal,
     canonical_platform,
     check_nested_support,
+    host_is_macos,
     verify_nested,
 )
 
@@ -132,8 +133,11 @@ def nested_support(
     pre-warmed answer instead of paying a second probe.
 
     A skipped check answers immediately without touching Docker. Otherwise the verdict is computed
-    once per platform and held; `fresh=True` recomputes AND refreshes the memo, so an operator who
-    fixes Rosetta and re-runs `doctor` unblocks subsequent runs without restarting the server.
+    once per platform and held. `fresh=True` recomputes AND refreshes the memo — for the platform
+    asked about and, when that is the native one (what `doctor` asks), for EVERY other platform a
+    run has asked about since boot. That second half is what makes "fix Rosetta, re-run `doctor`,
+    the next run works" true: the refusal that needs clearing is the amd64 entry on an Apple
+    Silicon host, and a native re-probe alone would leave it standing while doctor printed green.
     """
     key = canonical_platform(platform)
     if settings.nested_container_check == "skip":
@@ -144,26 +148,58 @@ def nested_support(
         hit = _memo.get(key)
         if hit is not None and not fresh:
             return hit
-        support, native = _probe(client_factory, key)
-        _memo[key] = support
-        if key is None and native is not None:
-            _memo[native] = support  # "native" and its explicit spelling are the same question
-        elif key is not None and key == native:
-            _memo[None] = support
-        _log_support(support)
+        support, native = _probe_into_memo(client_factory, key)
+        if fresh and key is None:
+            # Re-probe the other platforms runs have asked about, so a stale foreign refusal is
+            # cleared by the same `doctor` that reports the host healthy.
+            for other in [k for k in _memo if k is not None and k != native]:
+                _probe_into_memo(client_factory, other)
         return support
 
 
+def _probe_into_memo(
+    client_factory: Callable[[], object], key: str | None
+) -> tuple[NestedSupport, str | None]:
+    """Probe `key` (None = native), file the verdict under every spelling it answers, log it."""
+    support, native = _probe(client_factory, key)
+    _memo[key] = support
+    if key is None and native is not None:
+        _memo[native] = support  # "native" and its explicit spelling are the same question
+    elif key is not None and key == native:
+        _memo[None] = support
+    _log_support(support)
+    return support, native
+
+
+def memoised_verdicts() -> dict[str, NestedSupport]:
+    """The verdicts held for EXPLICIT platforms other than the daemon's native one — what
+    `doctor` lists alongside the native check, so a refused foreign platform is visible (and,
+    after a fresh re-probe, visibly cleared) rather than only discoverable by the next run."""
+    with _MEMO_LOCK:
+        native = _memo.get(None)
+        return {
+            k: v for k, v in _memo.items() if k is not None and (native is None or v is not native)
+        }
+
+
 def prewarm_nested_support(settings: Settings, client_factory: Callable[[], object]) -> None:
-    """Compute the NATIVE verdict ahead of the first run-create (called at boot, best-effort).
+    """Compute the verdicts a first run is likely to need, ahead of it (boot, best-effort).
 
     Warming the memo at startup means run-create reads it instantly instead of the first real run
-    paying the 10-40 s probe under a client timeout. Only the native platform is warmed: it is
-    what every mission with a native image runs at, and probing a foreign platform at every boot
-    would start a privileged emulated DinD for a case most operators never hit. Never raises: a
-    warm-up failure just leaves the memo cold, and the first run recomputes it."""
+    paying the 10-40 s probe under a client timeout — which is what made a first run look hung and
+    get retried into a duplicate. The native platform is always warmed: every mission with a
+    native image runs at it. On an Apple Silicon Mac the amd64 verdict is warmed too: Docker
+    Desktop runs amd64 under Rosetta there, missions without an arm64 image are common, and the
+    Rosetta probe is the one whose cold cost is highest. On Linux a foreign platform is NOT
+    warmed — that would start a privileged emulated DinD at every boot to learn, ninety seconds
+    later, the answer every arm64 Linux host gives. Never raises: a warm-up failure just leaves
+    the memo cold, and the first run recomputes it."""
     try:
-        nested_support(settings, client_factory)
+        native = nested_support(settings, client_factory)
+        with _MEMO_LOCK:
+            amd64_is_native = _memo.get("linux/amd64") is native  # filed under both spellings
+        if host_is_macos() and not amd64_is_native:
+            nested_support(settings, client_factory, platform="linux/amd64")
     except Exception as exc:  # noqa: BLE001 — a safety-net warm-up must never break boot
         log.debug("nested-support pre-warm skipped: %s", exc)
 

--- a/src/xorcise/core/rest/mission_pull.py
+++ b/src/xorcise/core/rest/mission_pull.py
@@ -421,6 +421,15 @@ def _acquire_and_install(
                     f"pulled {image} resolved to {actual}, not the selected {selected} — "
                     "refusing to install a mismatched artifact"
                 )
+        elif precheck is not None:
+            # No selection was possible (a pre-contract entry lists no platforms), so the gate
+            # above was asked about the daemon's native platform — but the registry may have
+            # served a single-arch FOREIGN image. Ask the gate about what actually landed, before
+            # anything is installed: the download is already paid (unavoidable without a platform
+            # list), but a refused install, and a run-create refusal after it, are not.
+            actual = deps.driver.image_platform(image)
+            if actual is not None and actual != deps.driver.daemon_platform():
+                precheck(actual)
 
     # Attachments travel out-of-band in the delivery bundle, not the image: fetch +
     # integrity-check the zip so install_pulled can materialize the declared files. The cloud

--- a/src/xorcise/core/rest/mission_pull.py
+++ b/src/xorcise/core/rest/mission_pull.py
@@ -168,7 +168,7 @@ def pull_mission(
     *,
     progress: PullProgressSink | None = None,
     should_cancel: Callable[[], bool] | None = None,
-    precheck: Callable[[], None] | None = None,
+    precheck: Callable[[str | None], None] | None = None,
 ) -> InstalledMission:
     """Acquire + install a library mission. Idempotent; failure leaves it not-installed.
 
@@ -182,8 +182,10 @@ def pull_mission(
     leaves the mission cleanly not-installed; once install begins it runs to completion.
 
     `precheck` (keyword-only, default None) runs after the cheap manifest fetch identifies a LAB
-    mission but BEFORE the multi-GB image download — run-create wires the nesting gate here so a
-    host that cannot run the mission is refused without first paying the pull. The explicit
+    mission and the pull has SELECTED its execution platform, but BEFORE the multi-GB image
+    download — run-create wires the nesting gate here so a host that cannot run the mission at
+    that platform is refused without first paying the pull. It receives the selected platform
+    (None ⇒ the driver's default, i.e. the daemon's native one). The explicit
     `xorcise mission pull` passes None: pre-staging a mission on a non-nesting host is allowed."""
     from xorcise.core.missions import get_installed
     from xorcise.core.missions.errors import MissionCollisionError
@@ -304,7 +306,7 @@ def _acquire_and_install(
     *,
     progress: PullProgressSink | None,
     should_cancel: Callable[[], bool] | None,
-    precheck: Callable[[], None] | None,
+    precheck: Callable[[str | None], None] | None,
     resolved: tuple[MissionDetail, str | None] | None = None,
 ) -> InstalledMission:
     """The shared acquire spine: resolve → (precheck) → pull → bundle → atomic install.
@@ -340,9 +342,6 @@ def _acquire_and_install(
     manifest = detail.manifest
     ref = MissionRef(mission_id=mission_id, image=image or "")
     if image is not None and not deps.driver.image_exists(image):
-        # A lab mission with a download ahead of it — gate now (nesting), before the pull.
-        if precheck is not None:
-            precheck()
         # Native-first platform selection (AS1–AS5), decided BEFORE any byte moves so an
         # impossible host/mission pairing costs one error message, not a download. None ⇒ no
         # selection was possible (pre-contract catalog / operator made none): the driver's
@@ -354,6 +353,12 @@ def _acquire_and_install(
         )
         if notice:
             log.warning("%s: %s", mission_id, notice)
+        # A lab mission with a download ahead of it — gate now (nesting AT the platform just
+        # selected), still before the pull. After selection, not before: whether this host can
+        # nest depends on WHICH platform it is asked to nest — amd64 under emulation on an arm64
+        # host is a different (and usually negative) answer from native arm64.
+        if precheck is not None:
+            precheck(selected)
         token = deps.source.pull_token(mission_id)  # None ⇒ image needs no registry auth
         report(PHASE_PREPARING_IMAGE)
         # Aggregate docker's per-layer events into running totals. The sum of layer totals

--- a/src/xorcise/core/rest/run_create.py
+++ b/src/xorcise/core/rest/run_create.py
@@ -80,12 +80,17 @@ def _no_live_subnets() -> set[str]:
     return set()
 
 
-def _no_nested_check() -> None:
+def _no_nested_check(platform: str | None = None) -> None:
     """Default `require_nested`: the stub/unit path deploys nothing, so there is nothing to nest."""
 
 
 def _no_base_check(image_ref: str, origin: str) -> None:
     """Default `check_base_compat`: the stub/unit path deploys no real image to gate."""
+
+
+def _no_image_platform(image_ref: str) -> str | None:
+    """Default `image_platform`: no Docker to inspect (stub / unit path) ⇒ unknown."""
+    return None
 
 
 @dataclass(frozen=True)
@@ -118,12 +123,18 @@ class RunCreateDeps:
     # unit path with no Docker); boot wires the docker-backed lister.
     live_subnets: Callable[[], set[str]] = _no_live_subnets
     # Raises NestedContainersUnavailableError if this host cannot run a mission's containers
-    # inside the run container — the only supported topology. Injected (not called inline) so the
+    # inside the run container AT THE GIVEN PLATFORM (None = the daemon's native one) — the only
+    # supported topology. Nesting is a property of the (host, platform) pair: an arm64 host nests
+    # its native arm64 missions fine and cannot nest amd64 without emulation, so the gate must be
+    # asked about the platform the mission actually pulled. Injected (not called inline) so the
     # stub/unit path has nothing to probe and no Docker to reach; boot wires the real check.
-    require_nested: Callable[[], None] = _no_nested_check
+    require_nested: Callable[[str | None], None] = _no_nested_check
     # Raises BaseImageIncompatibleError if the mission's fused image was built on a base
     # generation this XORCISE cannot run. Takes the image ref; boot wires label+tag inspection.
     check_base_compat: Callable[[str, str], None] = _no_base_check
+    # The `os/arch` of a LOCAL image, for installs whose record predates the platform field (and
+    # your_own fuses): the image itself is the honest answer to "what will this run execute as".
+    image_platform: Callable[[str], str | None] = _no_image_platform
 
 
 def _use_real_headscale(settings: Settings) -> bool:
@@ -210,8 +221,9 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
     # Default: no Docker to enumerate (stub/unit path) → the allocator sees no leftover subnets.
     live_subnets: Callable[[], set[str]] = _no_live_subnets
     # Default: the stub path deploys nothing, so nesting/base compat are not preconditions for it.
-    require_nested: Callable[[], None] = _no_nested_check
+    require_nested: Callable[[str | None], None] = _no_nested_check
     check_base_compat: Callable[[str, str], None] = _no_base_check
+    image_platform: Callable[[str], str | None] = _no_image_platform
     if control_real:
         # Real runner: _real_docker_driver fails loud if Docker/the runner extra is absent.
         from xorcise.core.headscale import overlapping_subnets
@@ -229,10 +241,12 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
         def live_subnets() -> set[str]:
             return overlapping_subnets(base, prefix, driver.list_network_cidrs())
 
-        # The mission stack only ever runs nested, so verify the host can do that before a run
-        # commits to anything. Memoised in-process, so it costs ~nothing per run after the first
-        # (which boot pre-warms — see role_all).
+        # The mission stack only ever runs nested, so verify the host can do that — at the
+        # mission's platform — before a run commits to anything. Memoised in-process per platform,
+        # so it costs ~nothing per run after the first (boot pre-warms the native one — see
+        # role_all).
         from xorcise.core.rest.docker_runtime import (
+            local_image_platform,
             require_base_compatible,
             require_nested_support,
         )
@@ -249,11 +263,14 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
                     "Docker daemon is not reachable — start Docker or set XORCISE_USE_STUBS=1"
                 ) from exc
 
-        def require_nested() -> None:
-            require_nested_support(settings, _client)
+        def require_nested(platform: str | None) -> None:
+            require_nested_support(settings, _client, platform=platform)
 
         def check_base_compat(image_ref: str, origin: str) -> None:
             require_base_compatible(image_ref, label_lookup=driver.image_labels, origin=origin)
+
+        def image_platform(image_ref: str) -> str | None:
+            return local_image_platform(settings, image_ref)
     else:
         control = InProcessControlStub(api_key="local")
     ca_cert = Path(settings.headscale_ca_cert).read_text() if settings.headscale_ca_cert else ""
@@ -278,6 +295,7 @@ def build_run_create_deps(settings: Settings, *, use_docker: bool | None = None)
         live_subnets=live_subnets,  # reconcile allocation against live Docker networks
         require_nested=require_nested,  # fail a lab run early if the host cannot nest containers
         check_base_compat=check_base_compat,  # refuse an artifact built on an incompatible base
+        image_platform=image_platform,  # what a record-less install would execute as
     )
 
 
@@ -602,10 +620,11 @@ def create_run(
         # docker-run-style: auto-pull on demand. pull_mission raises
         # MissionNotInCatalogError / PullError if it cannot be obtained.
         #
-        # `precheck` runs the nesting gate AFTER the cheap manifest fetch but BEFORE the multi-GB
-        # image pull, and only for a LAB mission (static missions have no image and need no
-        # nesting). Nesting is a HOST property, independent of the mission, so a host that cannot
-        # nest is refused without first downloading an image it could never run.
+        # `precheck` runs the nesting gate AFTER the cheap manifest fetch and the platform
+        # selection but BEFORE the multi-GB image pull, and only for a LAB mission (static
+        # missions have no image and need no nesting). It is handed the platform the pull
+        # selected, so a host that cannot nest THAT platform is refused without first downloading
+        # an image it could never run.
         installed = pull_mission(mission_slug, deps.pull, precheck=deps.require_nested)
 
     run_id = uuid4().hex
@@ -628,13 +647,16 @@ def create_run(
             intel_policy=policy,
         )
     # Only a LAB mission reaches here, and a lab mission needs its stack nested inside the run
-    # container. Checked HERE — after the static short-circuit, before the subnet reservation,
-    # the Headscale fence and the deploy — so a host that cannot nest costs one error message
-    # instead of a reserved CIDR, a minted auth key and a torn-down half-run. Static missions are
-    # deliberately unaffected: they have no runtime at all. (For an auto-pulled mission this
-    # already ran as the pull precheck, before the image download; re-running is cheap — the
-    # verdict is memoised — and covers the already-installed path that skips the pull.)
-    deps.require_nested()
+    # container AT ITS OWN PLATFORM. Checked HERE — after the static short-circuit, before the
+    # subnet reservation, the Headscale fence and the deploy — so a host that cannot nest costs
+    # one error message instead of a reserved CIDR, a minted auth key and a torn-down half-run.
+    # Static missions are deliberately unaffected: they have no runtime at all. (For an
+    # auto-pulled mission this already ran as the pull precheck, before the image download;
+    # re-running is cheap — the verdict is memoised per platform — and covers the
+    # already-installed path that skips the pull.) The platform is what the install recorded;
+    # an install that predates the record falls back to what its local image was built for, and
+    # an unknown platform probes the daemon's native one — the only thing it could be running.
+    deps.require_nested(installed.platform or deps.image_platform(installed.mission_ref.image))
     # And refuse an artifact fused on a base generation this XORCISE cannot run (e.g. a stale
     # engine-27 fuse after an upgrade) — it would die at deploy with no host-daemon fallback.
     deps.check_base_compat(installed.mission_ref.image, installed.origin)

--- a/src/xorcise/core/runner/docker/rosetta.py
+++ b/src/xorcise/core/runner/docker/rosetta.py
@@ -8,8 +8,13 @@ containers onto the operator's daemon, and mission bind mounts resolved against 
 filesystem. Every one of those is invisible with one run and fatal with several.
 
 Removing the fallback makes nesting a PRECONDITION rather than a preference, which is why this
-module now answers one question — can this host run a container inside a container? — and why a
-"no" has to fail a run loudly instead of silently degrading it.
+module now answers one question — can this host run a container inside a container AT THE
+PLATFORM OF THE MISSION ABOUT TO RUN? — and why a "no" has to fail a run loudly instead of
+silently degrading it. The platform matters: an arm64 Linux host nests arm64 natively and can
+run the 19-of-27 catalog missions that publish arm64 images, yet has no way to nest amd64 at
+all (no binfmt handler ⇒ `exec format error`; a qemu handler ⇒ the inner dockerd cannot init
+nftables). A probe hard-pinned to amd64 therefore refused that host EVERY mission, including
+the ones it could run, and blamed privileged containers. The probe is per platform now.
 
 WHY IT CAN FAIL AT ALL. Historically the runner mounted Docker Desktop's socket on macOS, on the
 premise that "Rosetta fails for nested DinD children". The OBSERVATION was real; the diagnosis
@@ -65,25 +70,35 @@ from typing import Any
 
 # Host-arch image used to read the VM's binfmt registration. Tiny (~4 MB) and pulled on demand.
 BINFMT_PROBE_IMAGE = "alpine:3.20"
-# DinD image used for the ground-truth nested check, run at `linux/amd64` — the shape XORCISE
-# ships today. This MUST track the `FROM` in containers/mission-base/Dockerfile (asserted by
-# tests/topology/test_dind_base_parity.py).
+# DinD image used for the ground-truth nested check, run at the PLATFORM OF THE MISSION under
+# test (host-native when none is given). This MUST track the `FROM` in
+# containers/mission-base/Dockerfile (asserted by tests/topology/test_dind_base_parity.py); the
+# tag is a multi-platform index, so the same constant serves every platform the base publishes.
 #
-# The capability is NOT a property of the host. It fails only when BOTH hold: the wrapper is
-# amd64 (so its dockerd runs under Rosetta) AND the engine is <= 27 (so it installs the
-# `/proc/<pid>/exe` prestart hook Rosetta cannot exec — see the module docstring). Break either
-# and nesting works; verified on an unchanged host:
+# The capability is NOT a property of the host alone — it is a property of (host, platform).
+# The historical amd64-on-Apple-Silicon failure needed BOTH: an amd64 wrapper (so its dockerd
+# runs under Rosetta) AND an engine <= 27 (so it installs the `/proc/<pid>/exe` prestart hook
+# Rosetta cannot exec — see the module docstring). Break either and nesting works; verified on
+# an unchanged host:
 #     amd64 wrapper + engine 27  -> fails
 #     amd64 wrapper + engine 28  -> works   (hook removed upstream, moby#47406)
 #     arm64 wrapper + engine 27  -> works   (dockerd is native; Rosetta never sees the hook)
 # The base is now pinned >= 28, so this probe is expected to PASS on a Rosetta-capable host.
 # It is kept rather than deleted because the other three gates (Apple Silicon, the Apple
-# Virtualization VMM, the Rosetta toggle) are still host properties the base cannot fix. This
-# probes HOST capability (can this machine nest at all); base-generation compatibility of a
-# specific fused artifact is a separate, cheaper check (build.base_major_from_ref/_labels).
+# Virtualization VMM, the Rosetta toggle) are still host properties the base cannot fix, and
+# because a Linux host has its own gate: a FOREIGN platform needs a binfmt emulator (qemu-user),
+# and qemu cannot service the nf_tables netlink calls the inner dockerd needs, so amd64 DinD
+# under emulation on arm64 Linux fails at `iptables: Failed to initialize nft` — invisible in any
+# version string, visible only by trying. Base-generation compatibility of a specific fused
+# artifact is a separate, cheaper check (build.base_major_from_ref/_labels).
 NESTED_PROBE_IMAGE = "docker:29.7.1-dind"
-# Ceiling for the Tier 2 container: inner dockerd boot + an inner amd64 pull + exec.
+# Ceiling for the Tier 2 container: inner dockerd boot + an inner child pull + exec. Under
+# emulation every step is several times slower, so the inner daemon wait below is a WALL-CLOCK
+# budget (not an iteration count) that stays under this ceiling — the container itself reports
+# "daemon never came up" with its log tail, instead of the SDK timing out first and discarding
+# everything the container had to say.
 NESTED_PROBE_TIMEOUT = 180
+_INNER_DAEMON_BUDGET = 90
 
 # Reaper label (mirrors runner.docker.MANAGED_LABEL) stamped on the Tier 2 probe container so a
 # crash mid-probe cannot strand a privileged DinD that `xorcise down` can never find.
@@ -91,7 +106,31 @@ _PROBE_LABEL = "xorcise.managed"
 
 _SENTINEL = "XORCISE_NESTED_ARCH="
 _ERR_SENTINEL = "XORCISE_NESTED_ERR="
+_OUTER_SENTINEL = "XORCISE_OUTER_ARCH="
+_DAEMON_LOG_SENTINEL = "XORCISE_DAEMON_LOG="
 _NO_HANDLER = "XORCISE_NO_HANDLER"
+
+# `uname -m` inside a container of the given platform. Only the two the base publishes; anything
+# else is verified by agreement with the wrapper's own arch (the child must match its parent).
+_MACHINE_FOR_PLATFORM = {"linux/amd64": "x86_64", "linux/arm64": "aarch64"}
+_PLATFORM_FOR_MACHINE = {"x86_64": "linux/amd64", "aarch64": "linux/arm64"}
+# Aliases docker and catalogs use for the same thing.
+_PLATFORM_ALIASES = {
+    "linux/x86_64": "linux/amd64",
+    "linux/amd64/v2": "linux/amd64",
+    "linux/amd64/v3": "linux/amd64",
+    "linux/aarch64": "linux/arm64",
+    "linux/arm64/v8": "linux/arm64",
+}
+
+
+def canonical_platform(platform: str | None) -> str | None:
+    """`os/arch` in the one spelling the rest of this module compares against, or None."""
+    if not platform:
+        return None
+    text = platform.strip().lower()
+    return _PLATFORM_ALIASES.get(text, text)
+
 
 _BINFMT_SCRIPT = (
     # binfmt_misc is usually unmounted inside a container; mounting it is why this needs
@@ -101,28 +140,45 @@ _BINFMT_SCRIPT = (
     f"cat /proc/sys/fs/binfmt_misc/rosetta 2>/dev/null || echo {_NO_HANDLER}"
 )
 
-_NESTED_SCRIPT = (
-    # The docker:dind image ships DOCKER_HOST=tcp://docker:2375 (plus TLS vars) for the
-    # docker-compose "dind sidecar" pattern. Left set, the inner CLI dials a host named `docker`
-    # that does not exist here and never reaches the daemon it just started — the probe then
-    # times out and reports "not available" on a host where nesting works perfectly. Clear them
-    # so the CLI falls back to the local unix socket.
-    "unset DOCKER_HOST DOCKER_TLS_VERIFY DOCKER_CERT_PATH; "
-    "dockerd-entrypoint.sh dockerd >/tmp/dockerd.log 2>&1 & "
-    "i=0; while ! docker info >/dev/null 2>&1; do "
-    "  i=$((i+1)); [ $i -gt 90 ] && exit 1; sleep 1; done; "
-    # Emit BOTH lines unconditionally. The two ways this fails need different fixes and look
-    # identical from an empty arch alone: the inner daemon never starting, versus the daemon
-    # being fine while the amd64 child dies in the runtime (e.g. "rosetta error: failed to open
-    # elf"). Reaching the sentinel at all proves the daemon came up, so the presence of these
-    # lines is what separates the two — and the captured stderr names the real cause.
-    # -q suppresses the inner pull's progress, which is written to stderr and would otherwise
-    # bury the actual error; the tail (not head) is taken for the same reason — the runtime's
-    # failure is the LAST thing on stderr.
-    f"arch=$(docker run --rm -q --platform linux/amd64 {BINFMT_PROBE_IMAGE} uname -m 2>/tmp/err); "
-    f'echo "{_SENTINEL}$arch"; '
-    f"echo \"{_ERR_SENTINEL}$(tr '\\n' ' ' </tmp/err | tail -c 300)\""
-)
+
+def _nested_script(platform: str | None) -> str:
+    """The Tier 2 script for one platform: bring up an inner daemon, run a child of the SAME
+    platform inside it, report both arches. `platform=None` ⇒ no `--platform` anywhere: the
+    wrapper and the child are whatever the daemon runs natively."""
+    child_platform = f"--platform {platform} " if platform else ""
+    return (
+        # The docker:dind image ships DOCKER_HOST=tcp://docker:2375 (plus TLS vars) for the
+        # docker-compose "dind sidecar" pattern. Left set, the inner CLI dials a host named
+        # `docker` that does not exist here and never reaches the daemon it just started — the
+        # probe then times out and reports "not available" on a host where nesting works
+        # perfectly. Clear them so the CLI falls back to the local unix socket.
+        "unset DOCKER_HOST DOCKER_TLS_VERIFY DOCKER_CERT_PATH; "
+        # The wrapper's own arch: what a `platform=None` child must agree with, and proof (when
+        # present at all) that the wrapper could exec — a foreign-arch wrapper with no binfmt
+        # handler dies before this line with "exec format error".
+        f'echo "{_OUTER_SENTINEL}$(uname -m)"; '
+        "dockerd-entrypoint.sh dockerd >/tmp/dockerd.log 2>&1 & "
+        f"deadline=$(( $(date +%s) + {_INNER_DAEMON_BUDGET} )); "
+        "while ! docker info >/dev/null 2>&1; do "
+        "  if [ $(date +%s) -gt $deadline ]; then "
+        # The daemon's own log is the ONLY place the cause lives (e.g. `iptables: Failed to
+        # initialize nft: Protocol not supported` under qemu) — hand its tail out before dying.
+        f"    echo \"{_DAEMON_LOG_SENTINEL}$(tr '\\n' ' ' </tmp/dockerd.log | tail -c 400)\"; "
+        "    exit 1; "
+        "  fi; sleep 1; "
+        "done; "
+        # Emit BOTH lines unconditionally. The two ways this fails need different fixes and look
+        # identical from an empty arch alone: the inner daemon never starting, versus the daemon
+        # being fine while the child dies in the runtime (e.g. "rosetta error: failed to open
+        # elf"). Reaching the sentinel at all proves the daemon came up, so the presence of these
+        # lines is what separates the two — and the captured stderr names the real cause.
+        # -q suppresses the inner pull's progress, which is written to stderr and would
+        # otherwise bury the actual error; the tail (not head) is taken for the same reason —
+        # the runtime's failure is the LAST thing on stderr.
+        f"arch=$(docker run --rm -q {child_platform}{BINFMT_PROBE_IMAGE} uname -m 2>/tmp/err); "
+        f'echo "{_SENTINEL}$arch"; '
+        f"echo \"{_ERR_SENTINEL}$(tr '\\n' ' ' </tmp/err | tail -c 300)\""
+    )
 
 
 @dataclass(frozen=True)
@@ -145,13 +201,17 @@ class NestedSupport:
     mission bind mounts resolve against the wrong filesystem. So this is a PRECONDITION, and a
     negative verdict must fail a run loudly rather than silently degrade it.
 
-    `detail` is written for the operator — it is what a failed run prints.
+    `detail` is written for the operator — it is what a failed run prints. `platform` is the
+    execution platform the verdict is ABOUT ("" = the daemon's native one): nesting is a property
+    of the (host, platform) pair, not of the host alone — an arm64 host nests arm64 natively and
+    may or may not be able to nest amd64 under emulation.
     """
 
     ok: bool
     detail: str
     fingerprint: str = ""
     remediation: str = ""
+    platform: str = ""
 
 
 def host_is_macos() -> bool:
@@ -265,46 +325,107 @@ def binfmt_signal(client: Any, *, image: str = BINFMT_PROBE_IMAGE) -> RosettaPro
 # ------------------------------------------------------------- tier 2: nested ground truth
 
 
-def verify_nested_amd64(
+def _decode(raw: Any) -> str:
+    return raw.decode(errors="replace") if isinstance(raw, bytes) else str(raw or "")
+
+
+def _output_tail(text: str, limit: int = 300) -> str:
+    """The last `limit` chars of a container's non-sentinel output, whitespace-collapsed. This
+    is where a wrapper that never ran its script says why (`exec format error`)."""
+    sentinels = (_SENTINEL, _ERR_SENTINEL, _OUTER_SENTINEL, _DAEMON_LOG_SENTINEL)
+    lines = [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith(sentinels)
+    ]
+    joined = " ".join(" ".join(lines).split())
+    return joined if len(joined) <= limit else "…" + joined[-(limit - 1) :]
+
+
+_PLATFORM_MISMATCH = "does not match the specified platform"
+
+
+def _start_wrapper(client: Any, image: str, wanted: str | None) -> Any:
+    """Start the detached DinD wrapper at `wanted`, pulling the right platform's image if the
+    local tag holds another's. Docker keeps ONE image per tag under overlay2, and docker-py's
+    `run` re-pulls only on a missing image — a present-but-wrong-platform tag surfaces as a 404
+    ("… was found but its platform (linux/amd64) does not match the specified platform
+    (linux/arm64)") that would otherwise read as "this host cannot nest"."""
+    kwargs: dict[str, Any] = {
+        "command": ["sh", "-c", _nested_script(wanted)],
+        "privileged": True,
+        "detach": True,
+        # The outer layer runs at the platform of the mission it stands in for. None ⇒ the
+        # daemon's native platform (docker's default when no platform is requested).
+        "platform": wanted,
+        # Labelled so a crash before the finally-remove leaves a container `xorcise down` can
+        # still reap — a stranded PRIVILEGED DinD is the worst thing to leak. Deliberately
+        # UNNAMED: a fixed name would 409 the next probe if a crashed one lingers; the reaper
+        # filters on the label, not the name.
+        "labels": {_PROBE_LABEL: "true"},
+    }
+    try:
+        return client.containers.run(image, **kwargs)
+    except Exception as exc:
+        if not wanted or _PLATFORM_MISMATCH not in str(exc):
+            raise
+        client.images.pull(image, platform=wanted)  # docker-py splits repo:tag itself
+        return client.containers.run(image, **kwargs)
+
+
+def verify_nested(
     client: Any,
     *,
+    platform: str | None = None,
     image: str = NESTED_PROBE_IMAGE,
     timeout: int = NESTED_PROBE_TIMEOUT,
 ) -> RosettaProbe:
-    """Tier 2 (~20-40 s). The only check that proves the WHOLE chain: start a throwaway
-    `--platform linux/amd64` DinD, wait for its inner daemon, run an amd64 child inside it and
-    assert the child reports `x86_64`.
+    """Tier 2 (~10-40 s natively). The only check that proves the WHOLE chain for ONE platform:
+    start a throwaway DinD wrapper at `platform`, wait for its inner daemon, run a child of the
+    same platform inside it and assert the child reports the machine that platform implies.
 
-    Slow by nature, so the caller caches the verdict against the Tier 1 fingerprint. The container
-    is always removed, including on timeout — a stranded privileged DinD would be worse than a
-    wrong answer."""
+    `platform=None` probes the daemon's NATIVE platform — no `--platform` anywhere, the child
+    must agree with the wrapper's own `uname -m`. A mission that pulled a native image is gated
+    on exactly this; a mission that pulled a foreign one (amd64 under emulation on an arm64 host)
+    is gated on `platform="linux/amd64"`, which is the only way to learn whether THAT works here.
+    Before this took a platform, the wrapper was hard-pinned to amd64 — so an arm64 Linux host
+    with no x86 emulation was refused every mission, including the native-arm64 ones it could
+    run perfectly, and told to check privileged containers.
+
+    Slow by nature, so the caller caches the verdict per platform. The container is always
+    removed (with its anonymous /var/lib/docker volume), including on timeout — a stranded
+    privileged DinD would be worse than a wrong answer. On timeout the container's output is
+    still read first: it is the diagnosis."""
+    wanted = canonical_platform(platform)
+    label = wanted or "host-native"
+    expected = _MACHINE_FOR_PLATFORM.get(wanted or "", "")
     container = None
+    text = ""
+    result: Any = None
+    failure: str | None = None
     try:
-        container = client.containers.run(
-            image,
-            command=["sh", "-c", _NESTED_SCRIPT],
-            privileged=True,
-            detach=True,
-            platform="linux/amd64",  # the outer amd64 layer — Rosetta's first hop
-            # Labelled so a crash before the finally-remove leaves a container `xorcise down` can
-            # still reap — a stranded PRIVILEGED DinD is the worst thing to leak. Deliberately
-            # UNNAMED: a fixed name would 409 the next probe if a crashed one lingers; the reaper
-            # filters on the label, not the name.
-            labels={_PROBE_LABEL: "true"},
-        )
-        result = container.wait(timeout=timeout)
-        logs = container.logs()
-        text = logs.decode(errors="replace") if isinstance(logs, bytes) else str(logs)
+        container = _start_wrapper(client, image, wanted)
+        try:
+            result = container.wait(timeout=timeout)
+        except Exception as exc:  # noqa: BLE001 — the SDK read timed out (or the daemon blinked)
+            failure = f"{type(exc).__name__}: {exc}"
+        # Read the output EVEN after a timeout: the container is still there, and what it printed
+        # so far (the daemon log tail, an exec error) is the only diagnosis there will be.
+        with contextlib.suppress(Exception):
+            text = _decode(container.logs())
     except Exception as exc:  # noqa: BLE001 — fail closed
-        return RosettaProbe(False, f"nested amd64 probe failed: {type(exc).__name__}: {exc}")
+        return RosettaProbe(False, f"nested {label} probe failed: {type(exc).__name__}: {exc}")
     finally:
         if container is not None:
-            # best effort; already-gone is the common case
+            # best effort; already-gone is the common case. v=True: the dind image declares
+            # VOLUME /var/lib/docker, so a plain remove leaks one anonymous volume per probe.
             with contextlib.suppress(Exception):
-                container.remove(force=True)
+                container.remove(force=True, v=True)
 
     arch = ""
     err = ""
+    outer = ""
+    daemon_log = ""
     reached_child = False
     for raw_line in text.splitlines():
         line = raw_line.strip()
@@ -313,19 +434,44 @@ def verify_nested_amd64(
             arch = line[len(_SENTINEL) :].strip()
         elif line.startswith(_ERR_SENTINEL):
             err = line[len(_ERR_SENTINEL) :].strip()
+        elif line.startswith(_OUTER_SENTINEL):
+            outer = line[len(_OUTER_SENTINEL) :].strip()
+        elif line.startswith(_DAEMON_LOG_SENTINEL):
+            daemon_log = line[len(_DAEMON_LOG_SENTINEL) :].strip()
 
-    if arch == "x86_64":
-        return RosettaProbe(True, "nested amd64 verified (x86_64 inside an amd64 DinD)")
+    if not expected:
+        # No platform requested (or one this table does not know): the child must match the
+        # wrapper it runs inside — the wrapper's own arch is the ground truth for "native".
+        expected = outer
+    if arch and arch == expected:
+        shown = wanted or _PLATFORM_FOR_MACHINE.get(arch, label)
+        return RosettaProbe(True, f"nested {shown} verified ({arch} inside a {shown} DinD)")
+
+    if failure is not None:
+        tail = daemon_log or _output_tail(text)
+        why = f"; last output: {tail}" if tail else ""
+        return RosettaProbe(
+            False, f"the {label} DinD probe did not finish within {timeout}s ({failure}){why}"
+        )
     status = (result or {}).get("StatusCode") if isinstance(result, dict) else result
     if not reached_child:
-        return RosettaProbe(False, f"the DinD probe's inner daemon never came up (exit {status})")
-    if not arch:
-        # The daemon was healthy and the amd64 child still failed — the interesting case, and
-        # the one whose cause is only in the runtime's stderr.
+        # Two very different causes share this branch, and only the output tells them apart: a
+        # wrapper that could not exec at all (`exec format error` — a foreign platform with no
+        # binfmt handler), versus one whose inner dockerd started and died (its log tail).
+        tail = daemon_log or _output_tail(text)
+        why = f": {tail}" if tail else ""
         return RosettaProbe(
-            False, f"nested amd64 container failed to start: {err or 'no error output'}"
+            False, f"the {label} DinD probe's inner daemon never came up (exit {status}){why}"
         )
-    return RosettaProbe(False, f"nested child reported {arch!r}, expected 'x86_64'")
+    if not arch:
+        # The daemon was healthy and the child still failed — the interesting case, and the one
+        # whose cause is only in the runtime's stderr.
+        return RosettaProbe(
+            False, f"nested {label} container failed to start: {err or 'no error output'}"
+        )
+    return RosettaProbe(
+        False, f"nested child reported {arch!r}, expected {expected or 'the wrapper arch'!r}"
+    )
 
 
 # --------------------------------------------------------------- precondition (pure)
@@ -342,6 +488,20 @@ _FIX_GENERIC = (
     "XORCISE runs each mission's containers INSIDE its own container, which this host could not "
     "do. Check that Docker can run privileged containers, then re-run 'xorcise doctor'"
 )
+# A Linux host asked to nest a platform it does not execute natively. There is no toggle for
+# this: a qemu binfmt handler runs foreign user-space but cannot service the nf_tables netlink
+# calls the inner dockerd makes, so amd64 DinD under emulation dies at iptables init.
+_FIX_EMULATION = (
+    "this mission's image is {platform}, but this host executes {host} natively and cannot run "
+    "{platform} containers nested — running a foreign platform's Docker-in-Docker needs CPU "
+    "emulation (qemu binfmt), which cannot bring up the inner Docker daemon on Linux. Choose a "
+    "mission that publishes a {host} image (see 'xorcise mission list'), or run XORCISE on a "
+    "{platform} host"
+)
+
+
+def _emulation_fix(platform: str | None, host: str | None) -> str:
+    return _FIX_EMULATION.format(platform=platform or "a foreign platform", host=host or "another")
 
 
 def clip_detail(text: str, limit: int = 160) -> str:
@@ -359,8 +519,11 @@ def check_nested_support(
     probe_tier1: Callable[[], RosettaProbe],
     probe_tier2: Callable[[RosettaProbe], RosettaProbe],
     on_macos: bool | None = None,
+    platform: str | None = None,
+    host_platform: str | None = None,
 ) -> NestedSupport:
-    """Can this host run the mission stack nested? Pure: both tiers (and the OS) are injected.
+    """Can this host run the mission stack nested AT `platform`? Pure: both tiers, the OS and the
+    platforms are injected.
 
     Tier 2 — actually starting a container inside a container — is the ONLY gate, because it is
     the thing we need and it means the same on every platform. Tier 1 (the Rosetta binfmt
@@ -373,30 +536,59 @@ def check_nested_support(
     (restricted CI, no privileged containers). It skips the check; it can never re-enable the
     removed sibling topology.
 
-    `on_macos` gates the Rosetta remediation: Rosetta is macOS-only, and Tier 1 ALWAYS fails on
-    Linux (no rosetta binfmt handler exists there), so choosing the fix on `not tier1.ok` alone
-    handed every Linux nesting failure the "enable Rosetta in Docker Desktop" advice for settings
-    that do not exist. Defaults to the real host OS; injected in tests.
+    `platform` is the execution platform the verdict is about (None = the daemon's native one)
+    and `host_platform` what the daemon executes natively (None = unknown). Together they pick
+    the remediation, because the three ways nesting fails need three different fixes:
+
+      * a FOREIGN platform on a Linux host — amd64 asked of an arm64 machine — is not a
+        privileged-container problem, it is "this host cannot run that platform's DinD at all"
+        (no binfmt handler ⇒ `exec format error`; a qemu handler ⇒ the inner dockerd dies at
+        iptables init). The fix is a different mission or a different host, and saying
+        "check privileged containers" sends the operator to fix something that is not broken;
+      * amd64 on Apple Silicon is the Rosetta case: on macOS a Tier 1 failure (or a "rosetta"
+        error from Tier 2) is the actionable cause, and only there — Tier 1 ALWAYS fails on
+        Linux (no rosetta binfmt handler exists there), so choosing the fix on `not tier1.ok`
+        alone handed every Linux nesting failure the "enable Rosetta in Docker Desktop" advice
+        for settings that do not exist. Rosetta is also irrelevant to a NATIVE arm64 failure on
+        the same Mac;
+      * everything else is the host's ability to nest its own platform: privileged containers.
+
+    `on_macos` defaults to the real host OS; injected in tests.
     """
     if skip:
         return NestedSupport(True, "nested-container check skipped by configuration")
 
     macos = host_is_macos() if on_macos is None else on_macos
+    wanted = canonical_platform(platform)
+    native = canonical_platform(host_platform)
     tier1 = probe_tier1()  # cheap; needed for the fingerprint whatever the verdict
     tier2 = probe_tier2(tier1)
     if tier2.ok:
-        return NestedSupport(True, tier2.detail, tier1.fingerprint)
+        return NestedSupport(True, tier2.detail, tier1.fingerprint, platform=wanted or "")
 
-    # The Rosetta fix applies ONLY on macOS: on Apple Silicon a Tier 1 failure (or a "rosetta"
-    # error from Tier 2) is the actionable cause. Off macOS, Rosetta is irrelevant no matter what
-    # Tier 1 says, so the generic "can this host run privileged containers" fix is the honest one.
-    rosetta_at_fault = macos and (not tier1.ok or "rosetta" in tier2.detail.lower())
-    detail = clip_detail(tier2.detail)
-    if macos and not tier1.ok:  # append the actionable half AFTER clipping, so it is never cut
-        detail = f"{detail} (rosetta: {tier1.detail})"
-    return NestedSupport(
-        False,
-        detail,
-        tier1.fingerprint,
-        _FIX_ROSETTA if rosetta_at_fault else _FIX_GENERIC,
+    lowered = tier2.detail.lower()
+    # Foreign = a platform was asked for AND it is not what the daemon runs natively. When the
+    # native platform is unknown, a wrapper that could not even exec is proof enough.
+    foreign = wanted is not None and (
+        (native is not None and wanted != native) or "exec format error" in lowered
     )
+    amd64_wanted = wanted == "linux/amd64"
+    # Rosetta is the amd64-on-Apple-Silicon path and nothing else: a native failure on the same
+    # Mac, or an arm64 probe, cannot be a Rosetta problem whatever Tier 1 says.
+    rosetta_at_fault = (
+        macos
+        and (amd64_wanted or (wanted is None and native is None))
+        and native != "linux/amd64"
+        and (not tier1.ok or "rosetta" in lowered)
+    )
+    detail = clip_detail(tier2.detail)
+    if rosetta_at_fault and not tier1.ok:
+        # append the actionable half AFTER clipping, so it is never cut
+        detail = f"{detail} (rosetta: {tier1.detail})"
+    if rosetta_at_fault:
+        fix = _FIX_ROSETTA
+    elif foreign and not macos:
+        fix = _emulation_fix(wanted, native)
+    else:
+        fix = _FIX_GENERIC
+    return NestedSupport(False, detail, tier1.fingerprint, fix, platform=wanted or "")

--- a/src/xorcise/core/runner/docker/rosetta.py
+++ b/src/xorcise/core/runner/docker/rosetta.py
@@ -488,15 +488,16 @@ _FIX_GENERIC = (
     "XORCISE runs each mission's containers INSIDE its own container, which this host could not "
     "do. Check that Docker can run privileged containers, then re-run 'xorcise doctor'"
 )
-# A Linux host asked to nest a platform it does not execute natively. There is no toggle for
-# this: a qemu binfmt handler runs foreign user-space but cannot service the nf_tables netlink
-# calls the inner dockerd makes, so amd64 DinD under emulation dies at iptables init.
+# A host asked to nest a platform it does not execute natively, where Rosetta is not the answer
+# (not a Mac, an Intel Mac asked for arm64, or Rosetta already on and still failing). There is
+# no toggle for this: a qemu binfmt handler runs foreign user-space but cannot service the
+# nf_tables netlink calls the inner dockerd makes, so foreign DinD under emulation dies at
+# iptables init — on Linux and inside Docker Desktop's Linux VM alike.
 _FIX_EMULATION = (
     "this mission's image is {platform}, but this host executes {host} natively and cannot run "
     "{platform} containers nested — running a foreign platform's Docker-in-Docker needs CPU "
-    "emulation (qemu binfmt), which cannot bring up the inner Docker daemon on Linux. Choose a "
-    "mission that publishes a {host} image (see 'xorcise mission list'), or run XORCISE on a "
-    "{platform} host"
+    "emulation, which cannot bring up the inner Docker daemon. Choose a mission that publishes "
+    "a {host} image (see 'xorcise mission list'), or run XORCISE on a {platform} host"
 )
 
 
@@ -540,23 +541,30 @@ def check_nested_support(
     and `host_platform` what the daemon executes natively (None = unknown). Together they pick
     the remediation, because the three ways nesting fails need three different fixes:
 
-      * a FOREIGN platform on a Linux host — amd64 asked of an arm64 machine — is not a
-        privileged-container problem, it is "this host cannot run that platform's DinD at all"
-        (no binfmt handler ⇒ `exec format error`; a qemu handler ⇒ the inner dockerd dies at
-        iptables init). The fix is a different mission or a different host, and saying
-        "check privileged containers" sends the operator to fix something that is not broken;
       * amd64 on Apple Silicon is the Rosetta case: on macOS a Tier 1 failure (or a "rosetta"
         error from Tier 2) is the actionable cause, and only there — Tier 1 ALWAYS fails on
         Linux (no rosetta binfmt handler exists there), so choosing the fix on `not tier1.ok`
         alone handed every Linux nesting failure the "enable Rosetta in Docker Desktop" advice
         for settings that do not exist. Rosetta is also irrelevant to a NATIVE arm64 failure on
         the same Mac;
+      * any OTHER foreign platform — amd64 asked of an arm64 Linux box, arm64 asked of an Intel
+        Mac, amd64 on Apple Silicon with Rosetta already on and still failing — is not a
+        privileged-container problem, it is "this host cannot run that platform's DinD at all"
+        (no binfmt handler ⇒ `exec format error`; a qemu handler ⇒ the inner dockerd dies at
+        iptables init). The fix is a different mission or a different host, and saying
+        "check privileged containers" sends the operator to fix something that is not broken.
+        The OS does not enter into it: what decides is that the platform is foreign AND Rosetta
+        is not the missing piece;
       * everything else is the host's ability to nest its own platform: privileged containers.
 
     `on_macos` defaults to the real host OS; injected in tests.
     """
     if skip:
-        return NestedSupport(True, "nested-container check skipped by configuration")
+        return NestedSupport(
+            True,
+            "nested-container check skipped by configuration",
+            platform=canonical_platform(platform) or "",
+        )
 
     macos = host_is_macos() if on_macos is None else on_macos
     wanted = canonical_platform(platform)
@@ -587,7 +595,7 @@ def check_nested_support(
         detail = f"{detail} (rosetta: {tier1.detail})"
     if rosetta_at_fault:
         fix = _FIX_ROSETTA
-    elif foreign and not macos:
+    elif foreign:
         fix = _emulation_fix(wanted, native)
     else:
         fix = _FIX_GENERIC

--- a/tests/adapters/test_rosetta_probe_wiring.py
+++ b/tests/adapters/test_rosetta_probe_wiring.py
@@ -28,7 +28,7 @@ class _Containers:
         self.kwargs: dict[str, Any] = {}
         self.removed = 0
 
-    def run(self, image, **kwargs):
+    def run(self, image: str, **kwargs: Any) -> Any:
         self.kwargs = {"image": image, **kwargs}
         if self.raises is not None:
             raise self.raises
@@ -58,8 +58,9 @@ class _NestedContainer:
     def logs(self):
         return self._logs
 
-    def remove(self, force=False):
+    def remove(self, force=False, v=False):
         self.removed = True
+        self.removed_volumes = v
 
 
 # ------------------------------------------------------------------------ tier 1 wiring
@@ -122,21 +123,56 @@ def _nested_client(logs: bytes, status: int = 0) -> tuple[_Client, _NestedContai
     return _Client(_Containers(container)), container
 
 
-def test_verify_nested_amd64_accepts_an_x86_64_child() -> None:
+AMD64 = "linux/amd64"
+
+
+def test_verify_nested_accepts_an_x86_64_child_for_an_amd64_platform() -> None:
     client, container = _nested_client(b"some noise\nXORCISE_NESTED_ARCH=x86_64\n")
-    probe = rosetta.verify_nested_amd64(client)
+    probe = rosetta.verify_nested(client, platform=AMD64)
     assert probe.ok
     assert client.containers.kwargs["platform"] == "linux/amd64"
     assert client.containers.kwargs["privileged"] is True
     assert client.containers.kwargs["detach"] is True
     assert container.removed  # never strand a privileged DinD
+    assert container.removed_volumes  # …nor the anonymous /var/lib/docker volume dind declares
 
 
-def test_verify_nested_amd64_rejects_a_non_x86_child() -> None:
+def test_verify_nested_runs_the_wrapper_at_the_platform_it_is_asked_about() -> None:
+    """The #79 fix. The wrapper used to be hard-pinned to linux/amd64, so an arm64 Linux host
+    with no x86 emulation could not exec it and was refused EVERY mission — including the native
+    arm64 ones it runs perfectly. The wrapper and the inner child now follow the platform of the
+    mission under test."""
+    client, _ = _nested_client(b"XORCISE_OUTER_ARCH=aarch64\nXORCISE_NESTED_ARCH=aarch64\n")
+    probe = rosetta.verify_nested(client, platform="linux/arm64")
+    assert probe.ok
+    assert client.containers.kwargs["platform"] == "linux/arm64"
+    assert "--platform linux/arm64" in client.containers.kwargs["command"][-1]
+    assert "linux/arm64" in probe.detail
+
+
+def test_verify_nested_native_pins_nothing_and_trusts_the_wrapper_arch() -> None:
+    """No platform ⇒ the daemon's native one: no `--platform` anywhere (docker's default), and
+    the child is right when it matches the wrapper it runs inside — whatever that is."""
+    client, _ = _nested_client(b"XORCISE_OUTER_ARCH=aarch64\nXORCISE_NESTED_ARCH=aarch64\n")
+    probe = rosetta.verify_nested(client)
+    assert probe.ok
+    assert client.containers.kwargs["platform"] is None
+    assert "--platform" not in client.containers.kwargs["command"][-1]
+    assert "linux/arm64" in probe.detail  # named from the arch actually observed
+
+
+def test_verify_nested_normalises_platform_spellings() -> None:
     client, _ = _nested_client(b"XORCISE_NESTED_ARCH=aarch64\n")
-    probe = rosetta.verify_nested_amd64(client)
+    assert rosetta.verify_nested(client, platform="linux/arm64/v8").ok
+    assert client.containers.kwargs["platform"] == "linux/arm64"
+
+
+def test_verify_nested_rejects_a_child_of_the_wrong_arch() -> None:
+    client, _ = _nested_client(b"XORCISE_NESTED_ARCH=aarch64\n")
+    probe = rosetta.verify_nested(client, platform=AMD64)
     assert probe.ok is False
     assert "aarch64" in probe.detail
+    assert "x86_64" in probe.detail
 
 
 def test_a_failed_child_is_reported_with_the_runtime_error() -> None:
@@ -147,26 +183,52 @@ def test_a_failed_child_is_reported_with_the_runtime_error() -> None:
     client, _ = _nested_client(
         b"XORCISE_NESTED_ARCH=\nXORCISE_NESTED_ERR=rosetta error: failed to open elf\n"
     )
-    probe = rosetta.verify_nested_amd64(client)
+    probe = rosetta.verify_nested(client, platform=AMD64)
     assert probe.ok is False
     assert "rosetta error: failed to open elf" in probe.detail
 
 
 def test_a_failed_child_with_no_stderr_still_says_so() -> None:
     client, _ = _nested_client(b"XORCISE_NESTED_ARCH=\nXORCISE_NESTED_ERR=\n")
-    assert "no error output" in rosetta.verify_nested_amd64(client).detail
+    assert "no error output" in rosetta.verify_nested(client, platform=AMD64).detail
 
 
 def test_a_daemon_that_never_started_is_distinguished_from_a_failed_child() -> None:
     """Different causes, different fixes: nothing to do with Rosetta, so it must not be reported
     as a Rosetta verdict. Reaching the sentinel at all is what proves the daemon came up."""
     client, _ = _nested_client(b"dockerd: exiting\n", status=1)
-    probe = rosetta.verify_nested_amd64(client)
+    probe = rosetta.verify_nested(client, platform=AMD64)
     assert probe.ok is False
     assert "inner daemon never came up" in probe.detail
 
 
-def test_verify_nested_amd64_removes_the_container_even_when_wait_raises() -> None:
+def test_a_wrapper_that_could_not_exec_reports_the_exec_error() -> None:
+    """The reporter's failure (#79): a foreign-platform wrapper with no binfmt handler dies
+    before its script runs, with `exec format error` and status 255. That text was read and
+    discarded, leaving "inner daemon never came up (exit 255)" — true, and useless. The
+    output tail is the diagnosis, so it rides along."""
+    client, _ = _nested_client(
+        b"exec /usr/local/bin/dockerd-entrypoint.sh: exec format error\n", status=255
+    )
+    probe = rosetta.verify_nested(client, platform=AMD64)
+    assert probe.ok is False
+    assert "exit 255" in probe.detail
+    assert "exec format error" in probe.detail
+
+
+def test_a_daemon_that_died_hands_out_its_own_log_tail() -> None:
+    """Under qemu the inner dockerd starts and dies at iptables init; only its log says so."""
+    client, _ = _nested_client(
+        b"XORCISE_OUTER_ARCH=x86_64\n"
+        b"XORCISE_DAEMON_LOG=... iptables: Failed to initialize nft: Protocol not supported\n",
+        status=1,
+    )
+    probe = rosetta.verify_nested(client, platform=AMD64)
+    assert probe.ok is False
+    assert "Failed to initialize nft" in probe.detail
+
+
+def test_verify_nested_removes_the_container_even_when_wait_raises() -> None:
     container = _NestedContainer(b"")
 
     def _boom(timeout=None):
@@ -174,14 +236,72 @@ def test_verify_nested_amd64_removes_the_container_even_when_wait_raises() -> No
 
     container.wait = _boom  # type: ignore[method-assign]
     client = _Client(_Containers(container))
-    probe = rosetta.verify_nested_amd64(client)
+    probe = rosetta.verify_nested(client, platform=AMD64)
     assert probe.ok is False
     assert container.removed
 
 
-def test_verify_nested_amd64_honours_an_explicit_image() -> None:
+def test_verify_nested_reads_the_output_even_when_wait_times_out() -> None:
+    """The 180 s ceiling used to surface as a bare `ConnectionError: Read timed out` with every
+    line the container printed thrown away. The container is still there at that point; what it
+    said so far is the only diagnosis there will be."""
+    container = _NestedContainer(
+        b'XORCISE_OUTER_ARCH=x86_64\nlevel=warning msg="iptables: Protocol not supported"\n'
+    )
+
+    def _boom(timeout=None):
+        raise TimeoutError("read timed out")
+
+    container.wait = _boom  # type: ignore[method-assign]
+    client = _Client(_Containers(container))
+    probe = rosetta.verify_nested(client, platform=AMD64, timeout=7)
+    assert probe.ok is False
+    assert "did not finish within 7s" in probe.detail
+    assert "Protocol not supported" in probe.detail
+    assert container.removed
+
+
+def test_verify_nested_honours_an_explicit_image() -> None:
     """Callers point Tier 2 at the fused mission image — the exact artifact the decision is
     about, and already local — instead of pulling a generic dind."""
     client, _ = _nested_client(b"XORCISE_NESTED_ARCH=x86_64\n")
-    rosetta.verify_nested_amd64(client, image="xorcise/fused-breachpoint:1")
+    rosetta.verify_nested(client, platform=AMD64, image="xorcise/fused-breachpoint:1")
     assert client.containers.kwargs["image"] == "xorcise/fused-breachpoint:1"
+
+
+def test_a_wrong_platform_local_tag_is_re_pulled_for_the_wanted_platform() -> None:
+    """Docker holds ONE image per tag under overlay2, and docker-py only re-pulls on a MISSING
+    image. A local `docker:29.7.1-dind` of the other platform therefore 404s the create with
+    "platform … does not match", which read as "this host cannot nest". Pull the right one and
+    retry once, instead."""
+    container = _NestedContainer(b"XORCISE_NESTED_ARCH=aarch64\n")
+    attempts: list[str | None] = []
+    pulled: list[tuple[str, str | None]] = []
+
+    class _Once(_Containers):
+        def run(self, image: str, **kwargs: Any) -> Any:
+            attempts.append(kwargs.get("platform"))
+            if len(attempts) == 1:
+                raise RuntimeError(
+                    "404 Client Error: image with reference docker:29.7.1-dind was found but "
+                    "its platform (linux/amd64) does not match the specified platform (linux/arm64)"
+                )
+            return super().run(image, **kwargs)
+
+    class _Images:
+        def pull(self, image, platform=None, **_kw):
+            pulled.append((image, platform))
+
+    client = _Client(_Once(container))
+    client.images = _Images()  # type: ignore[attr-defined]
+    probe = rosetta.verify_nested(client, platform="linux/arm64")
+    assert probe.ok
+    assert pulled == [("docker:29.7.1-dind", "linux/arm64")]
+    assert attempts == ["linux/arm64", "linux/arm64"]
+
+
+def test_other_create_failures_are_not_retried() -> None:
+    client = _Client(_Containers(raises=RuntimeError("permission denied")))
+    probe = rosetta.verify_nested(client, platform="linux/arm64")
+    assert probe.ok is False
+    assert "permission denied" in probe.detail

--- a/tests/unit/test_cli_ux.py
+++ b/tests/unit/test_cli_ux.py
@@ -1365,3 +1365,15 @@ def test_a_misspelt_subcommand_gets_the_close_match_not_the_carried_value():
     assert result.exit_code == 2
     assert "xorcise run events export" in result.stderr
     assert "export exprot" not in result.stderr
+
+
+def test_bracketed_tokens_render_literally_in_usage_errors():
+    """Review aside on #80: user-typed tokens reach rich as markup. `[/x]` used to raise
+    MarkupError out of the error renderer, and `[abc]` vanished from the suggestion."""
+    result = runner.invoke(app, ["run", "events", "[/x]"])
+    assert result.exit_code == 2, result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "[/x]" in result.stderr
+    result = runner.invoke(app, ["run", "events", "[abc]"])
+    assert result.exit_code == 2
+    assert "xorcise run events export [abc]" in result.stderr

--- a/tests/unit/test_cli_ux.py
+++ b/tests/unit/test_cli_ux.py
@@ -1348,3 +1348,20 @@ def test_config_show_groups_into_sections(monkeypatch):
     assert "inherits the judge model" in out  # said once, not repeated per field
     assert "Disabled" in out and "xorcise catalog connect" in out
     assert "Local" in out  # no network addresses set
+
+
+def test_run_events_with_a_bare_run_id_suggests_the_export_form():
+    """`xorcise run events <run-id>` (#79 finding 6): the group has ONE subcommand and the
+    natural reading skips it, so the run id lands as an unknown command. The hint must be the
+    paste-and-run form with the id carried over, not a bare "No such command"."""
+    result = runner.invoke(app, ["run", "events", "0123456789abcdef0123456789abcdef"])
+    assert result.exit_code == 2
+    assert "no such command" in result.stderr
+    assert "xorcise run events export 0123456789abcdef0123456789abcdef" in result.stderr
+
+
+def test_a_misspelt_subcommand_gets_the_close_match_not_the_carried_value():
+    result = runner.invoke(app, ["run", "events", "exprot"])
+    assert result.exit_code == 2
+    assert "xorcise run events export" in result.stderr
+    assert "export exprot" not in result.stderr

--- a/tests/unit/test_doctor_nested_containers.py
+++ b/tests/unit/test_doctor_nested_containers.py
@@ -138,3 +138,18 @@ def test_up_never_runs_the_nested_probe(monkeypatch) -> None:
     )
     names = {c.name for c in lifecycle._environment_checks()}
     assert "nested containers" not in names
+
+
+def test_doctor_lists_foreign_platform_verdicts_as_warnings(monkeypatch) -> None:
+    """The amd64-on-Apple-Silicon refusal must be visible in doctor's output — and visibly cleared
+    after Rosetta is enabled — not only discoverable by the next run."""
+    refused = NestedSupport(False, "rosetta error: failed to open elf", "fp", "enable Rosetta …")
+    monkeypatch.setattr(dr, "memoised_verdicts", lambda: {"linux/amd64": refused})
+    checks = diag.nested_containers_foreign()
+    assert [c.name for c in checks] == ["nested containers (linux/amd64)"]
+    assert checks[0].ok is True and checks[0].level == "warning"  # native missions still run
+    assert checks[0].remediation == "enable Rosetta …"
+    monkeypatch.setattr(dr, "memoised_verdicts", lambda: {"linux/amd64": OK})
+    assert diag.nested_containers_foreign()[0].level == "blocker"  # a plain green line
+    monkeypatch.setattr(dr, "memoised_verdicts", lambda: {})
+    assert diag.nested_containers_foreign() == []

--- a/tests/unit/test_nested_container_support.py
+++ b/tests/unit/test_nested_container_support.py
@@ -1,11 +1,11 @@
 """The nested-container precondition: setting + probe + in-memory memo + base-compat gate.
 
 Four things carry the weight here. A check that is configured off must open no daemon
-connection. The expensive probe must run at most once per process (memoised in memory — there is
-no on-disk cache: a persisted verdict turned a transient probe failure into a permanent refusal),
-while `doctor` can force a fresh re-probe. An unsupported host must RAISE, since the host-daemon
-fallback it used to degrade to no longer exists. And an artifact fused on an incompatible base
-generation must be refused up front, with direction-aware advice.
+connection. The expensive probe must run at most once per process AND PLATFORM (memoised in
+memory — there is no on-disk cache: a persisted verdict turned a transient probe failure into a
+permanent refusal), while `doctor` can force a fresh re-probe. An unsupported host must RAISE,
+since the host-daemon fallback it used to degrade to no longer exists. And an artifact fused on
+an incompatible base generation must be refused up front, with direction-aware advice.
 """
 
 from __future__ import annotations
@@ -32,12 +32,20 @@ def _boom() -> object:
 
 @pytest.fixture(autouse=True)
 def _clear_memo():
-    """The verdict is process-global; reset it around each test so they do not leak."""
-    dr._memo = None
-    dr._last_logged = None
+    """The verdicts are process-global; reset them around each test so they do not leak."""
+    dr.reset_nested_support_memo()
     yield
-    dr._memo = None
-    dr._last_logged = None
+    dr.reset_nested_support_memo()
+
+
+class _Daemon:
+    """A client whose version report names the platform it executes natively."""
+
+    def __init__(self, arch: str = "amd64") -> None:
+        self._arch = arch
+
+    def version(self) -> dict[str, str]:
+        return {"Os": "linux", "Arch": self._arch}
 
 
 # ------------------------------------------------------------------------------- memo
@@ -45,6 +53,7 @@ def _clear_memo():
 
 def test_skip_never_touches_docker() -> None:
     assert dr.nested_support(_settings("skip"), _boom).ok is True
+    assert dr.nested_support(_settings("skip"), _boom, platform="linux/amd64").ok is True
 
 
 def test_probe_runs_once_then_serves_the_memo(monkeypatch) -> None:
@@ -55,7 +64,7 @@ def test_probe_runs_once_then_serves_the_memo(monkeypatch) -> None:
         calls.append(1)
         return RosettaProbe(True, "nested amd64 verified")
 
-    monkeypatch.setattr(dr, "verify_nested_amd64", _tier2)
+    monkeypatch.setattr(dr, "verify_nested", _tier2)
 
     first = dr.nested_support(_settings(), lambda: object())
     second = dr.nested_support(_settings(), lambda: object())
@@ -63,12 +72,56 @@ def test_probe_runs_once_then_serves_the_memo(monkeypatch) -> None:
     assert calls == [1]  # the slow tier ran exactly once — memoised in memory
 
 
+def test_the_memo_is_per_platform(monkeypatch) -> None:
+    """Nesting is a property of (host, platform): an arm64 host nests arm64 and cannot nest amd64.
+    One verdict per platform, each probed at most once, and the probe is asked about the platform
+    the caller named."""
+    monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "handler", "fp-a"))
+    asked: list[str | None] = []
+
+    def _tier2(_client, *, platform=None, **_kw):
+        asked.append(platform)
+        return RosettaProbe(platform != "linux/amd64", f"probe of {platform}")
+
+    monkeypatch.setattr(dr, "verify_nested", _tier2)
+    daemon = lambda: _Daemon("arm64")  # noqa: E731
+
+    assert dr.nested_support(_settings(), daemon, platform="linux/arm64").ok is True
+    assert dr.nested_support(_settings(), daemon, platform="linux/amd64").ok is False
+    assert dr.nested_support(_settings(), daemon, platform="linux/arm64").ok is True
+    assert dr.nested_support(_settings(), daemon, platform="linux/amd64").ok is False
+    assert asked == ["linux/arm64", "linux/amd64"]  # one probe per platform, then the memo
+    assert dr.nested_support(_settings(), daemon, platform="linux/amd64").platform == "linux/amd64"
+
+
+def test_a_native_prewarm_answers_for_the_explicit_native_platform(monkeypatch) -> None:
+    """Boot pre-warms with no platform (the daemon's native one); the first run then asks about
+    the platform its install recorded — the same spelling of the same question. It must read the
+    warm verdict, not pay a second probe (the "first run hangs" symptom pre-warm exists for)."""
+    monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "handler", "fp-a"))
+    calls: list[str | None] = []
+
+    def _tier2(_client, *, platform=None, **_kw):
+        calls.append(platform)
+        return RosettaProbe(True, "ok")
+
+    monkeypatch.setattr(dr, "verify_nested", _tier2)
+    daemon = lambda: _Daemon("arm64")  # noqa: E731
+
+    dr.prewarm_nested_support(_settings(), daemon)
+    assert dr.nested_support(_settings(), daemon, platform="linux/arm64").ok
+    assert dr.nested_support(_settings(), daemon, platform="linux/arm64/v8").ok
+    # The warm-up was the only probe — asked with the native platform spelt out, so the wrapper
+    # insists on the right image even when the local tag holds another platform's copy.
+    assert calls == ["linux/arm64"]
+
+
 def test_fresh_forces_a_reprobe_and_refreshes_the_memo(monkeypatch) -> None:
     monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "h", "fp-a"))
     verdicts = iter(
         [RosettaProbe(False, "child died"), RosettaProbe(True, "nested amd64 verified")]
     )
-    monkeypatch.setattr(dr, "verify_nested_amd64", lambda *_a, **_k: next(verdicts))
+    monkeypatch.setattr(dr, "verify_nested", lambda *_a, **_k: next(verdicts))
 
     assert dr.nested_support(_settings(), lambda: object()).ok is False
     # fresh=True re-probes (doctor reporting current health) and updates the memo,
@@ -79,7 +132,7 @@ def test_fresh_forces_a_reprobe_and_refreshes_the_memo(monkeypatch) -> None:
 
 def test_the_probe_client_is_closed(monkeypatch) -> None:
     monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "h", "fp-a"))
-    monkeypatch.setattr(dr, "verify_nested_amd64", lambda *_a, **_k: RosettaProbe(True, "ok"))
+    monkeypatch.setattr(dr, "verify_nested", lambda *_a, **_k: RosettaProbe(True, "ok"))
     closed: list[int] = []
 
     class _Client:
@@ -95,24 +148,50 @@ def test_the_probe_client_is_closed(monkeypatch) -> None:
 
 def test_require_passes_silently_when_supported(monkeypatch) -> None:
     monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "h", "fp-a"))
-    monkeypatch.setattr(dr, "verify_nested_amd64", lambda *_a, **_k: RosettaProbe(True, "ok"))
+    monkeypatch.setattr(dr, "verify_nested", lambda *_a, **_k: RosettaProbe(True, "ok"))
     dr.require_nested_support(_settings(), lambda: object())  # must not raise
+    dr.require_nested_support(_settings(), lambda: object(), platform="linux/amd64")
 
 
 def test_require_raises_a_typed_error_when_unsupported(monkeypatch) -> None:
     """There is no fallback topology left, so this MUST raise rather than degrade. On macOS the
-    error names Rosetta; the ContractError renders as one clean CLI line."""
+    error names Rosetta for an amd64 mission; the ContractError renders as one clean CLI line.
+    Both spellings of the bypass are named, and the restart it needs — the server reads its
+    settings once at boot, so a config.toml edit alone changes nothing (#79 finding 3)."""
     monkeypatch.setattr(rosetta, "host_is_macos", lambda: True)
     monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(False, "disabled", "fp-a"))
+    monkeypatch.setattr(dr, "verify_nested", lambda *_a, **_k: RosettaProbe(False, "child died"))
+    with pytest.raises(NestedContainersUnavailableError) as exc:
+        dr.require_nested_support(_settings(), lambda: _Daemon("arm64"), platform="linux/amd64")
+    message = str(exc.value)
+    assert "(linux/amd64)" in message  # which platform the refusal is about
+    assert "child died" in message  # what went wrong
+    assert "Rosetta" in message  # how to fix it (macOS, amd64 on Apple Silicon)
+    assert "XORCISE_NESTED_CONTAINER_CHECK=skip" in message  # how to bypass it (env)
+    assert 'nested_container_check = "skip"' in message  # how to bypass it (config.toml)
+    assert "xorcise down && xorcise up" in message  # and that either needs a restart
+
+
+def test_require_names_the_emulation_problem_for_a_foreign_platform_on_linux(monkeypatch) -> None:
+    """The #79 message. An arm64 Linux host refused an amd64 mission must be told THAT, not to
+    check privileged containers."""
+    monkeypatch.setattr(rosetta, "host_is_macos", lambda: False)
+    monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(False, "no handler", "fp"))
     monkeypatch.setattr(
-        dr, "verify_nested_amd64", lambda *_a, **_k: RosettaProbe(False, "child died")
+        dr,
+        "verify_nested",
+        lambda *_a, **_k: RosettaProbe(
+            False,
+            "the linux/amd64 DinD probe's inner daemon never came up (exit 255): exec "
+            "/usr/local/bin/dockerd-entrypoint.sh: exec format error",
+        ),
     )
     with pytest.raises(NestedContainersUnavailableError) as exc:
-        dr.require_nested_support(_settings(), lambda: object())
+        dr.require_nested_support(_settings(), lambda: _Daemon("arm64"), platform="linux/amd64")
     message = str(exc.value)
-    assert "child died" in message  # what went wrong
-    assert "Rosetta" in message  # how to fix it (macOS)
-    assert "XORCISE_NESTED_CONTAINER_CHECK=skip" in message  # how to bypass it
+    assert "exec format error" in message
+    assert "emulation" in message
+    assert "privileged" not in message
 
 
 def test_require_is_a_no_op_when_the_check_is_skipped() -> None:

--- a/tests/unit/test_nested_container_support.py
+++ b/tests/unit/test_nested_container_support.py
@@ -244,3 +244,51 @@ def test_base_compat_keeps_the_allowance_for_your_own_fuses() -> None:
     # A local fuse has no catalog upstream; "update from the catalog" is not even the right
     # advice, so the undeterminable-base allowance stays.
     dr.require_base_compatible("xorcise/mission-x:local", origin="your_own")
+
+
+def test_a_fresh_native_probe_also_refreshes_every_foreign_verdict(monkeypatch) -> None:
+    """Review of #80. `doctor` asks with no platform, so `fresh=True` used to rewrite only the
+    native keys — and the amd64 refusal on an Apple Silicon host, the one case Rosetta applies to,
+    survived a green doctor: the operator enabled Rosetta, doctor said fine, the next run still
+    told them to enable Rosetta. A fresh native probe now re-probes every platform a run has asked
+    about since boot."""
+    monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "h", "fp"))
+    amd64 = {"ok": False}
+    asked: list[str | None] = []
+
+    def _tier2(_client, *, platform=None, **_kw):
+        asked.append(platform)
+        if platform == "linux/amd64":
+            return RosettaProbe(amd64["ok"], "amd64 probe")
+        return RosettaProbe(True, f"ok {platform}")
+
+    monkeypatch.setattr(dr, "verify_nested", _tier2)
+    daemon = lambda: _Daemon("arm64")  # noqa: E731
+    dr.prewarm_nested_support(_settings(), daemon)  # native
+    assert dr.nested_support(_settings(), daemon, platform="linux/amd64").ok is False  # a run
+    amd64["ok"] = True  # the operator enables Rosetta…
+    assert dr.nested_support(_settings(), daemon, fresh=True).ok  # …and re-runs doctor
+    assert dr.nested_support(_settings(), daemon, platform="linux/amd64").ok is True  # cleared
+    assert asked == ["linux/arm64", "linux/amd64", "linux/arm64", "linux/amd64"]
+    assert set(dr.memoised_verdicts()) == {"linux/amd64"}  # what doctor lists beside native
+
+
+def test_prewarm_also_warms_amd64_on_apple_silicon(monkeypatch) -> None:
+    """On a Mac the common cold case is amd64 under Rosetta (missions without an arm64 image), so
+    boot warms it too; on Linux a foreign warm-up would start a 90 s emulated DinD for nothing."""
+    monkeypatch.setattr(dr, "binfmt_signal", lambda _c: RosettaProbe(True, "h", "fp"))
+    asked: list[str | None] = []
+
+    def _tier2(_client, *, platform=None, **_kw):
+        asked.append(platform)
+        return RosettaProbe(True, "ok")
+
+    monkeypatch.setattr(dr, "verify_nested", _tier2)
+    monkeypatch.setattr(dr, "host_is_macos", lambda: True)
+    dr.prewarm_nested_support(_settings(), lambda: _Daemon("arm64"))
+    assert asked == ["linux/arm64", "linux/amd64"]
+    dr.reset_nested_support_memo()
+    asked.clear()
+    monkeypatch.setattr(dr, "host_is_macos", lambda: False)
+    dr.prewarm_nested_support(_settings(), lambda: _Daemon("arm64"))
+    assert asked == ["linux/arm64"]  # Linux: native only

--- a/tests/unit/test_pull_precheck.py
+++ b/tests/unit/test_pull_precheck.py
@@ -1,0 +1,136 @@
+"""The pull spine's nesting precheck: WHICH platform it is asked about, and WHEN.
+
+Two behavioural facts at the centre of #80 that nothing else pins: the precheck receives the
+platform `_select_platform` chose for this host, and it runs BEFORE `driver.pull` — a change that
+moved the gate below the download would pass every other lane. Plus the one hole the review
+found: a pre-contract entry (no platform list) makes no selection, so the gate is asked about the
+native platform while the registry may land a single-arch FOREIGN image — the gate must be asked
+again about what actually landed, before anything is installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xorcise.core.catalog import StubCatalogSource
+from xorcise.core.catalog.source import MissionDetail, PlatformImage
+from xorcise.core.contracts.errors import NestedContainersUnavailableError
+from xorcise.core.rest.mission_pull import PullDeps, pull_mission
+from xorcise.core.runner.docker import StubDockerDriver
+
+pytestmark = pytest.mark.unit
+
+
+class _MultiArchSource(StubCatalogSource):
+    """A contract-era entry publishing amd64 AND arm64."""
+
+    def fetch_detail(self, mission_id: str) -> MissionDetail:
+        return MissionDetail(
+            manifest=self.fetch_manifest(mission_id),
+            mission_version="1.0.0",
+            mission_base_version="2.0.0",
+            content_hash="0" * 16,
+            pull_ref="reg/xorcise/mis-sqli-login:latest",
+            release_ref="reg/xorcise/mis-sqli-login:1.0.0-base2.0.0",
+            index_digest="sha256:idx",
+            platforms=(
+                PlatformImage(os="linux", architecture="amd64", digest="sha256:amd"),
+                PlatformImage(os="linux", architecture="arm64", digest="sha256:arm", variant="v8"),
+            ),
+            base_index_digest="sha256:base",
+            base_platform_digests={"amd64": "sha256:bamd", "arm64": "sha256:barm"},
+        )
+
+
+class _RecordingDriver(StubDockerDriver):
+    """An arm64 host whose registry serves what it is asked; records the ORDER of events."""
+
+    def __init__(self, *, native: str = "linux/arm64", lands: str | None = None) -> None:
+        super().__init__()
+        self.events: list[str] = []
+        self._native = native
+        self._lands = lands  # what image_platform reports after the pull (None ⇒ the request)
+        self._pulled_platform: str | None = None
+
+    def daemon_platform(self) -> str | None:
+        return self._native
+
+    def image_exists(self, image: str) -> bool:
+        return False  # a download ahead
+
+    def pull(self, image: str, **kwargs: object) -> None:
+        platform = kwargs.get("platform")
+        self._pulled_platform = platform if isinstance(platform, str) else None
+        self.events.append(f"pull:{self._pulled_platform}")
+
+    def image_platform(self, image: str) -> str | None:
+        return self._lands or self._pulled_platform or self._native
+
+
+def test_precheck_gets_the_selected_platform_before_the_pull(tmp_path: Path) -> None:
+    driver = _RecordingDriver()
+    deps = PullDeps(source=_MultiArchSource(enabled=True), driver=driver, install_root=tmp_path)
+
+    def precheck(platform: str | None) -> None:
+        driver.events.append(f"precheck:{platform}")
+
+    pull_mission("sqli-login", deps, precheck=precheck)
+    # Asked about the platform selected for THIS host (native arm64), and asked before any byte.
+    assert driver.events == ["precheck:linux/arm64", "pull:linux/arm64"]
+
+
+def test_a_refusing_precheck_costs_no_download(tmp_path: Path) -> None:
+    driver = _RecordingDriver()
+    deps = PullDeps(source=_MultiArchSource(enabled=True), driver=driver, install_root=tmp_path)
+
+    def refuse(platform: str | None) -> None:
+        raise NestedContainersUnavailableError(f"cannot nest {platform}")
+
+    with pytest.raises(NestedContainersUnavailableError):
+        pull_mission("sqli-login", deps, precheck=refuse)
+    assert driver.events == []  # refused before `pull` ran
+    assert not (tmp_path / "sqli-login").exists()
+
+
+def test_precheck_follows_the_operator_override(tmp_path: Path) -> None:
+    driver = _RecordingDriver()
+    deps = PullDeps(
+        source=_MultiArchSource(enabled=True),
+        driver=driver,
+        install_root=tmp_path,
+        platform_override="linux/amd64",
+    )
+    seen: list[str | None] = []
+    pull_mission("sqli-login", deps, precheck=seen.append)
+    assert seen == ["linux/amd64"]  # the override wins the selection, so it is what gets gated
+
+
+def test_pre_contract_entry_is_regated_on_what_actually_landed(tmp_path: Path) -> None:
+    """No platform list ⇒ no selection ⇒ the gate is asked about native. If the registry then
+    serves a single-arch foreign image, the gate is asked AGAIN about that platform before the
+    install — a refusal there leaves the mission cleanly not-installed instead of recording a
+    platform run-create would refuse."""
+    driver = _RecordingDriver(lands="linux/amd64")  # the registry only has amd64
+    deps = PullDeps(source=StubCatalogSource(enabled=True), driver=driver, install_root=tmp_path)
+    asked: list[str | None] = []
+
+    def gate(platform: str | None) -> None:
+        asked.append(platform)
+        if platform == "linux/amd64":
+            raise NestedContainersUnavailableError("cannot nest linux/amd64 here")
+
+    with pytest.raises(NestedContainersUnavailableError):
+        pull_mission("sqli-login", deps, precheck=gate)
+    assert asked == [None, "linux/amd64"]  # native first (nothing better known), then the landing
+    assert driver.events == ["pull:None"]
+    assert not (tmp_path / "sqli-login").exists()
+
+
+def test_pre_contract_entry_landing_native_is_not_regated(tmp_path: Path) -> None:
+    driver = _RecordingDriver()  # the registry serves the host's own arch
+    deps = PullDeps(source=StubCatalogSource(enabled=True), driver=driver, install_root=tmp_path)
+    asked: list[str | None] = []
+    pull_mission("sqli-login", deps, precheck=asked.append)
+    assert asked == [None]

--- a/tests/unit/test_rosetta_probe.py
+++ b/tests/unit/test_rosetta_probe.py
@@ -283,3 +283,51 @@ def test_tier1_verdict_is_handed_to_tier2() -> None:
 
     check_nested_support(skip=False, probe_tier1=lambda: tier1, probe_tier2=_tier2)
     assert seen == [tier1]
+
+
+def test_a_foreign_platform_on_macos_gets_the_emulation_fix_when_rosetta_is_not_the_cause():
+    """Review of #80: `elif foreign and not macos` left every macOS foreign failure on the generic
+    "check privileged containers" fix — the same wrong-fix problem being fixed for Linux. Two ways
+    in: Apple Silicon with Rosetta already ON (Tier 1 fine) whose amd64 probe still fails, and an
+    Intel Mac asked for an arm64 mission. Neither is a Rosetta problem; both are "this host cannot
+    run that platform's DinD"."""
+    fail = RosettaProbe(False, "the linux/amd64 DinD probe's inner daemon never came up (exit 1)")
+    rosetta_on = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: OK,
+        probe_tier2=lambda _t: fail,
+        on_macos=True,
+        platform="linux/amd64",
+        host_platform="linux/arm64",
+    )
+    intel_mac = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: fail,
+        on_macos=True,
+        platform="linux/arm64",
+        host_platform="linux/amd64",
+    )
+    for s in (rosetta_on, intel_mac):
+        assert s.ok is False
+        assert "emulation" in s.remediation
+        assert "privileged" not in s.remediation
+        assert "Rosetta" not in s.remediation
+    # …while the genuine Rosetta case (Tier 1 failing, amd64 on Apple Silicon) still gets Rosetta.
+    rosetta_off = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: fail,
+        on_macos=True,
+        platform="linux/amd64",
+        host_platform="linux/arm64",
+    )
+    assert "Rosetta" in rosetta_off.remediation
+
+
+def test_a_skipped_verdict_still_names_its_platform():
+    s = check_nested_support(
+        skip=True, probe_tier1=_never, probe_tier2=_never, platform="linux/arm64/v8"
+    )
+    assert s.ok is True
+    assert s.platform == "linux/arm64"

--- a/tests/unit/test_rosetta_probe.py
+++ b/tests/unit/test_rosetta_probe.py
@@ -138,14 +138,106 @@ def test_tier1_is_not_a_gate() -> None:
 
 
 def test_tier1_explains_a_rosetta_failure_on_macos() -> None:
-    """On macOS, when Tier 1 also failed, its verdict is the actionable half — a bare OCI error
-    chain does not tell an operator to go turn Rosetta on."""
+    """On macOS, when the AMD64 probe fails and Tier 1 also failed, its verdict is the actionable
+    half — a bare OCI error chain does not tell an operator to go turn Rosetta on."""
     s = check_nested_support(
-        skip=False, probe_tier1=lambda: BAD, probe_tier2=lambda _t: BAD, on_macos=True
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: BAD,
+        on_macos=True,
+        platform="linux/amd64",
+        host_platform="linux/arm64",
     )
     assert s.ok is False
     assert "rosetta" in s.detail.lower()
     assert "Rosetta" in s.remediation
+
+
+def test_a_native_failure_on_apple_silicon_is_not_a_rosetta_problem() -> None:
+    """Most catalog missions now ship arm64, so on an Apple Silicon Mac the probe that fails is
+    usually the NATIVE one — Rosetta never enters into it, and Tier 1 always fails there for the
+    unrelated reason that it reads an amd64 handler. Sending the operator to the Rosetta toggle
+    would be the same wrong-fix mistake as on Linux."""
+    s = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: RosettaProbe(False, "the DinD probe's inner daemon never came up"),
+        on_macos=True,
+        platform="linux/arm64",
+        host_platform="linux/arm64",
+    )
+    assert s.ok is False
+    assert "Rosetta" not in s.remediation
+    assert "privileged" in s.remediation
+
+
+def test_a_foreign_platform_on_linux_gets_the_emulation_fix_not_privileged() -> None:
+    """The #79 finding. An arm64 Linux host asked to nest an amd64 mission cannot — no binfmt
+    handler means `exec format error`, a qemu handler means the inner dockerd dies at iptables —
+    and neither has anything to do with privileged containers. The honest fix names both
+    platforms and points at a mission that ships the host's, or another host."""
+    exec_error = RosettaProbe(
+        False,
+        "the linux/amd64 DinD probe's inner daemon never came up (exit 255): "
+        "exec /usr/local/bin/dockerd-entrypoint.sh: exec format error",
+        "fp-a",
+    )
+    s = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: exec_error,
+        on_macos=False,
+        platform="linux/amd64",
+        host_platform="linux/arm64",
+    )
+    assert s.ok is False
+    assert s.platform == "linux/amd64"
+    assert "exec format error" in s.detail
+    assert "privileged" not in s.remediation
+    assert "Rosetta" not in s.remediation
+    assert "linux/amd64" in s.remediation and "linux/arm64" in s.remediation
+    assert "emulation" in s.remediation
+
+
+def test_an_exec_format_error_marks_the_platform_foreign_even_when_the_host_is_unknown() -> None:
+    """A daemon whose version report could not be read leaves the native platform unknown; the
+    wrapper failing to exec at all is proof enough that the platform is not the host's."""
+    exec_error = RosettaProbe(False, "never came up (exit 255): exec format error", "fp-a")
+    s = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: exec_error,
+        on_macos=False,
+        platform="linux/amd64",
+        host_platform=None,
+    )
+    assert "emulation" in s.remediation
+    assert "privileged" not in s.remediation
+
+
+def test_a_native_platform_failure_on_linux_stays_generic() -> None:
+    """Asked about the platform it runs natively, a Linux host that cannot nest has a
+    privileged-container problem — the emulation advice would be nonsense there."""
+    s = check_nested_support(
+        skip=False,
+        probe_tier1=lambda: BAD,
+        probe_tier2=lambda _t: RosettaProbe(False, "the DinD probe's inner daemon never came up"),
+        on_macos=False,
+        platform="linux/arm64",
+        host_platform="linux/arm64",
+    )
+    assert "privileged" in s.remediation
+    assert "emulation" not in s.remediation
+
+
+def test_the_verdict_records_the_platform_it_is_about() -> None:
+    s = check_nested_support(
+        skip=False, probe_tier1=lambda: OK, probe_tier2=lambda _t: OK, platform="linux/arm64/v8"
+    )
+    assert s.ok
+    assert s.platform == "linux/arm64"  # canonical spelling
+    native = check_nested_support(skip=False, probe_tier1=lambda: OK, probe_tier2=lambda _t: OK)
+    assert native.platform == ""  # "" = the daemon's native platform
 
 
 def test_a_linux_failure_gets_the_generic_fix_not_rosetta() -> None:


### PR DESCRIPTION
## What changed

The nested-container probe (Tier 2, `runner/docker/rosetta.py`) is now asked about the **execution platform of the mission about to run** instead of being hard-pinned to `linux/amd64`:

- `verify_nested(client, platform=…)` starts the DinD wrapper at that platform (`None` = the daemon's native one, no `--platform` anywhere), runs an inner child of the same platform and checks the child reports the machine that platform implies (`x86_64` / `aarch64`; unknown platforms must match the wrapper's own `uname -m`).
- `check_nested_support(...)` takes `platform` + `host_platform` and picks the remediation from them. A foreign platform on a Linux host gets a new fix that names both platforms and says emulation cannot bring up the inner daemon; the Rosetta fix is now restricted to *amd64 asked of an Apple Silicon Mac*; everything else stays "check privileged containers". `NestedSupport` records the platform the verdict is about.
- `rest/docker_runtime.py` memoises **one verdict per platform**. A native probe (what boot pre-warms and `doctor` runs) is also filed under the daemon's explicit platform spelling, so the first run of a native mission still reads the warm verdict. `require_nested_support(..., platform=…)`.
- The pull spine calls `precheck(selected_platform)` **after** `_select_platform`, and run-create passes the install's recorded platform to the gate (falling back to the local image's platform for installs that predate the record).
- The probe **reads the container output on every failure path**: the exec error when the wrapper cannot start (`exec format error`), the inner dockerd's log tail when the daemon dies (emitted by the script inside a 90 s wall-clock budget), and whatever was printed so far when the SDK wait times out. Previously all of that was discarded and the operator saw `inner daemon never came up (exit 255)` or a bare `ConnectionError: Read timed out`.
- Under overlay2 a tag holds one platform and docker-py only re-pulls on a *missing* image, so a present-but-wrong-platform tag 404s ("platform … does not match"). The probe now pulls the wanted platform and retries once.
- The probe container is removed with `v=True` — the dind image declares `VOLUME /var/lib/docker`, so every probe leaked one anonymous volume.
- The refusal message names both spellings of the bypass (`XORCISE_NESTED_CONTAINER_CHECK=skip`, `nested_container_check = "skip"` in `config.toml`) and that either needs `xorcise down && xorcise up`.
- `xorcise run events <run-id>` now suggests `xorcise run events export <run-id>` with the id carried over (generic: an unknown token on a single-subcommand group whose subcommand takes a positional).
- Stale comment in `config/__init__.py` ("mission images are built amd64-only") replaced.

## Why

Closes #79.

On an arm64 Linux host with no x86 emulation, every `xorcise run create` for a lab mission was refused with *"the DinD probe's inner daemon never came up (exit 255). … Check that Docker can run privileged containers"* — including for the 19 of 27 catalog missions that publish a native arm64 image and would run perfectly. The probe's wrapper could not exec at all (foreign arch, no binfmt handler); the text saying so was read and thrown away, and off macOS the remediation selector could only ever produce the privileged-containers advice. Nesting is a property of the *(host, platform)* pair, and the gate now asks about the right pair.

Findings 3–6 of #79 (config.toml bypass frozen until restart, qemu DinD failing at nftables with no diagnosis, the stale amd64-only comment, `run events <id>` rejected without a hint) are addressed in the same PR because they all sit on the message an operator reads when this gate refuses them.

## Testing

Lint / types / layers:

```
$ uv run ruff check . && uv run ruff format --check .
All checks passed!
514 files already formatted
$ uv run mypy
Success: no issues found in 489 source files
$ uv run lint-imports
Contracts: 4 kept, 0 broken.
```

Test lanes:

```
$ uv run pytest -m unit -n auto -q
2150 passed
$ uv run pytest -m "adapters or topology" -q
179 passed
```

New/updated tests: `tests/unit/test_rosetta_probe.py` (platform-aware remediation: foreign-on-Linux → emulation fix, native-on-Apple-Silicon → not Rosetta, exec-format-error marks foreign even with unknown host), `tests/adapters/test_rosetta_probe_wiring.py` (wrapper follows the requested platform, native pins nothing, output tail on exec error / daemon log / SDK timeout, wrong-platform tag re-pull, anon volume removal), `tests/unit/test_nested_container_support.py` (memo per platform, native pre-warm answers the explicit spelling, message names both bypass spellings + restart), `tests/unit/test_cli_ux.py` (`run events <id>` hint; misspelt subcommand gets the close match instead).

Empirical, against the real daemon on this amd64 host (`linux/amd64`, overlay2, no aarch64 binfmt handler), using the production entry points (`nested_support` / `require_nested_support`, `xorcise doctor`):

| Case | Before (main @ 48caafb) | After |
|---|---|---|
| Native probe (`platform=None`) | pass, 8.2 s | pass, 8.8 s — `nested linux/amd64 verified (x86_64 inside a linux/amd64 DinD)` |
| Explicit `linux/amd64` right after the native pre-warm | n/a (one global memo) | memo hit, 0.000 s, same verdict object |
| Foreign platform (`linux/arm64` on this amd64 host, **no** binfmt) — the mirror of the reporter's situation | `inner daemon never came up (exit 255)` + "check privileged containers" | refused in 16 s: `… (exit 255): exec /usr/local/bin/dockerd-entrypoint.sh: exec format error. this mission's image is linux/arm64, but this host executes linux/amd64 natively and cannot run linux/arm64 containers nested — … Choose a mission that publishes a linux/amd64 image …, or run XORCISE on a linux/arm64 host. To bypass … XORCISE_NESTED_CONTAINER_CHECK=skip … or nested_container_check = "skip" in ~/.xorcise/config.toml, then restart it (xorcise down && xorcise up)` |
| Foreign platform **with** a qemu binfmt handler (`tonistiigi/binfmt --install arm64`, removed afterwards) — mirror of finding 4 | 180 s, `ConnectionError: Read timed out`, nothing else | wrapper execs (`XORCISE_OUTER_ARCH=aarch64`), inner dockerd dies, script hands out its log tail and exits 1 after the 90 s budget (93 s wall, `OOMKilled=false`): `… never came up (exit 1): … modprobe: can't change directory to '/lib/modules' … iptables: Failed to initialize nft: Protocol not supported` + the same emulation remediation |
| Wrong-platform local tag (`docker:29.7.1-dind` held arm64 after the mirror run, native probe asked for amd64) | 404 `platform (linux/arm64) does not match the specified platform (linux/amd64)` → "cannot nest" | re-pulled + retried; `xorcise doctor` green: `✓ nested containers: nested linux/amd64 verified …`; tag back to `linux/amd64` |
| Anonymous volumes (`docker volume ls -qf dangling=true | wc -l`) before / after a probe | +1 per probe | 352 / 352 |
| `xorcise run events 0123…cdef` | `No such command '0123…'` exit 2, no hint | exit 2 + `Did you mean? xorcise run events export 0123…cdef` |

Host state after the runs: no `xorcise.managed` containers, no aarch64 binfmt handler, `docker:29.7.1-dind` tag = `linux/amd64`.

Not run here: a real arm64 Linux host (the reporter's). The arm64 branch of the code is exercised only through the mirror above and the unit/adapters tests; the `full-ci` label would be worth adding if an arm64 runner is available.

**Test lanes affected**

- [x] `unit` — no Docker, fast
- [x] `adapters` — port/adapter contracts
- [x] `topology` — manifest / compose / import / extras parity
- [x] `integration` — needs Docker or a live server process (run-create gate; not run locally end-to-end)
- [ ] `e2e` — full `xorcise up` + scripted agent
- [ ] `frontend` — Next.js typecheck / vitest

## User-facing impact

- [ ] No user-visible change (internal refactor, tests, docs only)
- [x] Backwards-compatible addition (new command, new optional flag, new field)
- [ ] **Breaking change** — describe the break and the migration path below

Behaviour change, not an interface change: hosts that could never run a lab mission before (arm64 Linux, native-arm64 missions) now can; refusals carry a different, platform-specific message; `run events <id>` gains a hint. No CLI options, config keys, REST contracts or schemas change. Internal signatures that changed: `verify_nested_amd64` → `verify_nested(platform=…)`, `RunCreateDeps.require_nested: Callable[[str | None], None]`, `pull_mission(precheck=Callable[[str | None], None])`.

## Documentation

- [ ] No documentation change needed
- [ ] Documentation updated in this PR
- [x] Documentation needed and tracked in a follow-up issue (link it)

The docs site (separate repo) has no page for `nested_container_check` and nothing on arm64 Linux / emulation limits — tracked as findings 3 and 4 of #79; this PR puts the same facts into the error message and the setting's comment.

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] **No secrets, credentials, tokens, keys, internal hostnames or customer data** appear in the diff
- [x] No references to internal-only systems in code or documentation

---

- [x] I have signed the Contributor License Agreement.
