### PR TITLE
fix(cli): serve one uvicorn server per app so startup hooks run once, not once per address

### DIFF
--- a/src/xorcise/core/cli/_preflight.py
+++ b/src/xorcise/core/cli/_preflight.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import errno
 import os
 import socket
+from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 
 # Human label per known plane port, for the conflict message.
@@ -42,15 +43,19 @@ def address_unavailable(exc: OSError) -> bool:
 
 
 def bind_listener(host: str, port: int) -> socket.socket:
-    """Bind (not yet listening) `host:port` exactly the way asyncio's `create_server(host=…)`
-    would, and hand the socket back for the server to adopt. Raises OSError on failure.
+    """Bind AND listen on `host:port` the way asyncio's `create_server(host=…)` would, and hand
+    the socket back for the server to adopt. Raises OSError on failure.
 
-    Binding here, once, is the preflight: the same socket is then passed to uvicorn, so there is
-    no gap in which another process can take the port between the check and the listen. Options
-    mirror CPython's base_events.create_server — SO_REUSEADDR on POSIX (so a port left in
-    TIME_WAIT by the previous server rebinds immediately) and IPV6_V6ONLY on an IPv6 socket (so
-    the IPv6 loopback listener never shadows or collides with the IPv4 one). asyncio calls
-    listen() itself when it adopts the socket."""
+    The listen() is what makes this an atomic preflight. `SO_REUSEADDR` deliberately lets two
+    sockets bind the same address while NEITHER is listening (that is how a port in TIME_WAIT is
+    reused), so a bound-but-not-listening socket holds nothing: a concurrent `serve` would bind
+    it too, and the loser would only find out at listen() — inside uvicorn's socket-adoption
+    path, after the app's startup hooks had already run, with no shutdown to follow. Listening
+    here means the conflict surfaces in THIS call, where the caller reports it cleanly, and the
+    address is held from this moment on. asyncio's listen() on adoption merely re-applies the
+    backlog. Options mirror CPython's base_events.create_server — SO_REUSEADDR on POSIX (so a
+    port left in TIME_WAIT by the previous server rebinds immediately) and IPV6_V6ONLY on an IPv6
+    socket (so the IPv6 loopback listener never shadows or collides with the IPv4 one)."""
     sock = socket.socket(address_family(host), socket.SOCK_STREAM)
     try:
         if os.name == "posix":
@@ -58,6 +63,7 @@ def bind_listener(host: str, port: int) -> socket.socket:
         if sock.family == socket.AF_INET6 and hasattr(socket, "IPPROTO_IPV6"):
             sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
         sock.bind((host, port))
+        sock.listen()
     except OSError:
         sock.close()
         raise
@@ -100,8 +106,22 @@ def ports_in_use(host: str, ports: list[int]) -> list[int]:
     return [p for p in ports if not _bindable(host, p)]
 
 
+def _probe_addresses(hosts: str | Sequence[str]) -> list[str]:
+    """The addresses a port must be free on for the listener set `hosts`: every address the
+    server will bind, plus the IPv4 wildcard when any of them is a specific IPv4 interface — a
+    wildcard probe refuses a listener on ANY single interface, so it catches a squatter on an
+    interface the set does not name. Nothing else: the IPv6 loopback is probed exactly when it
+    is in the set (role:all on a local topology), not for a role whose spec never binds it — a
+    `[::1]:8800` listener must not relocate `serve --role runner`."""
+    listen_on = [hosts] if isinstance(hosts, str) else list(hosts)
+    probe = list(dict.fromkeys(listen_on))
+    if any(address_family(h) == socket.AF_INET and h != "0.0.0.0" for h in listen_on):
+        probe.append("0.0.0.0")
+    return probe
+
+
 def find_free_port(
-    host: str,
+    host: str | Sequence[str],
     start: int,
     attempts: int = _SCAN_ATTEMPTS,
     taken: AbstractSet[int] = frozenset(),
@@ -109,28 +129,26 @@ def find_free_port(
 ) -> int:
     """First free port at-or-above `start` (walks start, start+1, … for `attempts` probes).
 
-    A port only counts as free when `host`, the IPv4 wildcard ("0.0.0.0") AND the IPv6
-    loopback ("::1") are all bindable: a wildcard probe refuses a listener on any single IPv4
-    interface, and the IPv6 probe sees the `[::1]` listener an IPv4 probe cannot — role:all
-    binds every agent-facing plane on the IPv6 loopback too, so a port that passes here cannot
-    pass preflight and then crash uvicorn on an address-specific conflict. Reuses _bindable,
-    keeping the SO_REUSEADDR/TIME_WAIT semantics (and "IPv6 disabled" reads as free, not
-    taken). `taken` holds ports already promised to other planes in the same resolution round.
+    `host` is the address the server will bind, or the WHOLE list of addresses it will bind
+    (`_bind_hosts` of the role's spec) — the scan probes exactly that set, plus the IPv4
+    wildcard for any specific IPv4 interface in it (see _probe_addresses). Handing the real
+    listener set in, rather than a hand-maintained guess of it, is what keeps this from
+    drifting behind `_bind_hosts`/`bind_specs` again. Reuses _bindable, keeping the
+    SO_REUSEADDR/TIME_WAIT semantics (and "IPv6 disabled" reads as free, not taken). `taken`
+    holds ports already promised to other planes in the same resolution round.
     """
+    addresses = _probe_addresses(host)
     for candidate in range(start, min(start + attempts, _MAX_PORT + 1)):
         if candidate in taken:
             continue
-        if (
-            _bindable(host, candidate)
-            and (host == "0.0.0.0" or _bindable("0.0.0.0", candidate))
-            and (host == IPV6_LOOPBACK or _bindable(IPV6_LOOPBACK, candidate))
-        ):
+        if all(_bindable(address, candidate) for address in addresses):
             return candidate
     raise PortScanError(label, start, attempts)
 
 
-def resolve_ports(host: str, wanted: dict[str, int]) -> dict[str, int]:
-    """Resolve each plane's requested port to the first free one at-or-above it.
+def resolve_ports(host: str | Sequence[str], wanted: dict[str, int]) -> dict[str, int]:
+    """Resolve each plane's requested port to the first free one at-or-above it, on the
+    address (or the full listener set) the planes will bind.
 
     Planes resolve in dict order; earlier choices feed into `taken` so two planes
     contending for the same base port never resolve to the same one. Raises

--- a/src/xorcise/core/cli/_preflight.py
+++ b/src/xorcise/core/cli/_preflight.py
@@ -6,6 +6,8 @@ actionable conflict message. Used by `up` (before spawning) and `serve` (before 
 
 from __future__ import annotations
 
+import errno
+import os
 import socket
 from collections.abc import Set as AbstractSet
 
@@ -15,6 +17,51 @@ _PLANE = {3001: "rest", 4318: "otlp", 8800: "runner", 8080: "headscale"}
 # How far past the requested port the auto-increment scan walks before giving up.
 _SCAN_ATTEMPTS = 50
 _MAX_PORT = 65535
+
+# The IPv6 loopback every agent-facing spec also listens on (role_all + _bind_hosts). A probe on
+# the IPv4 side alone cannot see a squatter here, which is how a `[::1]:3001` listener used to
+# pass preflight and then crash uvicorn from inside Server.startup() with a bare sys.exit(1).
+IPV6_LOOPBACK = "::1"
+
+# bind() errors that mean "this address does not exist here" rather than "someone holds it":
+# IPv6 disabled on the host, or a configured host that is not a local interface.
+_ADDRESS_UNAVAILABLE = frozenset(
+    e for e in (errno.EADDRNOTAVAIL, errno.EAFNOSUPPORT, getattr(errno, "EPFNOSUPPORT", None)) if e
+)
+
+
+def address_family(host: str) -> int:
+    """AF_INET6 for a literal IPv6 address, AF_INET otherwise."""
+    return socket.AF_INET6 if ":" in host else socket.AF_INET
+
+
+def address_unavailable(exc: OSError) -> bool:
+    """Whether a failed bind means the ADDRESS is not usable on this host at all (as opposed to
+    the port being held by someone). Such an address cannot be "in use"."""
+    return exc.errno in _ADDRESS_UNAVAILABLE
+
+
+def bind_listener(host: str, port: int) -> socket.socket:
+    """Bind (not yet listening) `host:port` exactly the way asyncio's `create_server(host=…)`
+    would, and hand the socket back for the server to adopt. Raises OSError on failure.
+
+    Binding here, once, is the preflight: the same socket is then passed to uvicorn, so there is
+    no gap in which another process can take the port between the check and the listen. Options
+    mirror CPython's base_events.create_server — SO_REUSEADDR on POSIX (so a port left in
+    TIME_WAIT by the previous server rebinds immediately) and IPV6_V6ONLY on an IPv6 socket (so
+    the IPv6 loopback listener never shadows or collides with the IPv4 one). asyncio calls
+    listen() itself when it adopts the socket."""
+    sock = socket.socket(address_family(host), socket.SOCK_STREAM)
+    try:
+        if os.name == "posix":
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if sock.family == socket.AF_INET6 and hasattr(socket, "IPPROTO_IPV6"):
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        sock.bind((host, port))
+    except OSError:
+        sock.close()
+        raise
+    return sock
 
 
 class PortScanError(RuntimeError):
@@ -31,20 +78,21 @@ class PortScanError(RuntimeError):
 
 
 def _bindable(host: str, port: int) -> bool:
-    """True if we can bind host:port right now.
+    """True if nobody else holds host:port right now.
 
-    Sets SO_REUSEADDR so the probe matches how uvicorn actually binds: a port left in
-    TIME_WAIT after `xorcise down` (the server's just-closed connections) reads as free,
-    while a port with a live listener still fails to bind and reads as in use. Without
-    this, `up` right after `down` is falsely blocked until TIME_WAIT expires (~30-60s).
+    Probes with the exact socket the server will bind (bind_listener), for either address
+    family: SO_REUSEADDR so a port left in TIME_WAIT after `xorcise down` (the server's
+    just-closed connections) reads as free while a live listener still reads as in use —
+    without it, `up` right after `down` was falsely blocked until TIME_WAIT expired (~30-60 s).
+    An address this host cannot bind AT ALL (IPv6 disabled, a non-local host) is not "in use"
+    either: nobody can be holding it, and reporting it as taken would make every port look busy.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            s.bind((host, port))
-            return True
-        except OSError:
-            return False
+    try:
+        sock = bind_listener(host, port)
+    except OSError as exc:
+        return address_unavailable(exc)
+    sock.close()
+    return True
 
 
 def ports_in_use(host: str, ports: list[int]) -> list[int]:
@@ -61,17 +109,22 @@ def find_free_port(
 ) -> int:
     """First free port at-or-above `start` (walks start, start+1, … for `attempts` probes).
 
-    A port only counts as free when BOTH `host` and the IPv4 wildcard ("0.0.0.0") are
-    bindable: role:all binds REST/OTLP on the wildcard, and a wildcard probe also refuses
-    a listener on any single interface — so a port that passes here cannot pass preflight
-    and then crash uvicorn on an interface-specific conflict. Reuses _bindable, keeping
-    the SO_REUSEADDR/TIME_WAIT semantics. `taken` holds ports already promised to other
-    planes in the same resolution round.
+    A port only counts as free when `host`, the IPv4 wildcard ("0.0.0.0") AND the IPv6
+    loopback ("::1") are all bindable: a wildcard probe refuses a listener on any single IPv4
+    interface, and the IPv6 probe sees the `[::1]` listener an IPv4 probe cannot — role:all
+    binds every agent-facing plane on the IPv6 loopback too, so a port that passes here cannot
+    pass preflight and then crash uvicorn on an address-specific conflict. Reuses _bindable,
+    keeping the SO_REUSEADDR/TIME_WAIT semantics (and "IPv6 disabled" reads as free, not
+    taken). `taken` holds ports already promised to other planes in the same resolution round.
     """
     for candidate in range(start, min(start + attempts, _MAX_PORT + 1)):
         if candidate in taken:
             continue
-        if _bindable(host, candidate) and (host == "0.0.0.0" or _bindable("0.0.0.0", candidate)):
+        if (
+            _bindable(host, candidate)
+            and (host == "0.0.0.0" or _bindable("0.0.0.0", candidate))
+            and (host == IPV6_LOOPBACK or _bindable(IPV6_LOOPBACK, candidate))
+        ):
             return candidate
     raise PortScanError(label, start, attempts)
 

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -280,6 +280,20 @@ def _apply_runtime_env(role: str, *, stub: bool, ports: dict[str, int] | None = 
     get_settings.cache_clear()
 
 
+def _role_bind_hosts(role: str, configured_host: str) -> list[str]:
+    """The addresses the role's planes will listen on — the SAME set `serve` binds, from the
+    same function role_all builds it with — so port resolution probes what will be bound and
+    nothing else. role:all on a local topology binds the agent-facing loopbacks (IPv4 + IPv6;
+    the docker bridge gateway it adds on Linux is a specific IPv4 interface the wildcard probe
+    covers, so no docker call is needed here); every other role binds the configured host, so a
+    `[::1]:8800` listener never relocates `serve --role runner`."""
+    from xorcise.core.roles.boot import role_all
+
+    if role == "all" and get_settings().deployment_topology == "local":
+        return _bind_hosts(role_all.agent_facing_loopbacks(configured_host))
+    return _bind_hosts(configured_host)
+
+
 def _resolve_role_ports(role: str, overrides: dict[str, int | None]) -> dict[str, int]:
     """Auto-increment each of the role's planes to a free port, with a notice per move.
 
@@ -292,7 +306,7 @@ def _resolve_role_ports(role: str, overrides: dict[str, int | None]) -> dict[str
         # isinstance guards direct (non-CLI) calls, where typer defaults are OptionInfo.
         wanted[plane] = override if isinstance(override, int) else getattr(s, f"{plane}_port")
     try:
-        resolved = resolve_ports(s.host, wanted)
+        resolved = resolve_ports(_role_bind_hosts(role, s.host), wanted)
     except PortScanError as exc:
         err_console.print(f"[err]{exc}[/err]")
         raise typer.Exit(1) from None

--- a/src/xorcise/core/cli/commands/serve.py
+++ b/src/xorcise/core/cli/commands/serve.py
@@ -124,12 +124,13 @@ class BindConflict(Exception):
 def bind_specs(specs: list[AppSpec], default_host: str) -> list[BoundSpec]:
     """Bind every spec on every address `_bind_hosts` resolves for it, BEFORE the event loop.
 
-    Binding is the preflight: the same sockets are handed to uvicorn, so nothing can take a
-    port between the check and the listen, and a conflict surfaces here as a per-address
-    OSError we report cleanly — not from inside uvicorn's Server.startup(), which calls
-    sys.exit(1) and escaped serve()'s handling as a raw traceback. Every address is probed in
-    its own family, so a squatter on `[::1]:3001` is found the same as one on the IPv4 loopback
-    (the IPv4-only probe used to pass it).
+    Binding is the preflight: `bind_listener` binds AND listens, so from the moment it returns
+    the address is held — a concurrent `serve` cannot slip in between the check and the listen
+    (it could when the listen was left to uvicorn: SO_REUSEADDR lets two non-listening sockets
+    share an address) — and a conflict surfaces here as a per-address OSError we report cleanly,
+    not from inside uvicorn's Server.startup() after the app's startup hooks have already run.
+    Every address is probed in its own family, so a squatter on `[::1]:3001` is found the same
+    as one on the IPv4 loopback (the IPv4-only probe used to pass it).
 
     The IPv6 loopback companion is the one address allowed to be missing: on a host with IPv6
     disabled it does not exist, which is not a conflict — the IPv4 listeners still serve, and
@@ -173,36 +174,51 @@ def bind_specs(specs: list[AppSpec], default_host: str) -> list[BoundSpec]:
     return bound
 
 
+def listener_lines(bound: list[BoundSpec]) -> list[str]:
+    """One line per app naming every address it listens on — the record uvicorn no longer
+    writes for us (it logs "Uvicorn running on …" only when IT did the binding), and the one
+    `up` points the operator at (`see serve.log`) when a boot fails."""
+    lines = []
+    for b in bound:
+        addrs = ", ".join(
+            f"[{h}]:{b.spec.port}" if ":" in h else f"{h}:{b.spec.port}" for h in b.hosts
+        )
+        lines.append(f"listening on {addrs}")
+    return lines
+
+
 async def serve_bound(bound: list[BoundSpec]) -> list[BaseException]:
-    """Run one uvicorn.Server per bound app until the first exits; return the failures."""
+    """Run one uvicorn.Server per bound app until the first exits; return the failures.
+
+    A failure is an exception that escaped a Server OR a Server that never started: when an
+    app's lifespan startup fails, uvicorn logs it, skips the main loop and returns normally
+    (`Server.serve()` → None, `started` False), so without the second check `serve` would exit
+    0 having served nothing — and `up` would report only "did not become healthy"."""
     import uvicorn
 
     servers = [
-        (
-            uvicorn.Server(
-                uvicorn.Config(
-                    b.spec.app,
-                    # Only labels the "Uvicorn running on" line — the listeners are the sockets
-                    # (bind_specs guarantees at least one).
-                    host=b.hosts[0],
-                    port=b.spec.port,
-                    log_level=b.spec.log_level,
-                )
-            ),
-            b.sockets,
-        )
+        # Config's host/port are inert on this path — the listeners are the sockets handed to
+        # serve(); uvicorn does not even log "running on" for them (see listener_lines).
+        (uvicorn.Server(uvicorn.Config(b.spec.app, log_level=b.spec.log_level)), b)
         for b in bound
     ]
-    tasks = [asyncio.create_task(server.serve(sockets=socks)) for server, socks in servers]
+    tasks = [asyncio.create_task(server.serve(sockets=b.sockets)) for server, b in servers]
     await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     for server, _ in servers:
         server.should_exit = True
     results = await asyncio.gather(*tasks, return_exceptions=True)
-    return [
-        r
-        for r in results
-        if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
-    ]
+    failures: list[BaseException] = []
+    for (server, b), result in zip(servers, results, strict=True):
+        if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
+            failures.append(result)
+        elif not server.started:
+            failures.append(
+                RuntimeError(
+                    f"the app on port {b.spec.port} never started — its startup failed "
+                    "(see the log above)"
+                )
+            )
+    return failures
 
 
 @app.command(rich_help_panel="Advanced")
@@ -267,6 +283,8 @@ def serve(
         raise typer.Exit(1) from None
 
     console.print(lifecycle._serve_banner(role_name, specs))
+    for line in listener_lines(bound):
+        err_console.print(f"[dim]{line}[/dim]", highlight=False)  # stderr: lands in serve.log
     try:
         failures = asyncio.run(serve_bound(bound))
     except KeyboardInterrupt:

--- a/src/xorcise/core/cli/commands/serve.py
+++ b/src/xorcise/core/cli/commands/serve.py
@@ -9,15 +9,24 @@ namespace, so tests patching ``lifecycle.*`` intercept serve unchanged.
 from __future__ import annotations
 
 import asyncio
+import errno
+import socket
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 import typer
 
-from xorcise.core.cli._preflight import conflict_message, ports_in_use
+from xorcise.core.cli._preflight import (
+    IPV6_LOOPBACK,
+    address_unavailable,
+    bind_listener,
+    conflict_message,
+)
 from xorcise.core.cli._shared import app, console, err_console
 from xorcise.core.cli.commands import lifecycle
 from xorcise.core.home import init_home, scaffold_config, xorcise_home
 from xorcise.core.roles.activate import activate
+from xorcise.core.roles.boot import AppSpec
 
 
 class Role(StrEnum):
@@ -80,6 +89,122 @@ def _warn_experimental_role(role: str) -> None:
     err_console.print("[dim]  For a working install use 'xorcise up' (role 'all').[/dim]")
 
 
+@dataclass
+class BoundSpec:
+    """One app, already bound on every address it must serve: ONE uvicorn.Server, N sockets.
+
+    The previous shape — one uvicorn.Server per (app, address), all sharing the same app
+    object — ran the ASGI lifespan once per SERVER, so every `@app.on_event("startup")` hook
+    fired once per bind address: on Linux role:all resolves three agent-facing addresses, so
+    the REST app got three reconciles, three budget watchdogs and three readiness gates
+    scanning the same runs (two of them closing out the same failed run milliseconds apart,
+    the loser dying on a 409), and shutdown stopped only the last one assigned. uvicorn runs
+    the lifespan once per Server and opens one listener per socket it is handed
+    (`Server.serve(sockets=…)` — the path gunicorn workers use), so one Server per app with a
+    socket per address is the arrangement that matches what the hooks assume.
+    """
+
+    spec: AppSpec
+    hosts: list[str] = field(default_factory=list)
+    sockets: list[socket.socket] = field(default_factory=list)
+
+    def close(self) -> None:
+        for sock in self.sockets:
+            sock.close()
+
+
+class BindConflict(Exception):
+    """A port `serve` needs is held by another process; `taken` maps host → ports."""
+
+    def __init__(self, taken: dict[str, list[int]]) -> None:
+        self.taken = taken
+        super().__init__(", ".join(f"{h}:{p}" for h, ports in taken.items() for p in ports))
+
+
+def bind_specs(specs: list[AppSpec], default_host: str) -> list[BoundSpec]:
+    """Bind every spec on every address `_bind_hosts` resolves for it, BEFORE the event loop.
+
+    Binding is the preflight: the same sockets are handed to uvicorn, so nothing can take a
+    port between the check and the listen, and a conflict surfaces here as a per-address
+    OSError we report cleanly — not from inside uvicorn's Server.startup(), which calls
+    sys.exit(1) and escaped serve()'s handling as a raw traceback. Every address is probed in
+    its own family, so a squatter on `[::1]:3001` is found the same as one on the IPv4 loopback
+    (the IPv4-only probe used to pass it).
+
+    The IPv6 loopback companion is the one address allowed to be missing: on a host with IPv6
+    disabled it does not exist, which is not a conflict — the IPv4 listeners still serve, and
+    one warning says so. Any other unbindable address is a configuration error and is fatal.
+    On a conflict every socket bound so far is closed before BindConflict is raised.
+    """
+    bound: list[BoundSpec] = []
+    taken: dict[str, list[int]] = {}
+    for spec in specs:
+        entry = BoundSpec(spec)
+        bound.append(entry)
+        for host in lifecycle._bind_hosts(spec.host or default_host):
+            try:
+                sock = bind_listener(host, spec.port)
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    taken.setdefault(host, []).append(spec.port)
+                    continue
+                if host == IPV6_LOOPBACK and address_unavailable(exc):
+                    err_console.print(
+                        f"[warn]warning[/warn]: IPv6 loopback is not available on this host — "
+                        f"port {spec.port} will listen on IPv4 only",
+                        highlight=False,
+                    )
+                    continue
+                for b in bound:
+                    b.close()
+                raise
+            entry.hosts.append(host)
+            entry.sockets.append(sock)
+        if not entry.sockets and not taken:
+            # Every address was skipped (only the IPv6 loopback was configured and it does not
+            # exist here): a Server with no listener would boot "healthy" and answer nothing.
+            for b in bound:
+                b.close()
+            raise OSError(errno.EADDRNOTAVAIL, f"no bindable address for port {spec.port}")
+    if taken:
+        for b in bound:
+            b.close()
+        raise BindConflict(taken)
+    return bound
+
+
+async def serve_bound(bound: list[BoundSpec]) -> list[BaseException]:
+    """Run one uvicorn.Server per bound app until the first exits; return the failures."""
+    import uvicorn
+
+    servers = [
+        (
+            uvicorn.Server(
+                uvicorn.Config(
+                    b.spec.app,
+                    # Only labels the "Uvicorn running on" line — the listeners are the sockets
+                    # (bind_specs guarantees at least one).
+                    host=b.hosts[0],
+                    port=b.spec.port,
+                    log_level=b.spec.log_level,
+                )
+            ),
+            b.sockets,
+        )
+        for b in bound
+    ]
+    tasks = [asyncio.create_task(server.serve(sockets=socks)) for server, socks in servers]
+    await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for server, _ in servers:
+        server.should_exit = True
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return [
+        r
+        for r in results
+        if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
+    ]
+
+
 @app.command(rich_help_panel="Advanced")
 def serve(
     role: Role = _ROLE_OPTION,
@@ -108,8 +233,6 @@ def serve(
     Note: sibling commands (status/ui) discover relocated ports only for servers
     started via `up`.
     """
-    import uvicorn
-
     from xorcise.core.config import get_settings
 
     # isinstance guards direct (non-CLI) calls that pass a plain role string.
@@ -130,34 +253,28 @@ def serve(
     lifecycle._apply_runtime_env(role_name, stub=stub, ports=resolved)
     host = get_settings().host
     specs = activate(role_name)
-    taken = ports_in_use(host, [s.port for s in specs])
-    if taken:
-        err_console.print(f"[err]{conflict_message(host, taken)}[/err]")
-        raise typer.Exit(1)
-
-    async def _run() -> list[BaseException]:
-        servers = [
-            uvicorn.Server(uvicorn.Config(s.app, host=h, port=s.port, log_level=s.log_level))
-            for s in specs
-            for h in lifecycle._bind_hosts(s.host or host)
-        ]
-        tasks = [asyncio.create_task(s.serve()) for s in servers]
-        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for s in servers:
-            s.should_exit = True
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        return [
-            r
-            for r in results
-            if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
-        ]
+    # Bind first, on every address each app must serve. The bound sockets ARE the preflight
+    # (see bind_specs) and are what uvicorn listens on — one Server per app, so the startup
+    # hooks run once per app rather than once per address.
+    try:
+        bound = bind_specs(specs, host)
+    except BindConflict as exc:
+        for taken_host, ports in exc.taken.items():
+            err_console.print(f"[err]{conflict_message(taken_host, ports)}[/err]")
+        raise typer.Exit(1) from None
+    except OSError as exc:
+        err_console.print(f"[err]error[/err]: cannot bind {exc.strerror or exc}", highlight=False)
+        raise typer.Exit(1) from None
 
     console.print(lifecycle._serve_banner(role_name, specs))
     try:
-        failures = asyncio.run(_run())
+        failures = asyncio.run(serve_bound(bound))
     except KeyboardInterrupt:
         console.print("shutting down")
         return
+    finally:
+        for b in bound:
+            b.close()  # uvicorn closes what it adopted; this covers a bind that never got there
     if failures:
         # A crashed server plane must not exit 0 — surface the first failure.
         err_console.print(f"[err]error[/err]: server exited — {failures[0]}")

--- a/src/xorcise/core/roles/boot/role_all.py
+++ b/src/xorcise/core/roles/boot/role_all.py
@@ -60,7 +60,10 @@ def build_rest_app() -> FastAPI:
     # on 409 "removal of container … already in progress" — and, since each hook assigns its
     # instance to a nonlocal, shutdown stopped only the last one. `serve` now runs one Server per
     # app (sockets per address), which fires each hook once; the guards stay because they hold
-    # under ANY ASGI host arrangement, which this module cannot see.
+    # under ANY ASGI host arrangement, which this module cannot see. Each shutdown hook RELEASES
+    # its guard, so a lifespan that restarts on the same app object (two `TestClient(app)`
+    # blocks; a host that cycles the lifespan) comes back with live singletons, not with a
+    # stopped watchdog and no gate silently left behind by the previous cycle.
     _watchdog: BudgetWatchdog | None = None
     _readiness: ReadinessWatchdog | None = None
     # Separate from `_readiness` because the gate cannot be assigned until after an await; see
@@ -105,7 +108,9 @@ def build_rest_app() -> FastAPI:
         import asyncio
         import contextlib
 
+        nonlocal _reconcile_task
         task = _reconcile_task
+        _reconcile_task = None  # release the guard for a lifespan restart
         if isinstance(task, asyncio.Task) and not task.done():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -130,8 +135,10 @@ def build_rest_app() -> FastAPI:
 
     @app.on_event("shutdown")
     async def _stop_watchdog() -> None:
-        if _watchdog is not None:
-            await _watchdog.stop()
+        nonlocal _watchdog
+        watchdog, _watchdog = _watchdog, None  # release the guard for a lifespan restart
+        if watchdog is not None:
+            await watchdog.stop()
 
     @app.on_event("startup")
     async def _start_readiness_gate() -> None:
@@ -178,10 +185,18 @@ def build_rest_app() -> FastAPI:
 
     @app.on_event("shutdown")
     async def _stop_readiness_gate() -> None:
-        if _readiness is not None:
-            await _readiness.stop()
+        nonlocal _readiness, _readiness_claimed
+        gate, _readiness = _readiness, None
+        _readiness_claimed = False  # release the claim for a lifespan restart
+        if gate is not None:
+            await gate.stop()
 
     _prewarmed = False
+
+    @app.on_event("shutdown")
+    async def _reset_prewarm() -> None:
+        nonlocal _prewarmed
+        _prewarmed = False  # a restarted lifespan may warm again
 
     @app.on_event("startup")
     async def _prewarm_nested_support() -> None:
@@ -200,7 +215,7 @@ def build_rest_app() -> FastAPI:
         # warm-up costs: a cold memo the first run recomputes.
         nonlocal _prewarmed
         if _prewarmed:
-            return  # one uvicorn.Server per bind address shares this app — warm once
+            return  # several Servers may share this app — warm once per lifespan
         _prewarmed = True
         import logging
         import threading
@@ -283,14 +298,26 @@ def _agent_facing_bind_hosts(configured_host: str) -> tuple[str, ...]:
     explicit opt-back-in. Only the Linux gateway-unknown case falls back wide: a silent
     loopback-only bind there would break every run instead of locking anything down.
     """
-    if configured_host == "0.0.0.0":
-        return ("0.0.0.0",)
-    hosts: tuple[str, ...] = (LOOPBACK, "::1")
+    hosts = agent_facing_loopbacks(configured_host)
+    if hosts == ("0.0.0.0",):
+        return hosts
     if _system() == "Linux":
         gateway = _docker_bridge_gateway()
         if not (gateway and _locally_bindable(gateway)):
             return ("0.0.0.0",)
         hosts = (*hosts, gateway)
+    return hosts
+
+
+def agent_facing_loopbacks(configured_host: str) -> tuple[str, ...]:
+    """The addresses every local agent-facing spec binds BEFORE the docker bridge gateway is
+    considered: the IPv4 + IPv6 loopbacks, plus a configured non-loopback host; the wildcard
+    stays an explicit opt-in. Pure and docker-free, so port resolution (cli) can probe the same
+    set `serve` will bind without a subprocess — the gateway it leaves out is a specific IPv4
+    interface, which resolution's wildcard probe already refuses a squatter on."""
+    if configured_host == "0.0.0.0":
+        return ("0.0.0.0",)
+    hosts: tuple[str, ...] = (LOOPBACK, "::1")
     if configured_host not in hosts and configured_host not in LOOPBACK_HOSTS:
         hosts = (*hosts, configured_host)
     return hosts

--- a/src/xorcise/core/roles/boot/role_all.py
+++ b/src/xorcise/core/roles/boot/role_all.py
@@ -51,8 +51,21 @@ def build_rest_app() -> FastAPI:
     app.include_router(harnesses.router, prefix="/api")
     mount_ui(app)
 
+    # Process-wide background singletons. Every startup hook below is GUARDED, because the
+    # ASGI lifespan runs once per uvicorn.Server, and nothing in this module controls how many
+    # Servers `serve` builds around this one app object. It used to build one per bind address
+    # (three on Linux: loopback, ::1, the docker bridge gateway), so each hook fired three times:
+    # three reconciles, three budget watchdogs, three readiness gates scanning the same runs —
+    # two of which closed out the same failed run milliseconds apart, the loser's teardown dying
+    # on 409 "removal of container … already in progress" — and, since each hook assigns its
+    # instance to a nonlocal, shutdown stopped only the last one. `serve` now runs one Server per
+    # app (sockets per address), which fires each hook once; the guards stay because they hold
+    # under ANY ASGI host arrangement, which this module cannot see.
     _watchdog: BudgetWatchdog | None = None
     _readiness: ReadinessWatchdog | None = None
+    # Separate from `_readiness` because the gate cannot be assigned until after an await; see
+    # the claim in _start_readiness_gate.
+    _readiness_claimed = False
 
     _reconcile_task: object | None = None
 
@@ -65,6 +78,10 @@ def build_rest_app() -> FastAPI:
         import logging
 
         from xorcise.core.rest.reconcile import reconcile_all_on_startup
+
+        nonlocal _reconcile_task
+        if _reconcile_task is not None:
+            return  # a second listener on the same app — one reconcile per process
 
         async def _run() -> None:
             try:
@@ -79,7 +96,6 @@ def build_rest_app() -> FastAPI:
                 log.warning("startup reconcile failed: %s", exc)
                 log.debug("startup reconcile failure detail", exc_info=True)
 
-        nonlocal _reconcile_task
         _reconcile_task = asyncio.create_task(_run())
 
     @app.on_event("shutdown")
@@ -98,6 +114,8 @@ def build_rest_app() -> FastAPI:
     @app.on_event("startup")
     async def _start_watchdog() -> None:
         nonlocal _watchdog
+        if _watchdog is not None:
+            return  # a second listener on the same app — one watchdog per process
         from xorcise.core import runs
         from xorcise.core.rest.budget_watchdog import BudgetWatchdog
         from xorcise.core.rest.run_terminate import terminate_run
@@ -121,7 +139,16 @@ def build_rest_app() -> FastAPI:
         # for the inner mission stack, so without this such a run stays non-terminal forever with
         # a live agent working a target that never existed. Best-effort, like the boot reconcile —
         # it is a safety net, so a plane we cannot reach disables it rather than failing boot.
-        nonlocal _readiness
+        nonlocal _readiness, _readiness_claimed
+        # Claim the slot SYNCHRONOUSLY, before the first await. Guarding on `_readiness is not
+        # None` alone is a check-then-act race: this hook awaits build_run_create_deps (Docker +
+        # Headscale probes) before it can assign, and a concurrently-starting second listener
+        # reaches the same check while that await is still pending — so both proceed and two
+        # gates end up scanning the same runs. asyncio is single-threaded, so a flag set with no
+        # await between check and set is atomic against the other startup task.
+        if _readiness_claimed:
+            return  # another listener on the same app already owns the gate
+        _readiness_claimed = True
         import asyncio
         import logging
 

--- a/tests/unit/test_boot_singletons_once.py
+++ b/tests/unit/test_boot_singletons_once.py
@@ -91,3 +91,58 @@ def test_extra_listeners_still_create_only_one_of_each(monkeypatch, migrated_hom
         f"startup ran {listeners}x (one uvicorn.Server per bind host, same app) and built "
         f"duplicate background singletons: {counts}"
     )
+
+
+def test_a_lifespan_restart_builds_fresh_singletons(monkeypatch, migrated_home):
+    """Review of #81: the shutdown hooks left every guard claimed, so a startup → shutdown →
+    startup on the same app object (two TestClient blocks, a host cycling the lifespan) came back
+    with a STOPPED watchdog, no readiness gate and no reconcile — silently. Each shutdown hook now
+    releases its guard."""
+    import asyncio
+
+    import xorcise.core.rest.budget_watchdog as bw
+    import xorcise.core.rest.run_readiness as rr
+    from xorcise.core.roles.boot import role_all
+
+    counts = {"budget": 0, "readiness": 0, "reconcile": 0}
+
+    class _Budget(bw.BudgetWatchdog):
+        def __init__(self, *a, **k):
+            counts["budget"] += 1
+            super().__init__(*a, **k)
+
+        def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
+
+    class _Readiness(rr.ReadinessWatchdog):
+        def __init__(self, *a, **k):
+            counts["readiness"] += 1
+            super().__init__(*a, **k)
+
+        def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(bw, "BudgetWatchdog", _Budget)
+    monkeypatch.setattr(rr, "ReadinessWatchdog", _Readiness)
+    monkeypatch.setattr(
+        "xorcise.core.rest.reconcile.reconcile_all_on_startup",
+        lambda: counts.__setitem__("reconcile", counts["reconcile"] + 1),
+    )
+    app = role_all.build_rest_app()
+
+    async def cycle() -> None:
+        for h in app.router.on_startup:
+            await h()
+        await asyncio.sleep(0.2)
+        for h in app.router.on_shutdown:
+            await h()
+
+    asyncio.run(cycle())
+    asyncio.run(cycle())
+    assert counts == {"budget": 2, "readiness": 2, "reconcile": 2}

--- a/tests/unit/test_boot_singletons_once.py
+++ b/tests/unit/test_boot_singletons_once.py
@@ -1,0 +1,93 @@
+"""The app's startup singletons must be created ONCE per app, however many listeners share it.
+
+`serve` used to build one uvicorn.Server per BIND HOST and pass them all the SAME app object:
+
+    servers = [uvicorn.Server(uvicorn.Config(s.app, host=h, ...))
+               for s in specs for h in _bind_hosts(s.host or host)]
+
+role_all's agent-facing specs bind ('127.0.0.1', '::1') — plus the docker bridge gateway on
+Linux — so the REST app got two or three servers and every `@app.on_event("startup")` hook fired
+that many times. Observed live: two ReadinessWatchdog instances scanning the same runs, both
+closing out the same run 3.6 ms apart, the loser failing its teardown with 409 "removal of
+container ... is already in progress". Because each hook assigns its instance to a `nonlocal`,
+the last one overwrote the others — so shutdown stopped only one and the rest kept ticking until
+the process exited.
+
+`serve` now runs one Server per app (see commands/serve.py), which fires each hook once. The
+guards pinned here stay regardless: they hold under ANY ASGI host arrangement, which role_all
+cannot see.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _count_startup_constructions(monkeypatch, migrated_home, fire: int) -> dict[str, int]:
+    """Build the role_all app, fire its startup hooks `fire` times, count singletons made."""
+    import xorcise.core.rest.budget_watchdog as bw
+    import xorcise.core.rest.run_readiness as rr
+    from xorcise.core.roles.boot import role_all
+
+    counts = {"budget": 0, "readiness": 0, "reconcile": 0}
+
+    class _CountingBudget(bw.BudgetWatchdog):
+        def __init__(self, *a, **k):
+            counts["budget"] += 1
+            super().__init__(*a, **k)
+
+        def start(self) -> None:  # never schedule real background work in a unit test
+            pass
+
+    class _CountingReadiness(rr.ReadinessWatchdog):
+        def __init__(self, *a, **k):
+            counts["readiness"] += 1
+            super().__init__(*a, **k)
+
+        def start(self) -> None:
+            pass
+
+    def _counting_reconcile() -> None:
+        counts["reconcile"] += 1
+
+    monkeypatch.setattr(bw, "BudgetWatchdog", _CountingBudget)
+    monkeypatch.setattr(rr, "ReadinessWatchdog", _CountingReadiness)
+    monkeypatch.setattr("xorcise.core.rest.reconcile.reconcile_all_on_startup", _counting_reconcile)
+
+    app = role_all.build_rest_app()
+    handlers = app.router.on_startup
+    import asyncio
+
+    async def _fire_all() -> None:
+        # CONCURRENTLY, because that is what uvicorn does when several Servers share an app:
+        # each starts as its own asyncio task, so their startup hooks interleave at every await
+        # point. Firing them sequentially hides check-then-act races — a guard that reads a
+        # nonlocal, awaits, then assigns passes a sequential test and still double-starts here.
+        await asyncio.gather(*(h() for _ in range(fire) for h in handlers))
+        # Let the reconcile task (create_task → to_thread inside the hook) actually run.
+        await asyncio.sleep(0.2)
+
+    asyncio.run(_fire_all())
+    return counts
+
+
+def test_one_listener_creates_one_of_each(monkeypatch, migrated_home):
+    counts = _count_startup_constructions(monkeypatch, migrated_home, fire=1)
+    assert counts == {"budget": 1, "readiness": 1, "reconcile": 1}
+
+
+@pytest.mark.parametrize("listeners", [2, 3])
+def test_extra_listeners_still_create_only_one_of_each(monkeypatch, migrated_home, listeners):
+    """The regression. Several listeners share one app, so startup fires several times (three
+    on Linux: loopback, ::1, docker bridge gateway).
+
+    Two ReadinessWatchdogs is not merely redundant: both scan the same runs and both act on the
+    same verdict, which is how one run gets closed out twice and one teardown loses a 409.
+    """
+    counts = _count_startup_constructions(monkeypatch, migrated_home, fire=listeners)
+    assert counts == {"budget": 1, "readiness": 1, "reconcile": 1}, (
+        f"startup ran {listeners}x (one uvicorn.Server per bind host, same app) and built "
+        f"duplicate background singletons: {counts}"
+    )

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import subprocess
 from collections.abc import Mapping
@@ -482,6 +483,11 @@ def test_up_fails_fast_when_no_free_port(_prereqs_ok, monkeypatch, tmp_path):
     assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
+def _bind_in_use(host, port):
+    """A `bind_listener` whose address is always held by someone else."""
+    raise OSError(errno.EADDRINUSE, "Address already in use")
+
+
 def test_serve_fails_fast_on_port_conflict(monkeypatch, tmp_path):
     from xorcise.core.cli.commands import serve as serve_mod
 
@@ -489,7 +495,8 @@ def test_serve_fails_fast_on_port_conflict(monkeypatch, tmp_path):
     monkeypatch.setenv("XORCISE_HOME", str(tmp_path))  # serve bootstraps home+db now
     monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: dict(wanted))
     monkeypatch.setattr(serve_mod, "activate", lambda role: [AppSpec(app=object(), port=REST_PORT)])
-    monkeypatch.setattr(serve_mod, "ports_in_use", lambda host, ports: [REST_PORT])
+    # Binding IS the preflight now: a listener already on the address raises EADDRINUSE.
+    monkeypatch.setattr(serve_mod, "bind_listener", _bind_in_use)
     result = runner.invoke(app, ["serve"])
     assert result.exit_code == 1
     assert str(REST_PORT) in result.output
@@ -781,24 +788,23 @@ def test_serve_preflight_uses_configured_host_and_ports(monkeypatch, tmp_path):
     from xorcise.core.config import get_settings
 
     get_settings.cache_clear()
-    seen = {}
+    seen: list[tuple[str, int]] = []
 
-    def fake_ports_in_use(host, ports):
-        seen["host"] = host
-        seen["ports"] = ports
-        return [4001]  # force the fast-fail path, no uvicorn
+    def fake_bind_listener(host, port):
+        seen.append((host, port))
+        raise OSError(errno.EADDRINUSE, "in use")  # force the fast-fail path, no uvicorn
 
     from xorcise.core.cli.commands import serve as serve_mod
 
     monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: dict(wanted))
-    monkeypatch.setattr(serve_mod, "ports_in_use", fake_ports_in_use)
+    monkeypatch.setattr(serve_mod, "bind_listener", fake_bind_listener)
     try:
         result = runner.invoke(app, ["serve"])
     finally:
         get_settings.cache_clear()
     assert result.exit_code == 1
-    assert seen["host"] == "0.0.0.0"
-    assert 4001 in seen["ports"]
+    assert seen[0][0] == "0.0.0.0"  # the configured host is what gets bound first
+    assert 4001 in {port for _h, port in seen}
 
 
 def test_scaffolded_config_documents_endpoint_knobs(monkeypatch, tmp_path):
@@ -1225,7 +1231,7 @@ def test_serve_port_flag_resolves_before_activate(monkeypatch, tmp_path):
 
     monkeypatch.setattr(serve_mod, "activate", fake_activate)
     # report everything busy so serve fast-fails before reaching uvicorn
-    monkeypatch.setattr(serve_mod, "ports_in_use", lambda host, ports: ports)
+    monkeypatch.setattr(serve_mod, "bind_listener", _bind_in_use)
     try:
         result = runner.invoke(app, ["serve", "--port", "4001"])
     finally:

--- a/tests/unit/test_cli_ux.py
+++ b/tests/unit/test_cli_ux.py
@@ -159,7 +159,12 @@ def test_serve_scaffolds_fresh_db_before_boot(monkeypatch, tmp_path):
     monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: dict(wanted))
     monkeypatch.setattr(serve_mod, "activate", lambda role: [AppSpec(app=object(), port=45501)])
     # Everything 'busy' forces the fast-fail exit AFTER the bootstrap ran — uvicorn never starts.
-    monkeypatch.setattr(serve_mod, "ports_in_use", lambda host, ports: ports)
+    import errno
+
+    def _in_use(host, port):
+        raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(serve_mod, "bind_listener", _in_use)
     result = runner.invoke(app, ["serve"])
     assert result.exit_code == 1  # the deliberate port-conflict exit
     assert "prepared the database" in result.output

--- a/tests/unit/test_lifecycle_bind_hosts.py
+++ b/tests/unit/test_lifecycle_bind_hosts.py
@@ -36,3 +36,35 @@ def test_tuple_with_wildcard_still_gains_companion_without_duplicates() -> None:
     # and a tuple already naming ::1 doesn't get it twice.
     assert _bind_hosts(("0.0.0.0",)) == ["0.0.0.0", "::1"]
     assert _bind_hosts(("0.0.0.0", "::1")) == ["0.0.0.0", "::1"]
+
+
+def test_role_bind_hosts_is_the_set_serve_binds(monkeypatch) -> None:
+    """Review of #81: port resolution probed a hand-maintained guess (`host`, `0.0.0.0`, then
+    `::1` for everyone) that had to be kept in sync with `_bind_hosts`/`bind_specs` by hand —
+    twice widened after a production miss. Resolution now probes the role's real listener set,
+    built by the same role_all function `serve` uses — without the docker call (the bridge
+    gateway is a specific IPv4 interface the wildcard probe already covers)."""
+    import subprocess
+
+    from xorcise.core.cli.commands import lifecycle
+    from xorcise.core.config import get_settings
+
+    monkeypatch.setenv("XORCISE_DEPLOYMENT_TOPOLOGY", "local")
+    get_settings.cache_clear()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("resolution shelled out"))
+    try:
+        # role:all binds the agent-facing loopbacks (IPv4 + IPv6) …
+        assert lifecycle._role_bind_hosts("all", "127.0.0.1") == ["127.0.0.1", "::1"]
+        # … plus a configured non-loopback host; the wildcard stays an explicit opt-in.
+        assert lifecycle._role_bind_hosts("all", "192.168.1.10") == [
+            "127.0.0.1",
+            "::1",
+            "192.168.1.10",
+        ]
+        assert lifecycle._role_bind_hosts("all", "0.0.0.0") == ["0.0.0.0", "::1"]
+        # every other role binds the configured host only: no ::1 probe, so an unrelated
+        # `[::1]:8800` listener cannot relocate `serve --role runner`.
+        assert lifecycle._role_bind_hosts("runner", "127.0.0.1") == ["127.0.0.1"]
+        assert lifecycle._role_bind_hosts("collector", "0.0.0.0") == ["0.0.0.0", "::1"]
+    finally:
+        get_settings.cache_clear()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -152,3 +152,63 @@ def test_resolve_ports_never_assigns_the_same_port_twice():
     assert resolved["rest"] == port
     assert resolved["otlp"] != port  # the second plane must not collide with the first
     assert len(set(resolved.values())) == 2
+
+
+def _ipv6_loopback_available() -> bool:
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _ipv6_loopback_available(), reason="no IPv6 loopback here")
+def test_find_free_port_sees_a_squatter_on_the_ipv6_loopback():
+    """Finding 1 of #43. The probe hardcoded AF_INET, so a `[::1]:PORT` listener with the IPv4
+    side free passed — and uvicorn then died on it from inside Server.startup(). role:all binds
+    the IPv6 loopback too, so the scan has to look there."""
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as taken:
+        taken.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        taken.bind(("::1", 0))
+        taken.listen()
+        port = taken.getsockname()[1]
+        assert ports_in_use("::1", [port]) == [port]  # the probe speaks IPv6 now
+        assert ports_in_use("127.0.0.1", [port]) == []  # and the IPv4 side really is free
+        assert find_free_port("127.0.0.1", port) > port  # so the scan must walk past it
+
+
+def test_an_unavailable_address_family_reads_as_free_not_taken(monkeypatch):
+    """IPv6 disabled on the host: `::1` cannot be bound by anyone, so it is not "in use" —
+    reporting it as taken would make EVERY port look busy and exhaust the scan."""
+    import errno
+
+    from xorcise.core.cli import _preflight
+
+    def _no_v6(host: str, port: int) -> socket.socket:
+        if ":" in host:
+            raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    monkeypatch.setattr(_preflight, "bind_listener", _no_v6)
+    assert ports_in_use("::1", [3001]) == []
+    port = _released_port()
+    assert find_free_port("127.0.0.1", port) == port
+
+
+def test_bind_listener_hands_back_a_bound_socket_of_the_right_family():
+    from xorcise.core.cli._preflight import bind_listener
+
+    port = _released_port()
+    sock = bind_listener("127.0.0.1", port)
+    try:
+        assert sock.family == socket.AF_INET
+        assert sock.getsockname() == ("127.0.0.1", port)
+        # It is the preflight AND the listener: once asyncio adopts it (listen), the address is
+        # held and a second bind of the same address fails — SO_REUSEADDR only shares an address
+        # between sockets none of which is listening.
+        sock.listen()
+        with pytest.raises(OSError):
+            bind_listener("127.0.0.1", port).close()
+    finally:
+        sock.close()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -175,7 +175,11 @@ def test_find_free_port_sees_a_squatter_on_the_ipv6_loopback():
         port = taken.getsockname()[1]
         assert ports_in_use("::1", [port]) == [port]  # the probe speaks IPv6 now
         assert ports_in_use("127.0.0.1", [port]) == []  # and the IPv4 side really is free
-        assert find_free_port("127.0.0.1", port) > port  # so the scan must walk past it
+        # A listener set that includes ::1 (role:all on a local topology) must walk past it…
+        assert find_free_port(("127.0.0.1", "::1"), port) > port
+        # …but a role whose spec never binds ::1 (runner/control/collector: the configured host
+        # only) must NOT be relocated by an unrelated IPv6 listener.
+        assert find_free_port("127.0.0.1", port, label="runner") == port
 
 
 def test_an_unavailable_address_family_reads_as_free_not_taken(monkeypatch):
@@ -204,10 +208,13 @@ def test_bind_listener_hands_back_a_bound_socket_of_the_right_family():
     try:
         assert sock.family == socket.AF_INET
         assert sock.getsockname() == ("127.0.0.1", port)
-        # It is the preflight AND the listener: once asyncio adopts it (listen), the address is
-        # held and a second bind of the same address fails — SO_REUSEADDR only shares an address
-        # between sockets none of which is listening.
-        sock.listen()
+        # It is the preflight AND the listener, and it LISTENS before returning: SO_REUSEADDR
+        # only shares an address between sockets none of which is listening, so a second bind
+        # — a concurrent `serve` — fails HERE, not later inside uvicorn after the app started.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as rival:
+            rival.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            with pytest.raises(OSError):
+                rival.bind(("127.0.0.1", port))
         with pytest.raises(OSError):
             bind_listener("127.0.0.1", port).close()
     finally:

--- a/tests/unit/test_serve_sockets.py
+++ b/tests/unit/test_serve_sockets.py
@@ -1,0 +1,154 @@
+"""`serve` binds every address up front and runs ONE uvicorn.Server per app.
+
+Two properties carry the weight. Each app gets exactly one Server (so its ASGI lifespan, and
+every startup/shutdown hook, runs once) with one pre-bound socket per address it must serve. And
+binding IS the preflight: a squatter on any of those addresses — including `[::1]`, which the
+old IPv4-only probe could not see — is reported as a clean conflict before any server starts,
+never as uvicorn's sys.exit(1) from inside Server.startup().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import pytest
+
+from xorcise.core.cli.commands import serve as serve_mod
+from xorcise.core.roles.boot import AppSpec
+
+pytestmark = pytest.mark.unit
+
+
+def _released_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _ipv6_loopback_available() -> bool:
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return True
+    except OSError:
+        return False
+
+
+needs_ipv6 = pytest.mark.skipif(not _ipv6_loopback_available(), reason="no IPv6 loopback here")
+
+
+async def _noop_app(scope: Any, receive: Any, send: Any) -> None:  # pragma: no cover - not run
+    pass
+
+
+@needs_ipv6
+def test_bind_specs_binds_one_socket_per_address_per_app() -> None:
+    p1, p2 = _released_port(), _released_port()
+    specs = [
+        AppSpec(_noop_app, p1, host=("127.0.0.1", "::1")),
+        AppSpec(_noop_app, p2, host=("127.0.0.1", "::1")),
+    ]
+    bound = serve_mod.bind_specs(specs, "127.0.0.1")
+    try:
+        assert [b.spec.port for b in bound] == [p1, p2]
+        for b in bound:
+            assert b.hosts == ["127.0.0.1", "::1"]
+            assert [s.family for s in b.sockets] == [socket.AF_INET, socket.AF_INET6]
+            assert [s.getsockname()[1] for s in b.sockets] == [b.spec.port, b.spec.port]
+    finally:
+        for b in bound:
+            b.close()
+
+
+@needs_ipv6
+def test_a_squatter_on_the_ipv6_loopback_is_a_clean_conflict() -> None:
+    """Finding 1 of #43: `_bindable` hardcoded AF_INET, so a listener on `[::1]:PORT` with
+    `127.0.0.1:PORT` free passed preflight, and uvicorn then hit the conflict inside
+    Server.startup() and called sys.exit(1) — a raw traceback, no remediation."""
+    port = _released_port()
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as squatter:
+        squatter.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        squatter.bind(("::1", port))
+        squatter.listen()
+        with pytest.raises(serve_mod.BindConflict) as exc:
+            serve_mod.bind_specs([AppSpec(_noop_app, port, host=("127.0.0.1", "::1"))], "127.0.0.1")
+        assert exc.value.taken == {"::1": [port]}
+    # Everything bound before the conflict was released: the IPv4 side is free again.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", port))
+
+
+def test_a_squatter_on_ipv4_is_reported_with_its_host() -> None:
+    port = _released_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as squatter:
+        squatter.bind(("127.0.0.1", port))
+        squatter.listen()
+        with pytest.raises(serve_mod.BindConflict) as exc:
+            serve_mod.bind_specs([AppSpec(_noop_app, port, host="127.0.0.1")], "127.0.0.1")
+        assert exc.value.taken == {"127.0.0.1": [port]}
+
+
+def test_missing_ipv6_loopback_is_a_warning_not_a_failure(monkeypatch, capsys) -> None:
+    """A host with IPv6 disabled has no `::1`; the IPv4 listeners must still serve."""
+    import errno
+
+    from xorcise.core.cli._preflight import bind_listener as real
+
+    port = _released_port()
+
+    def _no_v6(host: str, p: int) -> socket.socket:
+        if host == "::1":
+            raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+        return real(host, p)
+
+    monkeypatch.setattr(serve_mod, "bind_listener", _no_v6)
+    bound = serve_mod.bind_specs([AppSpec(_noop_app, port, host=("127.0.0.1", "::1"))], "127.0.0.1")
+    try:
+        assert bound[0].hosts == ["127.0.0.1"]
+        assert len(bound[0].sockets) == 1
+    finally:
+        bound[0].close()
+    assert "IPv4 only" in capsys.readouterr().err
+
+
+def test_serve_bound_runs_one_server_per_app_with_all_its_sockets(monkeypatch) -> None:
+    """The structural fix for #43: N sockets per app go to ONE Server (`serve(sockets=…)`), not
+    one Server per socket. uvicorn runs the lifespan once per Server, so the app's startup hooks
+    run once."""
+    import uvicorn
+
+    made: list[dict[str, Any]] = []
+
+    class _Config:
+        def __init__(self, app: Any, **kw: Any) -> None:
+            self.app = app
+            self.kw = kw
+
+    class _Server:
+        def __init__(self, config: _Config) -> None:
+            self.config = config
+            self.should_exit = False
+
+        async def serve(self, sockets: list[socket.socket] | None = None) -> None:
+            made.append({"app": self.config.app, "sockets": list(sockets or [])})
+
+    monkeypatch.setattr(uvicorn, "Config", _Config)
+    monkeypatch.setattr(uvicorn, "Server", _Server)
+
+    a_sockets = [socket.socket(), socket.socket()]
+    b_sockets = [socket.socket(), socket.socket(), socket.socket()]
+    bound = [
+        serve_mod.BoundSpec(AppSpec("app-a", 1), ["127.0.0.1", "::1"], a_sockets),
+        serve_mod.BoundSpec(AppSpec("app-b", 2), ["127.0.0.1", "::1", "172.17.0.1"], b_sockets),
+    ]
+    try:
+        failures = asyncio.run(serve_mod.serve_bound(bound))
+    finally:
+        for b in bound:
+            b.close()
+    assert failures == []
+    assert [m["app"] for m in made] == ["app-a", "app-b"]  # one Server per APP…
+    assert made[0]["sockets"] == a_sockets  # …carrying every one of its listeners
+    assert made[1]["sockets"] == b_sockets

--- a/tests/unit/test_serve_sockets.py
+++ b/tests/unit/test_serve_sockets.py
@@ -130,8 +130,10 @@ def test_serve_bound_runs_one_server_per_app_with_all_its_sockets(monkeypatch) -
         def __init__(self, config: _Config) -> None:
             self.config = config
             self.should_exit = False
+            self.started = False
 
         async def serve(self, sockets: list[socket.socket] | None = None) -> None:
+            self.started = True  # what uvicorn sets once startup() succeeded
             made.append({"app": self.config.app, "sockets": list(sockets or [])})
 
     monkeypatch.setattr(uvicorn, "Config", _Config)
@@ -152,3 +154,51 @@ def test_serve_bound_runs_one_server_per_app_with_all_its_sockets(monkeypatch) -
     assert [m["app"] for m in made] == ["app-a", "app-b"]  # one Server per APP…
     assert made[0]["sockets"] == a_sockets  # …carrying every one of its listeners
     assert made[1]["sockets"] == b_sockets
+
+
+def test_a_failed_lifespan_startup_is_reported_as_a_failure() -> None:
+    """Review of #81: uvicorn returns normally from serve() when the app's startup fails
+    (`started` stays False), so the exception filter alone found nothing and `serve` exited 0
+    having served nothing."""
+
+    async def failing_app(scope: Any, receive: Any, send: Any) -> None:
+        if scope["type"] == "lifespan":
+            await receive()
+            await send({"type": "lifespan.startup.failed", "message": "config error"})
+
+    port = _released_port()
+    bound = serve_mod.bind_specs([AppSpec(failing_app, port, host="127.0.0.1")], "127.0.0.1")
+    try:
+        failures = asyncio.run(serve_mod.serve_bound(bound))
+    finally:
+        for b in bound:
+            b.close()
+    assert len(failures) == 1
+    assert "never started" in str(failures[0]) and str(port) in str(failures[0])
+
+
+def test_bind_specs_holds_the_address_so_a_concurrent_binder_loses_immediately() -> None:
+    """Review of #81: bound-but-not-listening sockets share an address under SO_REUSEADDR, so a
+    concurrent `serve` could bind the same port and win the listen() race inside uvicorn. The
+    sockets bind_specs hands out are listening, so the rival fails at its own bind()."""
+    port = _released_port()
+    bound = serve_mod.bind_specs([AppSpec(_noop_app, port, host="127.0.0.1")], "127.0.0.1")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as rival:
+            rival.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            with pytest.raises(OSError):
+                rival.bind(("127.0.0.1", port))
+    finally:
+        for b in bound:
+            b.close()
+
+
+def test_listener_lines_name_every_bound_address() -> None:
+    bound = [
+        serve_mod.BoundSpec(AppSpec("a", 3001), ["127.0.0.1", "::1", "172.17.0.1"], []),
+        serve_mod.BoundSpec(AppSpec("b", 4318), ["127.0.0.1"], []),
+    ]
+    assert serve_mod.listener_lines(bound) == [
+        "listening on 127.0.0.1:3001, [::1]:3001, 172.17.0.1:3001",
+        "listening on 127.0.0.1:4318",
+    ]


### PR DESCRIPTION
> Stacked on #80 (`fix/arm64-nested-probe`). Review the diff against that branch; merge #80 first.

## What changed

- **`serve` runs ONE uvicorn.Server per app, with a pre-bound socket per address** (`commands/serve.py`: `bind_specs` → `serve_bound`). Every address `_bind_hosts` resolves for a spec is bound up front (`_preflight.bind_listener`, same options asyncio's `create_server` would set: `SO_REUSEADDR` on POSIX, `IPV6_V6ONLY` on IPv6) and the socket list is handed to `Server.serve(sockets=…)` — uvicorn's gunicorn-worker path, which runs the ASGI lifespan once per Server and opens one listener per socket. Before, `serve` built one Server per *(app, address)* around the same app object, so every `@app.on_event("startup")` hook fired once per bind address.
- **Binding is the preflight.** A conflict surfaces as a per-address `EADDRINUSE` before any server starts and is printed through `conflict_message` naming the host — not as uvicorn's `sys.exit(1)` from inside `Server.startup()`. The IPv6 loopback companion is the one address allowed to be missing (IPv6 disabled ⇒ one warning, IPv4 still serves); a spec with no bindable address at all is fatal.
- **Port preflight sees IPv6.** `_preflight._bindable` hardcoded `AF_INET`; it now probes in the address's own family, and `find_free_port` also requires `[::1]` free (role:all binds it), while an address family that does not exist on the host reads as *free*, not *taken* (otherwise every port would look busy on an IPv6-disabled host).
- **The startup hooks are guarded** (`roles/boot/role_all.py`): reconcile, budget watchdog and readiness gate each run once per app whatever the ASGI host does. The readiness guard claims a flag *before* its first `await` — an `is not None` check is a check-then-act race across `build_run_create_deps`. This is commit b5cb829 from the unmerged `fix-fuse-platform-and-boot-singletons` branch, re-applied (the rest of that branch was superseded by #41/#57).

## Why

Fixes the root cause and finding 1 of #43.

On Linux role:all resolves three agent-facing addresses (loopback, `::1`, the docker bridge gateway), so the REST app got **three** reconciles, **three** budget watchdogs and **three** readiness gates scanning the same runs; two gates closed out the same failed run milliseconds apart and the loser's teardown died on `409 removal of container … already in progress`. Each hook assigns to a `nonlocal`, so shutdown stopped only the last instance. Separately, a listener on `[::1]:3001` with `127.0.0.1:3001` free passed the IPv4-only preflight and crashed uvicorn from inside `Server.startup()` with a raw traceback.

**Not in this PR** (still tracked on #43): finding 2 (close-out destroys the failure evidence), finding 3 (`compose_service_states` → `()` → READY fails open), finding 4 (`_check_one` tears down twice), finding 5 (90 s readiness default). Those change readiness *behaviour* and deserve their own PR and their own empirical run.

## Testing

```
$ uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run lint-imports
All checks passed! / 514 files already formatted / Success: no issues found in 491 source files / Contracts: 4 kept, 0 broken.
$ uv run pytest -m unit -n auto -q          → 2161 passed
$ uv run pytest -m "adapters or topology" -q → 179 passed
```

New tests: `tests/unit/test_boot_singletons_once.py` (hooks fired 1×/2×/3× concurrently with `asyncio.gather`, exactly one budget watchdog, one readiness gate, one reconcile each time), `tests/unit/test_serve_sockets.py` (one socket per address per app; `[::1]` squatter → `BindConflict` naming `::1` and every socket bound so far released; IPv4 squatter; missing IPv6 loopback is a warning; `serve_bound` hands ALL of an app's sockets to ONE Server), `tests/unit/test_preflight.py` (+3: `find_free_port` walks past a `[::1]` squatter; an unavailable address family reads as free; `bind_listener` family/bound/held-once-listening). Four existing `serve` tests re-seamed from `ports_in_use` to `bind_listener`.

**Empirical — the real `xorcise serve --stub` (role all, real uvicorn, isolated `XORCISE_HOME`), booted from the previous tree and from this branch on this Linux host, with counters wrapped around the production singletons and nothing else changed:**

| | Before (one Server per address) | After (one Server per app) |
|---|---|---|
| Listeners (`ss -tlnH`) | 6: `127.0.0.1`, `[::1]`, `172.17.0.1` × REST, OTLP | 6, same set |
| REST reachable ipv4 / ipv6 / gateway | 200 / 200 / 200 | 200 / 200 / 200 |
| `BudgetWatchdog` built / started | **3 / 3** | 1 / 1 |
| `ReadinessWatchdog` built / started | **3 / 3** | 1 / 1 |
| `reconcile_all_on_startup` runs | **3** | 1 |
| SIGTERM → exit, time, ports left listening | exit 0, 936 ms, 0 | exit 143, 418 ms, 0 (see note) |
| SIGINT (Ctrl-C) → exit, ports left listening | — | exit 0 ("shutting down"), 0 |
| Immediate rebind of both ports after stop | ok | ok |
| Squatter on `[::1]:P`, `127.0.0.1:P` free, `serve --port P` | banner printed, then uvicorn `OSError: [Errno 98] … ('::1', P, 0, 0)`, **109-line traceback**, exit 1 | resolution now sees the IPv6 side: `--port P` relocates to P+1 and serves; no traceback (the `BindConflict` path is covered by the unit tests) |

Note on exit 143: uvicorn's `capture_signals` re-raises the captured signal after a graceful shutdown, so a single Server terminates by SIGTERM (143), which is uvicorn's own CLI behaviour. The previous exit 0 was an artefact of six nested handler restorations. `down` waits on process exit and never reads the status; Ctrl-C still exits 0.

**Test lanes affected**

- [x] `unit`
- [ ] `adapters`
- [ ] `topology`
- [x] `integration` — `serve`/`up` boot path; validated by hand above, not in CI
- [x] `e2e` — full `xorcise up` (uses `serve`); please add `full-ci`
- [ ] `frontend`

## User-facing impact

- [x] No user-visible change (internal refactor, tests, docs only)

Behaviour: `serve`/`up` boot the same listeners; conflicts on any address are reported cleanly; a port whose IPv6 side is taken is skipped by auto-increment. No interface change.

## Documentation

- [x] No documentation change needed

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] No secrets, credentials, tokens, keys, internal hostnames or customer data in the diff
- [x] No references to internal-only systems

---

- [x] I have signed the Contributor License Agreement.
