### PR TITLE
fix(cli): up/down/db upgrade find a live server by pid file OR port, and never orphan or duplicate it

### DIFF
--- a/src/xorcise/core/cli/commands/db.py
+++ b/src/xorcise/core/cli/commands/db.py
@@ -30,10 +30,24 @@ def db_upgrade(force: bool = _FORCE_OPTION) -> None:
     """
     from alembic.util.exc import CommandError
 
-    from xorcise.core.cli.commands.lifecycle import _live_instance
+    from xorcise.core.cli.commands.lifecycle import InstanceUndetermined, _live_instance
     from xorcise.core.config import get_settings
 
-    live = None if force else _live_instance(get_settings())
+    # `is True`: a direct (non-CLI) call gets the typer OptionInfo as the default, and that
+    # object is truthy — `if force:` would skip the guard that stops database corruption.
+    if force is True:
+        live = None
+    else:
+        try:
+            live = _live_instance(get_settings())
+        except InstanceUndetermined as exc:
+            # Cannot tell whether a server holds the DB: the safe answer is no migration.
+            err_console.print(
+                f"[err]error[/err]: {exc}. Not migrating while that is unknown "
+                "(--force overrides; unsafe.)",
+                highlight=False,
+            )
+            raise typer.Exit(1) from None
     if live is not None:
         where = f"pid {live.pid}" if live.pid is not None else f"port {live.rest_port}"
         err_console.print(

--- a/src/xorcise/core/cli/commands/db.py
+++ b/src/xorcise/core/cli/commands/db.py
@@ -11,10 +11,38 @@ db_app = typer.Typer(help="Database maintenance (advanced).", no_args_is_help=Tr
 app.add_typer(db_app, name="db", rich_help_panel="Advanced")
 
 
+_FORCE_OPTION = typer.Option(
+    False,
+    "--force",
+    help="Migrate even if a XORCISE server of this home appears to be running (unsafe).",
+)
+
+
 @db_app.command("upgrade")
-def db_upgrade() -> None:
-    """Apply pending database migrations (explicit; never on boot)."""
+def db_upgrade(force: bool = _FORCE_OPTION) -> None:
+    """Apply pending database migrations (explicit; never on boot).
+
+    Refuses while a server of this home is running: the current migrations rebuild tables in
+    place (SQLite batch mode — copy, swap, rename), so migrating under a live server replaces
+    the tables it has open and renames columns its ORM is still using. The boot-time guard
+    only ever pointed HERE ("run 'xorcise db upgrade' first"), and it fires precisely when an
+    older server may still be up — so this end has to hold the line too (#74).
+    """
     from alembic.util.exc import CommandError
+
+    from xorcise.core.cli.commands.lifecycle import _live_instance
+    from xorcise.core.config import get_settings
+
+    live = None if force else _live_instance(get_settings())
+    if live is not None:
+        where = f"pid {live.pid}" if live.pid is not None else f"port {live.rest_port}"
+        err_console.print(
+            f"[err]error[/err]: XORCISE is running ({where}) and holds this database open — "
+            "migrating it underneath a live server rewrites the tables it is using. "
+            "Stop it first: [value]xorcise down[/value], then [value]xorcise db upgrade[/value], "
+            "then [value]xorcise up[/value]. (--force overrides; unsafe.)"
+        )
+        raise typer.Exit(1)
 
     try:
         console.print(_upgrade())

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -12,7 +12,7 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 import httpx
@@ -339,8 +339,13 @@ def _ensure_db_ready() -> None:
         db.upgrade()
         console.print("prepared the database")
     elif state == "stale":
+        # Name the WHOLE sequence. This message fires exactly when an older server may still be
+        # serving (that is why the DB is behind), and `db upgrade` alone would migrate the tables
+        # underneath it — the stop comes first.
         err_console.print(
-            "[err]database is behind the schema — run 'xorcise db upgrade' first[/err]"
+            "[err]database is behind the schema[/err] — stop any running XORCISE first "
+            "([value]xorcise down[/value]), then run [value]xorcise db upgrade[/value] and "
+            "start it again"
         )
         raise typer.Exit(1)
 
@@ -369,20 +374,22 @@ def up(
     Already-running is success, not an error — safe to re-run any time.
     """
     pf = pid_file()
-    if pf.exists():
-        try:
-            os.kill(int(pf.read_text()), 0)
-        except (ProcessLookupError, ValueError):
-            pf.unlink(missing_ok=True)
-        except PermissionError:
-            # The pid exists but belongs to another user — treat as running.
-            console.print(f"already running — UI at {_effective_ui_url()}")
-            return
+    live = _live_instance(get_settings(), extra_ports=[port] if port else [])
+    if live is not None:
+        if live.source == "probe":
+            # An instance of THIS home is serving but the pid record is gone or names a dead
+            # process (a `down` whose kill failed, an earlier `up` that overwrote it). Booting
+            # here would start a SECOND server over the same database — and migrate it under
+            # the first. Adopt the live one instead: repair the record so `down`/`status`/`ui`
+            # can find it again, and converge.
+            _repair_instance_record(live)
+            console.print(f"already running (pid record repaired) — UI at {_effective_ui_url()}")
         else:
             # Idempotent converge: 'already true' is exit 0, matching `down` on
             # not-running — scripts and agents re-run `up` defensively.
             console.print(f"already running — UI at {_effective_ui_url()}")
-            return
+        return
+    pf.unlink(missing_ok=True)  # absent, corrupt, or names a process that is gone
 
     # Prerequisites BEFORE anything is written. A missing Compose v2 plugin used to
     # surface ~20 lines in, after the home was created, the DB migrated and two RSA
@@ -538,7 +545,9 @@ def _foreign_instance_home(host: str, rest_port: int) -> str | None:
     this home's — else None. Lets doctor say 'held by another XORCISE instance'
     instead of accusing an unknown process."""
     try:
-        info = httpx.get(f"http://{host}:{rest_port}/api/system", timeout=1).json()
+        info = httpx.get(
+            f"http://{host}:{rest_port}/api/system", timeout=_INSTANCE_PROBE_TIMEOUT
+        ).json()
     except (httpx.HTTPError, ValueError):
         return None
     their_home = str(info.get("home") or "") if isinstance(info, dict) else ""
@@ -548,6 +557,153 @@ def _foreign_instance_home(host: str, rest_port: int) -> str | None:
         if Path(their_home).resolve() == Path(xorcise_home()).resolve():
             return None
     return their_home
+
+
+@dataclass(frozen=True)
+class LiveInstance:
+    """A running server of THIS home: how it was found, where it listens, and its pid if known.
+
+    `source` is "pidfile" when the pid file names a live process, "probe" when the pid file was
+    absent/stale but an instance of this home answered on a REST port this home would use —
+    the shape a failed `down` or an overwriting second `up` leaves behind (#72, #73)."""
+
+    pid: int | None
+    rest_port: int
+    otlp_port: int | None
+    source: str
+
+
+def _pid_from_file() -> int | None:
+    """The pid the pid file names, when that process is alive; None when the file is absent,
+    corrupt, or names a process that is gone. A pid that exists but cannot be signalled
+    (another user's) still counts as alive — it is not ours to declare dead."""
+    pf = pid_file()
+    if not pf.exists():
+        return None
+    try:
+        pid = int(pf.read_text())
+    except ValueError:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return pid
+    return pid
+
+
+# `/api/system` is cheap when warm but its FIRST answer waits on remote catalog probes (measured
+# well over a second cold), and a timeout here reads as "not ours" — which is how a live server
+# got dropped as pid reuse. Nothing listening still fails instantly (connection refused).
+_INSTANCE_PROBE_TIMEOUT = 8.0
+
+
+def _same_home_instance_on(host: str, rest_port: int) -> dict[str, object] | None:
+    """`/api/system` of whatever answers on `host:rest_port`, when it is an instance of THIS
+    home — else None (nothing there, not XORCISE, or another home's instance)."""
+    try:
+        info = httpx.get(
+            f"http://{host}:{rest_port}/api/system", timeout=_INSTANCE_PROBE_TIMEOUT
+        ).json()
+        if not isinstance(info, dict):
+            return None
+        their_home = str(info.get("home") or "")
+        if not their_home:
+            return None
+        same = Path(their_home).resolve() == Path(xorcise_home()).resolve()
+    except Exception:  # noqa: BLE001 — a best-effort probe; anything odd means "not ours"
+        return None
+    return info if same else None
+
+
+def _candidate_rest_ports(settings, extra: list[int] = []) -> list[int]:  # type: ignore[no-untyped-def]  # noqa: B006
+    """Where a server of this home could be listening: the configured REST port, the one the
+    runtime record names (an auto-incremented instance) and any the caller was told about
+    (`up --port N`), configured first, without duplicates."""
+    ports = [settings.rest_port]
+    recorded = (read_runtime_ports() or {}).get("rest")
+    for candidate in (recorded, *extra):
+        if isinstance(candidate, int) and candidate not in ports:
+            ports.append(candidate)
+    return ports
+
+
+def _otlp_from_info(info: dict[str, object]) -> int | None:
+    """The OTLP port an instance reports in its `/api/system` planes, if it does."""
+    planes = info.get("planes")
+    if not isinstance(planes, list):
+        return None
+    for plane in planes:
+        if isinstance(plane, dict) and plane.get("name") == "otlp":
+            _host, _, port = str(plane.get("location") or "").rpartition(":")
+            if port.isdigit():
+                return int(port)
+    return None
+
+
+def _live_instance(settings, extra_ports: list[int] = []) -> LiveInstance | None:  # type: ignore[no-untyped-def]  # noqa: B006
+    """The running server of THIS home, if any: by pid file first, then by asking the REST
+    port(s) this home would use whether an instance of this home answers.
+
+    The pid file alone is not enough — `up` used to guard on it only, so once it was stale or
+    gone (a failed `down`, see #72) a live sibling on the REST port read as a generic busy port,
+    `up` auto-incremented past it and booted a second instance over the same SQLite file (#73).
+    """
+    pid = _pid_from_file()
+    if pid is not None:
+        recorded = read_runtime_ports() or {}
+        return LiveInstance(
+            pid, recorded.get("rest", settings.rest_port), recorded.get("otlp"), "pidfile"
+        )
+    for port in _candidate_rest_ports(settings, extra_ports):
+        info = _same_home_instance_on(settings.host, port)
+        if info is not None:
+            reported = info.get("pid")
+            return LiveInstance(
+                reported if isinstance(reported, int) else None,
+                port,
+                _otlp_from_info(info),
+                "probe",
+            )
+    return None
+
+
+def _repair_instance_record(live: LiveInstance) -> None:
+    """Re-create the pid file and runtime-ports record for an instance found by probe, so the
+    sibling commands can name it again."""
+    if live.pid is not None:
+        pid_file().write_text(str(live.pid))
+    ports = {"rest": live.rest_port}
+    if live.otlp_port is not None:
+        ports["otlp"] = live.otlp_port
+    write_runtime_ports(ports)
+
+
+def _stop_process(pid: int) -> str:
+    """SIGTERM `pid`, escalate to SIGKILL, and say what actually happened:
+
+    "stopped" — it exited; "gone" — it was already gone; "unsignalable" — it is alive but not
+    ours to signal (another user's process, or pid reuse); "survived" — it outlived SIGKILL.
+    `down` used to swallow the last two into "stopped" and unlink the pid file regardless,
+    which turned a failed kill into a permanently orphaned server (#72)."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "gone"
+    except PermissionError:
+        return "unsignalable"
+    # Wait for it to actually exit (release its ports) so a following `up` isn't racing a
+    # still-terminating server; escalate to SIGKILL if it won't stop.
+    if _await_exit(pid):
+        return "stopped"
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return "stopped"
+    except PermissionError:
+        return "unsignalable"
+    return "stopped" if _await_exit(pid, timeout=2.0) else "survived"
 
 
 def _note_foreign_instance(host: str, rest_port: int) -> None:
@@ -873,28 +1029,102 @@ def down(
         )
         raise typer.Exit(2)
 
+    from xorcise.core.config import get_settings
+
+    settings = get_settings()
     pf = pid_file()
     running = pf.exists()
     if running:
-        with (
-            contextlib.suppress(ProcessLookupError, ValueError, PermissionError),
-            step_progress("stopping XORCISE"),
-        ):
-            pid = int(pf.read_text())
-            os.kill(pid, signal.SIGTERM)
-            # Wait for it to actually exit (release its ports) so a following `up` isn't
-            # racing a still-terminating server; escalate to SIGKILL if it won't stop.
-            if not _await_exit(pid):
-                os.kill(pid, signal.SIGKILL)
-                _await_exit(pid, timeout=2.0)
+        try:
+            pid: int | None = int(pf.read_text())
+        except ValueError:
+            pid = None  # corrupt record: nothing to signal by it; the port sweep below decides
+        outcome = "gone"
+        if pid is not None:
+            with step_progress("stopping XORCISE"):
+                outcome = _stop_process(pid)
+        # Alive but not ours to signal? Two very different situations look like this: the pid
+        # was reused by some unrelated process (the server is gone, or is running as some OTHER
+        # pid — the record is merely wrong), or the server really is running under another
+        # user. Only the ports tell them apart: ask every port an instance of this home could
+        # be on, and compare the pid each one reports with the one in the file.
+        if outcome == "unsignalable":
+            reported = {
+                info.get("pid")
+                for p in _candidate_rest_ports(settings)
+                if (info := _same_home_instance_on(settings.host, p)) is not None
+            }
+            if pid not in reported and all(isinstance(r, int) for r in reported):
+                # No instance of this home claims this pid: the file is stale. Whatever IS
+                # serving (if anything) is stopped by the sweep below, by the pid it reports.
+                console.print(
+                    f"[dim]pid {pid} in the pid file is not XORCISE (pid reuse) — "
+                    "dropping the stale record[/dim]"
+                )
+                outcome = "gone"
+        if outcome in ("unsignalable", "survived"):
+            # A failed kill must stay visible: the pid file is LEFT IN PLACE (unlinking it is
+            # what made the server unfindable forever), the pid is named, and the exit is
+            # non-zero.
+            reason = (
+                "it is alive but cannot be signalled from this user"
+                if outcome == "unsignalable"
+                else "it did not exit after SIGKILL"
+            )
+            err_console.print(
+                f"[err]error[/err]: could not stop XORCISE (pid {pid}) — {reason}. "
+                f"The pid file {pf} is left in place; stop the process "
+                f"([value]kill {pid}[/value], as the user that owns it) and re-run "
+                "[value]xorcise down[/value]"
+            )
+            raise typer.Exit(1)
         pf.unlink(missing_ok=True)
         runtime_ports_file().unlink(missing_ok=True)  # the record dies with the server
+    # The pid file names ONE process. An instance of this home can be serving without being in
+    # it — a second `up` overwrote the record (#73), or the record was lost — so ask the ports
+    # this home would use, and stop any instance of this home that still answers, by the pid it
+    # reports. A foreign home's instance is left alone (and named). Bounded: one per candidate
+    # port, never a loop on something we cannot stop.
+    for port in _candidate_rest_ports(settings):
+        info = _same_home_instance_on(settings.host, port)
+        if info is None:
+            continue
+        orphan_pid = info.get("pid")
+        if not isinstance(orphan_pid, int) or orphan_pid == os.getpid():
+            err_console.print(
+                f"[err]error[/err]: an instance of this home still answers on port {port} but "
+                "did not report its pid (an older server) — find it with "
+                f"[value]ss -tlnp 'sport = :{port}'[/value] and stop it, then re-run "
+                "[value]xorcise down[/value]"
+            )
+            raise typer.Exit(1)
+        with step_progress(f"stopping an orphaned instance of this home (pid {orphan_pid})"):
+            outcome = _stop_process(orphan_pid)
+        if outcome not in ("stopped", "gone"):
+            err_console.print(
+                f"[err]error[/err]: could not stop the instance of this home on port {port} "
+                f"(pid {orphan_pid}) — stop it by hand and re-run [value]xorcise down[/value]"
+            )
+            raise typer.Exit(1)
+        running = True
+        console.print(
+            f"stopped an orphaned instance of this home (pid {orphan_pid}) that was still "
+            f"serving port {port}"
+        )
+    # Verify the release. "stopped" is claimed only when nothing of ours listens any more; a
+    # foreign holder is a fact worth one line, not a failure of THIS home's `down`.
+    still = ports_in_use(settings.host, sorted({settings.rest_port, settings.otlp_port}))
+    for port in still:
+        foreign = (
+            _foreign_instance_home(settings.host, port) if port == settings.rest_port else None
+        )
+        who = f"the XORCISE instance at {foreign}" if foreign else "another process"
+        console.print(f"[dim]note: port {port} is held by {who} — not this home's server[/dim]")
     # Reap orphaned per-run mission containers. Unconditional and label-driven, so it
     # also clears containers from abandoned runs (agent crashed before terminal) and prior sessions
     # — the server's in-process deploy map is gone once it is killed above. Runs BEFORE the
     # Headscale teardown so a reaped router never lingers pointing at a control plane we are
     # about to remove.
-    from xorcise.core.config import get_settings
     from xorcise.core.rest.reap import reap_managed_containers
 
     with step_progress("reaping orphaned run containers"):

--- a/src/xorcise/core/cli/commands/lifecycle.py
+++ b/src/xorcise/core/cli/commands/lifecycle.py
@@ -374,16 +374,34 @@ def up(
     Already-running is success, not an error — safe to re-run any time.
     """
     pf = pid_file()
-    live = _live_instance(get_settings(), extra_ports=[port] if port else [])
+    try:
+        live = _live_instance(get_settings(), extra_ports=[port] if port else [])
+    except InstanceUndetermined as exc:
+        # Fail closed: booting past a port we cannot identify is how a second instance of this
+        # home ends up on the same database. Say what was seen and what to do.
+        err_console.print(f"[err]error[/err]: {exc}", highlight=False)
+        raise typer.Exit(1) from None
     if live is not None:
         if live.source == "probe":
             # An instance of THIS home is serving but the pid record is gone or names a dead
             # process (a `down` whose kill failed, an earlier `up` that overwrote it). Booting
             # here would start a SECOND server over the same database — and migrate it under
-            # the first. Adopt the live one instead: repair the record so `down`/`status`/`ui`
-            # can find it again, and converge.
+            # the first. Adopt the live one instead: repair what can be repaired so
+            # `down`/`status`/`ui` can find it again, and converge.
             _repair_instance_record(live)
-            console.print(f"already running (pid record repaired) — UI at {_effective_ui_url()}")
+            s = get_settings()
+            url = f"http://{s.host}:{live.rest_port}/ui"  # the port it was FOUND on, not config
+            if live.pid is not None:
+                console.print(f"already running (pid record repaired) — UI at {url}")
+            else:
+                # An older server that does not report its pid: the pid file cannot be
+                # restored, so say so rather than claim a repair; the port record is written,
+                # which is what lets `down` find and stop it.
+                console.print(
+                    f"already running on port {live.rest_port} — UI at {url}. Its pid is not "
+                    "known (an older server), so the pid file could not be restored; "
+                    "'xorcise down' will find it by port"
+                )
         else:
             # Idempotent converge: 'already true' is exit 0, matching `down` on
             # not-running — scripts and agents re-run `up` defensively.
@@ -446,7 +464,7 @@ def up(
     try:
         for _ in range(50):
             try:
-                if httpx.get(health, timeout=1).status_code == 200:
+                if httpx.get(health, timeout=1, trust_env=False).status_code == 200:
                     healthy = True
                     break
             except httpx.HTTPError:
@@ -546,7 +564,9 @@ def _foreign_instance_home(host: str, rest_port: int) -> str | None:
     instead of accusing an unknown process."""
     try:
         info = httpx.get(
-            f"http://{host}:{rest_port}/api/system", timeout=_INSTANCE_PROBE_TIMEOUT
+            f"http://{host}:{rest_port}/api/system",
+            timeout=_INSTANCE_PROBE_TIMEOUT,
+            trust_env=False,  # a loopback probe must never be routed through HTTP_PROXY
         ).json()
     except (httpx.HTTPError, ValueError):
         return None
@@ -557,6 +577,37 @@ def _foreign_instance_home(host: str, rest_port: int) -> str | None:
         if Path(their_home).resolve() == Path(xorcise_home()).resolve():
             return None
     return their_home
+
+
+# Signals delivered by pid are only as safe as the pid: 0 addresses the caller's whole process
+# group (`down` and the operator's shell pipeline), a bool passes `isinstance(x, int)`, and a
+# value past C long makes os.kill raise OverflowError — which `except ValueError` never catches.
+# Every pid that arrives from a FILE or a JSON body goes through this first.
+_PID_MAX = 2**31 - 1
+
+
+def _valid_pid(value: object) -> int | None:
+    """`value` as a pid we may signal — a real int (not a bool) in (0, 2**31) — else None."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 < value < _PID_MAX else None
+
+
+class InstanceUndetermined(RuntimeError):
+    """A REST port this home could be serving on accepted the connection but did not answer
+    `/api/system` in time (or answered garbage): we cannot tell whether an instance of this home
+    is running there. The guards fail CLOSED on this — proceeding is exactly the duplicate-
+    instance / migrate-under-a-live-server outcome they exist to prevent."""
+
+    def __init__(self, port: int) -> None:
+        self.port = port
+        super().__init__(
+            f"port {port} accepted a connection but did not answer /api/system within "
+            f"{_INSTANCE_PROBE_TIMEOUT:g}s, so it is unknown whether a XORCISE server of this "
+            "home is running there. If it is a hung XORCISE, run 'xorcise down' (it stops what "
+            "it can identify) or stop the process by hand; if it is something else, configure a "
+            "different port (XORCISE_REST_PORT) and retry"
+        )
 
 
 @dataclass(frozen=True)
@@ -581,9 +632,11 @@ def _pid_from_file() -> int | None:
     if not pf.exists():
         return None
     try:
-        pid = int(pf.read_text())
+        pid = _valid_pid(int(pf.read_text()))
     except ValueError:
         return None
+    if pid is None:
+        return None  # corrupt: a value no process can have
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -593,28 +646,80 @@ def _pid_from_file() -> int | None:
     return pid
 
 
+def _read_pid_file(pf: Path) -> int | None:
+    """The pid file's content as a signalable pid, or None when absent/corrupt/out of range."""
+    try:
+        return _valid_pid(int(pf.read_text()))
+    except (OSError, ValueError):
+        return None
+
+
 # `/api/system` is cheap when warm but its FIRST answer waits on remote catalog probes (measured
 # well over a second cold), and a timeout here reads as "not ours" — which is how a live server
 # got dropped as pid reuse. Nothing listening still fails instantly (connection refused).
 _INSTANCE_PROBE_TIMEOUT = 8.0
 
 
-def _same_home_instance_on(host: str, rest_port: int) -> dict[str, object] | None:
-    """`/api/system` of whatever answers on `host:rest_port`, when it is an instance of THIS
-    home — else None (nothing there, not XORCISE, or another home's instance)."""
+class _Undetermined:
+    """Marker: the probe could not tell (see InstanceUndetermined)."""
+
+
+UNDETERMINED = _Undetermined()
+
+
+def _probe_system(host: str, rest_port: int) -> dict[str, object] | _Undetermined | None:
+    """GET `/api/system` on a loopback port: the body as a dict, None when nothing that could be
+    ours is there (connection refused; or a plain answer that is not a XORCISE system endpoint —
+    an HTML 404 from some other web service), UNDETERMINED when something accepted the
+    connection but would not say what it is (timeout, transport error, a 5xx: a server exists
+    and is broken, and it may well be ours).
+
+    `trust_env=False`: httpx honours HTTP_PROXY/ALL_PROXY by default and applies no implicit
+    loopback bypass, so in a shell where a proxy is set and NO_PROXY does not cover the loopback
+    this probe would go to the proxy, come back 502 or hang, and read as "nothing running" — the
+    exact duplicate-instance failure it guards against. A loopback probe never wants a proxy."""
     try:
-        info = httpx.get(
-            f"http://{host}:{rest_port}/api/system", timeout=_INSTANCE_PROBE_TIMEOUT
-        ).json()
-        if not isinstance(info, dict):
-            return None
-        their_home = str(info.get("home") or "")
-        if not their_home:
-            return None
+        response = httpx.get(
+            f"http://{host}:{rest_port}/api/system",
+            timeout=_INSTANCE_PROBE_TIMEOUT,
+            trust_env=False,
+        )
+    except httpx.ConnectError:
+        return None  # nothing listening: the one answer that means "absent"
+    except httpx.HTTPError:
+        return UNDETERMINED  # accepted but did not answer in time, or died mid-response
+    if response.status_code >= 500:
+        return UNDETERMINED  # something is serving and failing — possibly a sick instance of ours
+    try:
+        info = response.json()
+    except ValueError:
+        return None  # answered, but not JSON: not a XORCISE system endpoint
+    return info if isinstance(info, dict) else None
+
+
+def _same_home_instance_on(host: str, rest_port: int) -> dict[str, object] | _Undetermined | None:
+    """`/api/system` of whatever answers on `host:rest_port` when it is an instance of THIS
+    home; None when nothing of ours is there (nothing listening, or another home's instance /
+    some other service answering); UNDETERMINED when the port accepted but would not say."""
+    info = _probe_system(host, rest_port)
+    if info is None or isinstance(info, _Undetermined):
+        return info
+    their_home = str(info.get("home") or "")
+    if not their_home:
+        return None  # answered, but not a XORCISE server
+    try:
         same = Path(their_home).resolve() == Path(xorcise_home()).resolve()
-    except Exception:  # noqa: BLE001 — a best-effort probe; anything odd means "not ours"
+    except OSError:
         return None
     return info if same else None
+
+
+def _ours_on(host: str, rest_port: int) -> dict[str, object] | None:
+    """`_same_home_instance_on`, failing CLOSED: an undetermined port raises."""
+    info = _same_home_instance_on(host, rest_port)
+    if isinstance(info, _Undetermined):
+        raise InstanceUndetermined(rest_port)
+    return info
 
 
 def _candidate_rest_ports(settings, extra: list[int] = []) -> list[int]:  # type: ignore[no-untyped-def]  # noqa: B006
@@ -657,21 +762,16 @@ def _live_instance(settings, extra_ports: list[int] = []) -> LiveInstance | None
             pid, recorded.get("rest", settings.rest_port), recorded.get("otlp"), "pidfile"
         )
     for port in _candidate_rest_ports(settings, extra_ports):
-        info = _same_home_instance_on(settings.host, port)
+        info = _ours_on(settings.host, port)  # raises InstanceUndetermined: fail closed
         if info is not None:
-            reported = info.get("pid")
-            return LiveInstance(
-                reported if isinstance(reported, int) else None,
-                port,
-                _otlp_from_info(info),
-                "probe",
-            )
+            return LiveInstance(_valid_pid(info.get("pid")), port, _otlp_from_info(info), "probe")
     return None
 
 
 def _repair_instance_record(live: LiveInstance) -> None:
-    """Re-create the pid file and runtime-ports record for an instance found by probe, so the
-    sibling commands can name it again."""
+    """Re-create what can be re-created for an instance found by probe: the runtime-ports record
+    always (so `down` finds the instance by port next time), the pid file only when the instance
+    reported a pid — an older server does not, and a pid file we cannot fill is not repaired."""
     if live.pid is not None:
         pid_file().write_text(str(live.pid))
     ports = {"rest": live.rest_port}
@@ -713,7 +813,7 @@ def _note_foreign_instance(host: str, rest_port: int) -> None:
     if pid_file().exists():
         return
     with contextlib.suppress(Exception):
-        info = httpx.get(f"http://{host}:{rest_port}/api/system", timeout=1).json()
+        info = httpx.get(f"http://{host}:{rest_port}/api/system", timeout=1, trust_env=False).json()
         their_home = str(info.get("home") or "")
         if their_home and Path(their_home).resolve() != Path(xorcise_home()).resolve():
             console.print(
@@ -1034,11 +1134,15 @@ def down(
     settings = get_settings()
     pf = pid_file()
     running = pf.exists()
+    # Everything the sweep and the release check below need is read NOW, before any record is
+    # unlinked: the runtime record names the port an auto-incremented instance is on (the #73
+    # shape), and reading it after the unlink meant the sweep only ever looked at the
+    # configured port — and claimed "stopped" over a live server on the recorded one.
+    candidates = _candidate_rest_ports(settings)
+    recorded = read_runtime_ports() or {}
+    release_ports = sorted({settings.rest_port, settings.otlp_port, *recorded.values()})
     if running:
-        try:
-            pid: int | None = int(pf.read_text())
-        except ValueError:
-            pid = None  # corrupt record: nothing to signal by it; the port sweep below decides
+        pid = _read_pid_file(pf)  # None: corrupt/out-of-range — nothing to signal by it
         outcome = "gone"
         if pid is not None:
             with step_progress("stopping XORCISE"):
@@ -1047,14 +1151,20 @@ def down(
         # was reused by some unrelated process (the server is gone, or is running as some OTHER
         # pid — the record is merely wrong), or the server really is running under another
         # user. Only the ports tell them apart: ask every port an instance of this home could
-        # be on, and compare the pid each one reports with the one in the file.
+        # be on, and compare the pid each one reports with the one in the file. A port that
+        # cannot be identified means we cannot tell — keep the record, fail.
         if outcome == "unsignalable":
-            reported = {
-                info.get("pid")
-                for p in _candidate_rest_ports(settings)
-                if (info := _same_home_instance_on(settings.host, p)) is not None
-            }
-            if pid not in reported and all(isinstance(r, int) for r in reported):
+            reported: set[int | None] = set()
+            for p in candidates:
+                info = _same_home_instance_on(settings.host, p)
+                if isinstance(info, _Undetermined):
+                    err_console.print(
+                        f"[err]error[/err]: {InstanceUndetermined(p)}", highlight=False
+                    )
+                    raise typer.Exit(1)
+                if info is not None:
+                    reported.add(_valid_pid(info.get("pid")))
+            if pid not in reported and None not in reported:
                 # No instance of this home claims this pid: the file is stale. Whatever IS
                 # serving (if anything) is stopped by the sweep below, by the pid it reports.
                 console.print(
@@ -1085,17 +1195,32 @@ def down(
     # this home would use, and stop any instance of this home that still answers, by the pid it
     # reports. A foreign home's instance is left alone (and named). Bounded: one per candidate
     # port, never a loop on something we cannot stop.
-    for port in _candidate_rest_ports(settings):
+    for port in candidates:
         info = _same_home_instance_on(settings.host, port)
         if info is None:
             continue
-        orphan_pid = info.get("pid")
-        if not isinstance(orphan_pid, int) or orphan_pid == os.getpid():
+        if isinstance(info, _Undetermined):
+            # Something on a port of ours accepted and did not answer: it may well be a hung
+            # instance of this home, and "stopped" cannot be claimed over it.
+            err_console.print(f"[err]error[/err]: {InstanceUndetermined(port)}", highlight=False)
+            raise typer.Exit(1)
+        orphan_pid = _valid_pid(info.get("pid"))
+        if orphan_pid is None:
             err_console.print(
                 f"[err]error[/err]: an instance of this home still answers on port {port} but "
-                "did not report its pid (an older server) — find it with "
+                "did not report a usable pid (an older server) — find it with "
                 f"[value]ss -tlnp 'sport = :{port}'[/value] and stop it, then re-run "
                 "[value]xorcise down[/value]"
+            )
+            raise typer.Exit(1)
+        if orphan_pid == os.getpid():
+            # Cannot happen for a real server (this CLI process is not one); a body that names
+            # the caller's own pid is not something to signal, so refuse rather than SIGTERM
+            # ourselves and call it a stop.
+            err_console.print(
+                f"[err]error[/err]: the instance answering on port {port} reported THIS "
+                f"process's pid ({orphan_pid}) — refusing to signal it; check what is serving "
+                f"there with [value]ss -tlnp 'sport = :{port}'[/value]"
             )
             raise typer.Exit(1)
         with step_progress(f"stopping an orphaned instance of this home (pid {orphan_pid})"):
@@ -1113,11 +1238,9 @@ def down(
         )
     # Verify the release. "stopped" is claimed only when nothing of ours listens any more; a
     # foreign holder is a fact worth one line, not a failure of THIS home's `down`.
-    still = ports_in_use(settings.host, sorted({settings.rest_port, settings.otlp_port}))
+    still = ports_in_use(settings.host, release_ports)
     for port in still:
-        foreign = (
-            _foreign_instance_home(settings.host, port) if port == settings.rest_port else None
-        )
+        foreign = _foreign_instance_home(settings.host, port) if port in candidates else None
         who = f"the XORCISE instance at {foreign}" if foreign else "another process"
         console.print(f"[dim]note: port {port} is held by {who} — not this home's server[/dim]")
     # Reap orphaned per-run mission containers. Unconditional and label-driven, so it

--- a/src/xorcise/core/contracts/config.py
+++ b/src/xorcise/core/contracts/config.py
@@ -184,3 +184,8 @@ class SystemInfo(_Frozen):
     # The daemon's native os/arch (AS1) — what missions execute on natively here. None in stub
     # mode or when docker is unreachable. The run form warns off it (emulation, no-native).
     host_platform: str | None = None
+    # The serving process's pid. A sibling CLI whose pid file is gone or wrong (a `down` whose
+    # kill failed, a second `up` that overwrote it) can still find the instance by asking the
+    # port — and, with the pid, stop it or repair the record instead of orphaning it. None from
+    # a server that predates the field.
+    pid: int | None = None

--- a/src/xorcise/core/rest/system_view.py
+++ b/src/xorcise/core/rest/system_view.py
@@ -7,6 +7,7 @@ because cli is ABOVE rest in the layer order and rest must not import upward (.i
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import time
@@ -270,6 +271,7 @@ def build_system_info(settings: Settings) -> SystemInfo:
         topology=settings.deployment_topology,
         mission_base=_cached("mission_base", lambda: _mission_base_view(source)),
         host_platform=_host_platform(settings),
+        pid=os.getpid(),  # lets `down`/`up`/`db upgrade` find this instance without the pid file
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,19 @@ def _force_stubs(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _no_loopback_instance_probe(monkeypatch):
+    """Keep the unit lane off the loopback network: `up`/`down`/`db upgrade` ask `/api/system` on
+    the REST ports this home could be serving on. Unstubbed, that is a real HTTP call from a unit
+    test — and on a developer machine with `xorcise up` running it can find a REAL instance and
+    turn a green test red. Default to "nothing of ours is there"; tests that exercise the probe
+    override this with their own monkeypatch (fixture order: autouse first, the test's wins).
+    """
+    from xorcise.core.cli.commands import lifecycle
+
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda host, port: None)
+
+
+@pytest.fixture(autouse=True)
 def _skip_frontend_build(monkeypatch):
     """Keep the suite npm-free: `xorcise up` tests must not shell out to `npm run build:static`.
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -762,7 +762,13 @@ def test_down_running_stops_server_and_reports(monkeypatch, tmp_path):
     pf = tmp_path / "xorcise.pid"
     pf.write_text("999999")
     killed: dict[str, int] = {}
-    monkeypatch.setattr(os, "kill", lambda pid, sig: killed.update(pid=pid, sig=sig))
+
+    def fake_kill(pid, sig):
+        if sig == 0 and killed:  # liveness probe after the SIGTERM: the server has exited
+            raise ProcessLookupError
+        killed.update(pid=pid, sig=sig)
+
+    monkeypatch.setattr(os, "kill", fake_kill)
     result = runner.invoke(app, ["down"])
     assert result.exit_code == 0
     assert "xorcise down" in result.output

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1186,7 +1186,7 @@ def test_up_auto_increments_and_records_runtime_ports(_prereqs_ok, monkeypatch, 
     class _Resp:
         status_code = 200
 
-    def fake_get(url, timeout=1):
+    def fake_get(url, timeout=1, **kwargs):
         polled["url"] = url
         return _Resp()
 

--- a/tests/unit/test_cli_ux.py
+++ b/tests/unit/test_cli_ux.py
@@ -113,12 +113,16 @@ def test_main_guard_unexpected_error_mentions_debug_hatch(monkeypatch, capsys):
     assert "XORCISE_DEBUG=1" in err
 
 
-def test_db_upgrade_history_mismatch_is_a_targeted_error(monkeypatch):
+def test_db_upgrade_history_mismatch_is_a_targeted_error(monkeypatch, tmp_path):
     """A DB stamped by a different build (a revision id this build's migration
     chain doesn't know) must explain itself, not surface as 'unexpected error'."""
     from alembic.util.exc import CommandError
 
     from xorcise.core.cli.commands import db as db_cmd
+
+    # Its own home: the liveness guard reads the pid file, and the developer's real ~/.xorcise
+    # may well have a server running.
+    monkeypatch.setenv("XORCISE_HOME", str(tmp_path))
 
     def boom():
         raise CommandError("Can't locate revision identified by '9999_other_build'")
@@ -733,7 +737,7 @@ def test_status_names_a_foreign_instance_after_down(monkeypatch, tmp_path):
         def json():
             return {"home": "/somebody/elses/.xorcise"}
 
-    monkeypatch.setattr(httpx, "get", lambda url, timeout=1: FakeResp())
+    monkeypatch.setattr(httpx, "get", lambda url, **kwargs: FakeResp())
     result = runner.invoke(app, ["status"])
     get_settings.cache_clear()
     assert result.exit_code == 0

--- a/tests/unit/test_lifecycle_guards.py
+++ b/tests/unit/test_lifecycle_guards.py
@@ -1,0 +1,285 @@
+"""`up` / `down` / `db upgrade` agree on ONE question — is a server of this home running? —
+and answer it from more than the pid file.
+
+Three defects shared a root (#72, #73, #74). `down` unlinked the pid file even when its kill
+failed, so a server it could not stop became unfindable forever. `up` guarded on the pid file
+alone, so with that file stale or gone a live sibling on the REST port read as a generic busy
+port: `up` auto-incremented past it and booted a SECOND instance over the same SQLite file —
+after preparing that shared DB. And `db upgrade` had no liveness check at all, while the only
+boot-time guard pointed straight at it ("run 'xorcise db upgrade' first") in exactly the state
+where an older server may still be serving. The pinned behaviours below are the fixes.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import xorcise.core.cli.app  # noqa: F401 — registers commands on the shared app
+from xorcise.core.cli._shared import app
+from xorcise.core.cli.commands import lifecycle
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XORCISE_HOME", str(tmp_path))
+    monkeypatch.delenv("XORCISE_REST_PORT", raising=False)
+    monkeypatch.delenv("XORCISE_OTLP_PORT", raising=False)
+    (tmp_path / "logs").mkdir(parents=True)
+    from xorcise.core.config import get_settings
+
+    get_settings.cache_clear()
+    # No real network in a unit test: nothing answers on any port, unless a test says so.
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda host, port: None)
+    monkeypatch.setattr(lifecycle, "_foreign_instance_home", lambda host, port: None)
+    monkeypatch.setattr(lifecycle, "ports_in_use", lambda host, ports: [])
+    monkeypatch.setattr("xorcise.core.rest.reap.reap_managed_containers", lambda settings, **kw: [])
+    yield tmp_path
+    get_settings.cache_clear()
+
+
+def _instance(pid: int | None, rest: int = 3001, otlp: int = 4318) -> dict[str, object]:
+    """What `/api/system` of an instance of THIS home answers."""
+    return {
+        "home": os.environ["XORCISE_HOME"],
+        "pid": pid,
+        "planes": [
+            {"name": "rest", "location": f"127.0.0.1:{rest}"},
+            {"name": "otlp", "location": f"127.0.0.1:{otlp}"},
+        ],
+    }
+
+
+# ------------------------------------------------------------------------------- down (#72)
+
+
+def test_down_keeps_the_pid_file_and_fails_when_the_kill_is_refused(home, monkeypatch) -> None:
+    """PermissionError used to be swallowed into the success path: pid file unlinked, "stopped"
+    printed, exit 0 — and the still-running server could never be named again."""
+    (home / "xorcise.pid").write_text("1")
+
+    def refuse(pid, sig):
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(os, "kill", refuse)
+    # The server IS alive on its port (so this is not pid reuse) — but reports no pid.
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: _instance(None))
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 1
+    assert "could not stop XORCISE (pid 1)" in result.output
+    assert "left in place" in result.output
+    assert (home / "xorcise.pid").exists(), "a failed kill must not erase the only record"
+
+
+def test_down_treats_an_unsignalable_pid_with_no_server_behind_it_as_stale(home, monkeypatch):
+    """pid reuse: the pid file names a root-owned process, but nothing of this home answers on
+    any port — the server is long gone, the record is stale, and `down` is a clean no-op."""
+    (home / "xorcise.pid").write_text("1")
+
+    def refuse(pid, sig):
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(os, "kill", refuse)
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 0
+    assert "pid reuse" in result.output
+    assert not (home / "xorcise.pid").exists()
+
+
+def test_down_fails_when_the_process_survives_sigkill(home, monkeypatch) -> None:
+    (home / "xorcise.pid").write_text("4242")
+    monkeypatch.setattr(os, "kill", lambda pid, sig: None)  # every signal "delivered", never dies
+    monkeypatch.setattr(lifecycle, "_await_exit", lambda pid, **kw: False)
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 1
+    assert "did not exit after SIGKILL" in result.output
+    assert (home / "xorcise.pid").exists()
+
+
+def test_down_stops_an_orphaned_instance_the_pid_file_does_not_name(home, monkeypatch) -> None:
+    """The #73 aftermath: the pid file names the SECOND instance; the first (orphaned by the
+    overwrite) still serves the configured port. `down` used to kill only the recorded pid and
+    report "stopped" while the orphan kept serving."""
+    (home / "xorcise.pid").write_text("2000")
+    (home / "runtime-ports.json").write_text('{"rest": 3002, "otlp": 4319}')
+    signalled: list[int] = []
+    alive = {2000, 1000}
+
+    def kill(pid, sig):
+        if pid not in alive:
+            raise ProcessLookupError
+        if sig != 0:
+            signalled.append(pid)
+            alive.discard(pid)  # exits on the first signal
+
+    monkeypatch.setattr(os, "kill", kill)
+    # The orphan answers on the CONFIGURED port (3001) and reports its pid; 3002 is now free.
+    monkeypatch.setattr(
+        lifecycle,
+        "_same_home_instance_on",
+        lambda h, p: _instance(1000) if p == 3001 and 1000 in alive else None,
+    )
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 0
+    assert signalled == [2000, 1000]  # the recorded pid, then the orphan it found by port
+    assert "orphaned instance of this home (pid 1000)" in result.output
+    assert alive == set()
+
+
+def test_down_refuses_to_claim_stopped_when_an_old_instance_cannot_name_its_pid(home, monkeypatch):
+    (home / "xorcise.pid").write_text("2000")
+    monkeypatch.setattr(os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: _instance(None))
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 1
+    assert "still answers on port 3001" in result.output
+    assert "ss -tlnp" in result.output
+
+
+def test_down_names_a_foreign_holder_of_the_port_without_failing(home, monkeypatch) -> None:
+    """Another home's instance on the default ports is a fact, not a failure of THIS down."""
+    monkeypatch.setattr(lifecycle, "ports_in_use", lambda host, ports: [3001])
+    monkeypatch.setattr(lifecycle, "_foreign_instance_home", lambda h, p: "/other/home")
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 0
+    assert "held by the XORCISE instance at /other/home" in result.output
+
+
+# --------------------------------------------------------------------------------- up (#73)
+
+
+def _up_never_spawns(monkeypatch) -> None:
+    import subprocess
+
+    def boom(*a, **k):
+        raise AssertionError("up must not spawn a second server")
+
+    monkeypatch.setattr(subprocess, "Popen", boom)
+    monkeypatch.setattr(lifecycle, "_require_prerequisites", lambda *, stub=False: None)
+
+
+def test_up_adopts_a_live_instance_when_the_pid_file_is_gone(home, monkeypatch) -> None:
+    """The record was lost (a failed `down`, #72) but this home's server still answers on the
+    REST port: converge, repair the record from what it reports — never boot a second one."""
+    _up_never_spawns(monkeypatch)
+    monkeypatch.setattr(lifecycle, "_ensure_db_ready", lambda: pytest.fail("DB touched"))
+    monkeypatch.setattr(
+        lifecycle, "_same_home_instance_on", lambda h, p: _instance(777, rest=3001, otlp=4318)
+    )
+    result = runner.invoke(app, ["up"])
+    assert result.exit_code == 0
+    assert "already running (pid record repaired)" in result.output
+    assert (home / "xorcise.pid").read_text() == "777"
+    from xorcise.core.home import read_runtime_ports
+
+    assert read_runtime_ports() == {"rest": 3001, "otlp": 4318}
+
+
+def test_up_adopts_a_live_instance_when_the_pid_file_is_stale(home, monkeypatch) -> None:
+    _up_never_spawns(monkeypatch)
+    (home / "xorcise.pid").write_text("999999")  # nobody home at this pid
+
+    def kill(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(os, "kill", kill)
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: _instance(778))
+    result = runner.invoke(app, ["up"])
+    assert result.exit_code == 0
+    assert (home / "xorcise.pid").read_text() == "778"
+
+
+def test_up_looks_where_the_lost_instance_could_be(home, monkeypatch) -> None:
+    """The configured port, the runtime record's port and `--port` are all asked."""
+    _up_never_spawns(monkeypatch)
+    (home / "runtime-ports.json").write_text('{"rest": 3005}')
+    asked: list[int] = []
+
+    def answer(h, p):
+        asked.append(p)
+        return _instance(779, rest=p) if p == 3009 else None
+
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", answer)
+    result = runner.invoke(app, ["up", "--port", "3009"])
+    assert result.exit_code == 0
+    assert asked == [3001, 3005, 3009]
+    assert (home / "xorcise.pid").read_text() == "779"
+
+
+def test_up_still_boots_when_only_a_foreign_instance_holds_the_port(home, monkeypatch) -> None:
+    """A different home on the default port is what auto-increment is for — proceed."""
+    import subprocess
+    from types import SimpleNamespace
+
+    import httpx
+
+    monkeypatch.setattr(lifecycle, "_require_prerequisites", lambda *, stub=False: None)
+    monkeypatch.setattr(lifecycle, "ensure_frontend_ready", lambda console: None)
+    monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: {**wanted, "rest": 3002})
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: SimpleNamespace(pid=4321))
+    monkeypatch.setattr(httpx, "get", lambda url, timeout=1: SimpleNamespace(status_code=200))
+    # `_same_home_instance_on` is already "nobody of THIS home" from the fixture.
+    result = runner.invoke(app, ["up", "--stub"])
+    assert result.exit_code == 0, result.output
+    assert "busy" in result.output and "3002" in result.output
+    assert (home / "xorcise.pid").read_text() == "4321"
+
+
+# --------------------------------------------------------------------------- db upgrade (#74)
+
+
+def test_db_upgrade_refuses_while_a_server_of_this_home_is_running(home, monkeypatch) -> None:
+    (home / "xorcise.pid").write_text(str(os.getpid()))  # a live pid: this test process
+    ran: list[int] = []
+
+    def _upgrade() -> str:
+        ran.append(1)
+        return "ran"
+
+    monkeypatch.setattr("xorcise.core.cli.commands.db._upgrade", _upgrade)
+    result = runner.invoke(app, ["db", "upgrade"])
+    assert result.exit_code == 1
+    assert f"XORCISE is running (pid {os.getpid()})" in result.output
+    assert "xorcise down" in result.output
+    assert ran == []
+
+
+def test_db_upgrade_refuses_when_only_the_port_reveals_the_server(home, monkeypatch) -> None:
+    """No pid file (the #72 aftermath) — the REST port still says an instance is up."""
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: _instance(None))
+    monkeypatch.setattr("xorcise.core.cli.commands.db._upgrade", lambda: "ran")
+    result = runner.invoke(app, ["db", "upgrade"])
+    assert result.exit_code == 1
+    assert "port 3001" in result.output
+
+
+def test_db_upgrade_force_overrides_the_guard(home, monkeypatch) -> None:
+    (home / "xorcise.pid").write_text(str(os.getpid()))
+    monkeypatch.setattr("xorcise.core.cli.commands.db._upgrade", lambda: "migrations: ran")
+    result = runner.invoke(app, ["db", "upgrade", "--force"])
+    assert result.exit_code == 0
+    assert "migrations: ran" in result.output
+
+
+def test_db_upgrade_runs_when_nothing_is_live(home, monkeypatch) -> None:
+    monkeypatch.setattr("xorcise.core.cli.commands.db._upgrade", lambda: "migrations: ran")
+    result = runner.invoke(app, ["db", "upgrade"])
+    assert result.exit_code == 0
+
+
+def test_stale_db_refusal_says_to_stop_the_server_first(home, monkeypatch, capsys) -> None:
+    """The one boot-time guard used to route operators straight into the unguarded path."""
+    from xorcise.core import db
+
+    monkeypatch.setattr(db, "boot_state", lambda: "stale")
+    with pytest.raises(typer.Exit):
+        lifecycle._ensure_db_ready()
+    assert "xorcise down" in capsys.readouterr().err

--- a/tests/unit/test_lifecycle_guards.py
+++ b/tests/unit/test_lifecycle_guards.py
@@ -225,7 +225,7 @@ def test_up_still_boots_when_only_a_foreign_instance_holds_the_port(home, monkey
     monkeypatch.setattr(lifecycle, "ensure_frontend_ready", lambda console: None)
     monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: {**wanted, "rest": 3002})
     monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: SimpleNamespace(pid=4321))
-    monkeypatch.setattr(httpx, "get", lambda url, timeout=1: SimpleNamespace(status_code=200))
+    monkeypatch.setattr(httpx, "get", lambda url, **k: SimpleNamespace(status_code=200))
     # `_same_home_instance_on` is already "nobody of THIS home" from the fixture.
     result = runner.invoke(app, ["up", "--stub"])
     assert result.exit_code == 0, result.output
@@ -283,3 +283,202 @@ def test_stale_db_refusal_says_to_stop_the_server_first(home, monkeypatch, capsy
     with pytest.raises(typer.Exit):
         lifecycle._ensure_db_ready()
     assert "xorcise down" in capsys.readouterr().err
+
+
+# ------------------------------------------------------------ review follow-ups (#82)
+
+
+def test_down_probes_the_recorded_port_even_though_it_unlinks_the_record(home, monkeypatch):
+    """The review's blocker. `_candidate_rest_ports` read runtime-ports.json, but `down` unlinked
+    that file before the sweep — so the instance that auto-incremented to 3002 (exactly the #73
+    shape) was never probed and "stopped" was printed over it. The candidates are read first now."""
+    (home / "xorcise.pid").write_text("999999")  # stale: a dead pid
+    (home / "runtime-ports.json").write_text('{"rest": 3002, "otlp": 4319}')
+    killed: list[int] = []
+    alive = {4242}
+
+    def kill(pid, sig):
+        if pid not in alive:
+            raise ProcessLookupError
+        if sig != 0:
+            killed.append(pid)
+            alive.discard(pid)
+
+    monkeypatch.setattr(os, "kill", kill)
+    # Only 3002 answers, reporting a live pid 4242.
+    monkeypatch.setattr(
+        lifecycle,
+        "_same_home_instance_on",
+        lambda h, p: _instance(4242, rest=3002) if p == 3002 and 4242 in alive else None,
+    )
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 0, result.output
+    assert killed == [4242]
+    assert "orphaned instance of this home (pid 4242)" in result.output
+    assert not (home / "runtime-ports.json").exists()
+
+
+def test_down_verifies_release_on_the_recorded_ports_too(home, monkeypatch):
+    (home / "runtime-ports.json").write_text('{"rest": 3002, "otlp": 4319}')
+    probed: list[list[int]] = []
+
+    def record(h: str, ports: list[int]) -> list[int]:
+        probed.append(ports)
+        return []
+
+    monkeypatch.setattr(lifecycle, "ports_in_use", record)
+    assert runner.invoke(app, ["down"]).exit_code == 0
+    assert probed == [[3001, 3002, 4318, 4319]]
+
+
+def test_up_adopting_an_instance_without_a_pid_says_so_and_names_the_right_port(home, monkeypatch):
+    """Review: with no pid reported nothing was repaired, yet `up` printed "pid record repaired"
+    and advertised the CONFIGURED port's URL for an instance found on another port."""
+    _up_never_spawns(monkeypatch)
+    (home / "runtime-ports.json").write_text('{"rest": 3005}')  # a relocated instance, pid lost
+    monkeypatch.setattr(
+        lifecycle,
+        "_same_home_instance_on",
+        lambda h, p: _instance(None, rest=3005) if p == 3005 else None,
+    )
+    result = runner.invoke(app, ["up"])
+    assert result.exit_code == 0
+    assert "repaired" not in result.output
+    assert "pid is not known" in result.output
+    assert ":3005/ui" in result.output and ":3001/ui" not in result.output
+    assert not (home / "xorcise.pid").exists()  # nothing to write
+    from xorcise.core.home import read_runtime_ports
+
+    assert read_runtime_ports() == {"rest": 3005, "otlp": 4318}  # what lets `down` find it
+
+
+def test_an_undetermined_port_fails_up_closed(home, monkeypatch):
+    """A port of ours accepted but did not answer (hung server, proxy stall): booting past it is
+    the duplicate-instance outcome the guard exists for, so `up` refuses and says why."""
+    _up_never_spawns(monkeypatch)
+    monkeypatch.setattr(lifecycle, "_ensure_db_ready", lambda: pytest.fail("DB touched"))
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: lifecycle.UNDETERMINED)
+    result = runner.invoke(app, ["up"])
+    assert result.exit_code == 1
+    assert "did not answer /api/system" in result.output and "port 3001" in result.output
+
+
+def test_an_undetermined_port_fails_db_upgrade_closed_and_force_overrides(home, monkeypatch):
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: lifecycle.UNDETERMINED)
+    monkeypatch.setattr("xorcise.core.cli.commands.db._upgrade", lambda: "migrations: ran")
+    result = runner.invoke(app, ["db", "upgrade"])
+    assert result.exit_code == 1 and "Not migrating" in result.output
+    assert runner.invoke(app, ["db", "upgrade", "--force"]).exit_code == 0
+
+
+def test_an_undetermined_port_fails_down_closed(home, monkeypatch):
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: lifecycle.UNDETERMINED)
+    result = runner.invoke(app, ["down"])
+    assert result.exit_code == 1
+    assert "did not answer /api/system" in result.output
+
+
+def test_db_upgrade_guard_holds_for_a_direct_call(home, monkeypatch):
+    """Review: `bool(typer.Option(False))` is True, so `if force:` skipped the guard whenever
+    db_upgrade() was called directly (a test, a script, a future internal caller)."""
+    from xorcise.core.cli.commands import db as db_cmd
+
+    (home / "xorcise.pid").write_text(str(os.getpid()))
+    ran: list[int] = []
+
+    def _upgrade() -> str:
+        ran.append(1)
+        return "ran"
+
+    monkeypatch.setattr(db_cmd, "_upgrade", _upgrade)
+    with pytest.raises(typer.Exit):
+        db_cmd.db_upgrade()  # default = the OptionInfo, not False
+    assert ran == []
+
+
+@pytest.mark.parametrize("bad", [True, 0, -1, 2**40, "4242", None])
+def test_pids_from_a_json_body_are_validated_before_any_signal(home, monkeypatch, bad):
+    """Review: `isinstance(True, int)` is True and os.kill(0, SIGTERM) signals the caller's whole
+    process group. Nothing from /api/system reaches os.kill without `_valid_pid`."""
+    signalled: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: signalled.append(pid))
+    monkeypatch.setattr(lifecycle, "_same_home_instance_on", lambda h, p: _instance(bad))
+    result = runner.invoke(app, ["down"])
+    assert signalled == []
+    assert result.exit_code == 1 and "usable pid" in result.output
+
+
+def test_a_pid_file_past_c_long_is_stale_not_a_traceback(home, monkeypatch):
+    """Review: a huge value raised OverflowError from os.kill, which `except ValueError` did not
+    catch — `up`/`down`/`db upgrade` died with a raw traceback."""
+    (home / "xorcise.pid").write_text(str(10**29))
+    _up_never_spawns(monkeypatch)
+    import subprocess
+    from types import SimpleNamespace
+
+    import httpx
+
+    monkeypatch.setattr(lifecycle, "ensure_frontend_ready", lambda console: None)
+    monkeypatch.setattr(lifecycle, "resolve_ports", lambda host, wanted: dict(wanted))
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: SimpleNamespace(pid=4321))
+    monkeypatch.setattr(httpx, "get", lambda url, timeout=1, **k: SimpleNamespace(status_code=200))
+    result = runner.invoke(app, ["up", "--stub"])
+    assert result.exit_code == 0, result.output  # the corrupt record was dropped, not fatal
+    assert (home / "xorcise.pid").read_text() == "4321"
+    result = runner.invoke(app, ["down"])  # and down reads it as nothing to signal
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_probes_never_use_the_proxy_environment(monkeypatch):
+    """Review: httpx defaults to trust_env=True with no loopback bypass, so HTTP_PROXY diverted the
+    probe and a dead proxy read as "nothing running" — the failure the probe exists to prevent."""
+    import httpx
+
+    seen: list[dict[str, object]] = []
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"home": os.environ.get("XORCISE_HOME", ""), "pid": 4242}
+
+    def fake_get(url, **kwargs):
+        seen.append(kwargs)
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    lifecycle._probe_system("127.0.0.1", 3001)
+    lifecycle._foreign_instance_home("127.0.0.1", 3001)
+    assert seen and all(k.get("trust_env") is False for k in seen)
+
+
+def test_probe_distinguishes_refused_from_undetermined(monkeypatch):
+    import httpx
+
+    def refused(url, **k):
+        raise httpx.ConnectError("refused")
+
+    def timed_out(url, **k):
+        raise httpx.ReadTimeout("slow")
+
+    monkeypatch.setattr(httpx, "get", refused)
+    assert lifecycle._probe_system("127.0.0.1", 3001) is None  # nothing there
+    monkeypatch.setattr(httpx, "get", timed_out)
+    assert lifecycle._probe_system("127.0.0.1", 3001) is lifecycle.UNDETERMINED  # cannot tell
+
+    class _Resp:
+        def __init__(self, status: int, body: object) -> None:
+            self.status_code, self._body = status, body
+
+        def json(self) -> object:
+            if isinstance(self._body, ValueError):
+                raise self._body
+            return self._body
+
+    # A plain web service on the port (HTML 404) is FOREIGN, not undetermined — `up` must still
+    # auto-increment past it rather than refuse to boot behind it forever.
+    monkeypatch.setattr(httpx, "get", lambda url, **k: _Resp(404, ValueError("not json")))
+    assert lifecycle._probe_system("127.0.0.1", 3001) is None
+    # A 5xx is a server that exists and is broken — possibly a sick instance of ours: cannot tell.
+    monkeypatch.setattr(httpx, "get", lambda url, **k: _Resp(500, {"detail": "boom"}))
+    assert lifecycle._probe_system("127.0.0.1", 3001) is lifecycle.UNDETERMINED

--- a/tests/unit/test_lifecycle_polish.py
+++ b/tests/unit/test_lifecycle_polish.py
@@ -83,7 +83,7 @@ def test_up_tty_prints_update_notice_after_banner(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(lifecycle, "_maybe_provision_headscale", lambda *a, **k: "skip-stub")
     monkeypatch.setattr(lifecycle, "pid_file", lambda: tmp_path / "pid")
     monkeypatch.setattr(f"{_LC}.subprocess.Popen", lambda cmd, **kw: SimpleNamespace(pid=4321))
-    monkeypatch.setattr(f"{_LC}.httpx.get", lambda url, timeout=1: SimpleNamespace(status_code=200))
+    monkeypatch.setattr(f"{_LC}.httpx.get", lambda url, **kw: SimpleNamespace(status_code=200))
     monkeypatch.setattr(
         lifecycle,
         "begin_update_check",

--- a/tests/unit/test_system_rest.py
+++ b/tests/unit/test_system_rest.py
@@ -23,3 +23,13 @@ def test_system_reports_role_planes_db_catalog(migrated_home) -> None:
     assert body["db_schema"] in {"head", "behind", "fresh", "unknown"}
     assert "state" in body["catalog"]
     assert isinstance(body["remotes"], list)
+
+
+@pytest.mark.unit
+def test_system_reports_the_serving_pid(migrated_home) -> None:
+    """`down`/`up`/`db upgrade` find an instance whose pid file is gone by asking its port; the
+    pid is what lets them stop it or repair the record instead of orphaning it (#72/#73)."""
+    import os
+
+    body = _client().get("/api/system").json()
+    assert body["pid"] == os.getpid()  # TestClient serves in-process

--- a/tests/unit/test_up_builds_frontend.py
+++ b/tests/unit/test_up_builds_frontend.py
@@ -51,7 +51,7 @@ def test_up_builds_frontend_before_spawning_serve(tmp_path, monkeypatch) -> None
     monkeypatch.setattr("xorcise.core.cli.commands.lifecycle.subprocess.Popen", _popen)
     monkeypatch.setattr(
         "xorcise.core.cli.commands.lifecycle.httpx.get",
-        lambda url, timeout=1: SimpleNamespace(status_code=200),
+        lambda url, **kw: SimpleNamespace(status_code=200),
     )
 
     try:


### PR DESCRIPTION
> Stacked on #81 (`fix/boot-singletons`), which is stacked on #80. Review the diff against `fix/boot-singletons`; merge in order.

## What changed

`up`, `down` and `db upgrade` now agree on one question — *is a server of this home running?* — and answer it from more than the pid file (`lifecycle._live_instance`): the pid file when it names a live process, otherwise `/api/system` on every REST port an instance of this home could be on (the configured port, the runtime record's port, `--port`). `/api/system` gains a `pid` field so a found instance can be stopped or re-recorded.

- **`down` (#72)** — `_stop_process` reports what actually happened (`stopped` / `gone` / `unsignalable` / `survived`) instead of `contextlib.suppress`-ing `PermissionError` into "stopped". A kill that is refused or a process that outlives SIGKILL is a **failure**: the pid named, the pid file **left in place**, exit 1. An unsignalable pid that no instance of this home claims is pid reuse: the stale record is dropped. After the recorded pid, `down` **sweeps the ports** and stops any instance of this home still answering, by the pid it reports (an older server that cannot report one is refused with an `ss -tlnp` hint, never silently left behind). "stopped" is claimed only after checking the ports are released; a foreign holder is named in one line, not treated as a failure.
- **`up` (#73)** — before touching anything, `_live_instance` runs. An instance of this home found by probe (pid file gone or stale) is **adopted**: pid file and runtime-ports record are repaired from what it reports, "already running (pid record repaired)", exit 0. No second instance, and `_ensure_db_ready` is never reached while a sibling holds the DB. A foreign home's instance still auto-increments as before.
- **`db upgrade` (#74)** — refuses while an instance of this home is live (by pid or by port), naming it and the sequence `xorcise down` → `xorcise db upgrade` → `xorcise up`; `--force` overrides. The boot-time stale-DB refusal now says to stop the server *first*, instead of routing operators straight into the unguarded path.
- `SystemInfo.pid` (contracts) / `build_system_info` sets `os.getpid()`. Additive, optional.

## Why

Closes #72, closes #73, closes #74.

One incident, three gaps: a `down` whose kill failed unlinked the pid file and printed "stopped" (the server kept serving :3001, now unfindable); the next `up` saw only a busy port, auto-incremented and booted a second instance of the same home over the same SQLite file; `db upgrade` then rebuilt the `runs`/`results` tables (SQLite batch mode: copy, swap, rename `mission_version` → `install_revision`) underneath the older server, whose ORM was suddenly wrong about tables it had open.

**Not in this PR:** the optional `BEGIN IMMEDIATE` sentinel lock suggested in #74 — the liveness checks cover the reported path; a lock would be a second line of defence with SQLite-specific semantics worth its own change. Also the checked-in `frontend/openapi.json` / `schema.ts` snapshot: regenerating it here produced formatting noise unrelated to the one added field (whatever produced the current file is not `json.dump`), so it is left for the owner of that codegen step; the frontend does not read `pid`.

## Testing

```
$ uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run lint-imports
All checks passed! / already formatted / Success: no issues found in 492 source files / Contracts: 4 kept, 0 broken.
$ uv run pytest -m unit -n auto -q          → 2177 passed
$ uv run pytest -m "adapters or topology" -q → 179 passed
```

New: `tests/unit/test_lifecycle_guards.py` (15 tests — refused kill keeps the pid file and exits 1; unsignalable pid with nothing behind it is stale; survives-SIGKILL fails; orphan the pid file does not name is found by port and stopped; old server that cannot name its pid is refused with the `ss` hint; foreign holder is named without failing; `up` adopts a live instance when the pid file is gone / stale, repairs both records, asks configured + recorded + `--port`, and still boots past a foreign instance; `db upgrade` refuses by pid, refuses by port, `--force` overrides, runs when nothing is live; the stale-DB message names `xorcise down`). `test_system_rest.py` asserts `pid`. One existing `down` test re-seamed (its `os.kill` stub never let the process "exit", which the verified stop now correctly reports).

**Empirical — the real CLI (`up --stub` / `down` / `db upgrade`, isolated `XORCISE_HOME`, stub mode) from the previous tree and from this branch:**

| Scenario | Before | After |
|---|---|---|
| **A** `up`; pid file overwritten with `1` (root-owned → `PermissionError`); `down` | exit 0, "stopped", pid file **gone**, server **alive**, 3 listeners still up — permanently orphaned | `pid 1 … is not XORCISE (pid reuse) — dropping the stale record`, then `stopped an orphaned instance of this home (pid 1107211) that was still serving port 57619`; server gone, 0 listeners, exit 0 |
| **B** `up`; pid file deleted; `up` again | second instance booted on port+1 (`… is busy — using …`), pid file now names it, **2 serve processes** of one home on one DB | `already running (pid record repaired) — UI at …`; pid file restored to the first pid, **1 process**, nothing on port+1 |
| **C** `up`; `db upgrade` with the server live | exit 0, `migrations: upgraded to head` — migrated under a live server, no warning | exit 1: `XORCISE is running (pid 1110919) and holds this database open … Stop it first: xorcise down, then xorcise db upgrade, then xorcise up`; `--force` proceeds; `down` clean |
| **D** two instances of one home (orphan on the configured port, second in the pid file); `down` | exit 0 "stopped", orphan **alive** and serving | both built from this branch: `stopped an orphaned instance of this home (pid …) that was still serving port …`, both gone, both ports released, exit 0. Orphan built from the **old** tree (no `pid` in `/api/system`): exit 1, `an instance of this home still answers on port … but did not report its pid (an older server) — find it with ss -tlnp …` — refused honestly rather than reported stopped |

One thing the first run of this experiment caught: `/api/system` takes ~1.9 s cold (remote catalog probes on first hit) versus 0.15 s warm, so a 1 s probe timeout read a live server as "not ours". The instance probe uses an 8 s timeout (nothing listening still fails instantly on connection refused); `_foreign_instance_home` shares it.

**Test lanes affected**

- [x] `unit`
- [ ] `adapters`
- [ ] `topology`
- [x] `integration` — `up`/`down` lifecycle; validated by hand above
- [x] `e2e` — full `xorcise up`/`down`; please add `full-ci`
- [ ] `frontend`

## User-facing impact

- [x] Backwards-compatible addition (new command, new optional flag, new field)

`xorcise db upgrade --force` (new flag); `GET /api/system` gains optional `pid`. Behaviour changes: `down` can exit 1 where it used to print "stopped" over a live server; `up` can print "already running (pid record repaired)" instead of booting a duplicate; `db upgrade` refuses while the server runs.

## Documentation

- [x] Documentation needed and tracked in a follow-up issue (link it) — the `db upgrade --force` flag and the new `down` failure mode belong on the CLI reference page (docs site is a separate repo); noting on #74.

## Dependencies

- [x] No dependency changes

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy` passes (strict)
- [x] `uv run lint-imports` passes (architecture layer rules)
- [x] Relevant test lanes pass locally
- [x] No secrets, credentials, tokens, keys, internal hostnames or customer data in the diff
- [x] No references to internal-only systems

---

- [x] I have signed the Contributor License Agreement.
