### PR TITLE
fix(frontend): call CSS.escape through CSS, and group the frontend dependency sets that must move together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,42 @@ updates:
     labels:
       - dependencies
     groups:
+      # Packages that must move TOGETHER, majors included. A partial bump of either set is not
+      # a smaller change than the whole one — it is a broken one, and Dependabot cannot know
+      # that, so it is said here.
+      #
+      # react: `react` and `react-dom` must be on the same major (a 19 renderer against an 18
+      # core is unsupported), and the two @types packages describe them. Bumped one at a time
+      # they produce a PR that cannot pass; bumped together they produce a React migration PR
+      # that can be reviewed as one.
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      # test-toolchain: @vitejs/plugin-react peers on a specific Vite MAJOR (6.x wants
+      # vite ^8), and this project has no direct Vite dependency — it gets Vite from vitest.
+      # So the plugin can only move when vitest moves. Deliberately NOT including jsdom: it is
+      # the DOM implementation the tests run against, versioned independently of Vite, and
+      # coupling it here would hold a good jsdom bump behind a vitest major.
+      test-toolchain:
+        patterns:
+          - vitest
+          - "@vitejs/plugin-react"
+      # Everything else, minor and patch only.
       frontend-minor-patch:
         update-types:
           - minor
           - patch
+    ignore:
+      # @types/node must track the Node this project RUNS, never lead it: package.json
+      # declares engines.node ">=22 <23" and .nvmrc pins 22. Types for a newer Node make
+      # `tsc --noEmit` accept APIs that do not exist at runtime, which turns the typecheck
+      # from evidence into noise. Raise this the same day engines.node moves, not before.
+      # Minor/patch still flow, and `ignore` never suppresses security updates.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # Grouped into one PR: a single reviewable PR actually gets merged, which is what keeps the
   # SHA pins current.

--- a/frontend/src/features/replay/replay-timeline.tsx
+++ b/frontend/src/features/replay/replay-timeline.tsx
@@ -415,9 +415,13 @@ export function ReplayTimeline({
     const root = scrollRef.current;
     if (!root) return;
     // Ids can contain CSS-hostile characters (":", "="); CSS.escape may be absent in old jsdom.
+    // Called THROUGH `CSS`, never as a detached reference: it is an interface static, and
+    // jsdom's generated IDL wrapper rejects a call whose receiver is not `CSS` itself
+    // ("'escape' called on an object that is not a valid instance of CSS") even though
+    // browsers tolerate it.
     const esc =
       typeof CSS !== "undefined" && typeof CSS.escape === "function"
-        ? CSS.escape
+        ? (s: string) => CSS.escape(s)
         : (s: string) => s.replace(/["\\]/g, "\\$&");
     const el = root.querySelector<HTMLElement>(`[data-event-id="${esc(selectedEventId)}"]`);
     if (!el) return;


### PR DESCRIPTION
## What changed

Two things, both in service of getting the frontend Dependabot queue moving again.

**1. `CSS.escape` is called through `CSS`** (`replay-timeline.tsx`). It was assigned as a bare
function reference, so the call had no receiver:

```diff
-        ? CSS.escape
+        ? (s: string) => CSS.escape(s)
```

Browsers tolerate a detached `CSS.escape`; jsdom's generated IDL wrapper does not. Under
jsdom 30 the replay timeline's scroll-into-view effect throws
`TypeError: 'escape' called on an object that is not a valid instance of CSS`, failing five
tests in `replay-timeline.test.tsx`. It is latent on the current jsdom 25, which resolves the
same reference without checking the receiver — so this is a correctness fix per the WebIDL
binding, not a test-only accommodation.

**2. `.github/dependabot.yml` groups the sets that must move together**, and ignores
`@types/node` majors.

## Why

Three frontend Dependabot PRs could never pass, for reasons Dependabot cannot see from a
version number:

| PR | Proposed | Why it cannot merge alone |
|---|---|---|
| #11 | `react-dom` + `@types/react-dom` → 19 | leaves `react`/`@types/react` at 18; the two must share a major |
| #8 | `@vitejs/plugin-react` → 6 | peers on `vite: ^8`; this project has no direct Vite dep — it gets vite 5.4.21 from vitest 2 |
| #10 | `@types/node` → 26 | `engines.node` is `">=22 <23"`, `.nvmrc` is `22`; types that lead the runtime make `tsc` accept absent APIs |

Grouping `react`/`react-dom`/`@types/react`/`@types/react-dom`, and `vitest` with
`@vitejs/plugin-react`, means each set arrives as one coherent, reviewable PR instead of a
partial bump that is broken on arrival. Nothing is suppressed — both groups will re-raise
these.

`jsdom` is **deliberately excluded** from the vitest group: it is the DOM implementation the
tests run against, versioned independently of Vite, and coupling it would hold a good jsdom
bump behind a vitest major. #9 (jsdom → 30) merges on its own once this lands.

`@types/node` majors are the one `ignore`, with the reason recorded next to the rule. `ignore`
suppresses version bumps only; security updates are unaffected.

## Testing

The `CSS.escape` fix, with jsdom actually installed at each version:

| | jsdom 30 (what #9 proposes) | jsdom 25 (current `main`) |
|---|---|---|
| `replay-timeline.test.tsx` before the fix | **5 failed** / 35 | 35 passed |
| `replay-timeline.test.tsx` after | 35 passed | 35 passed |
| full frontend suite after | **734 passed** (100 files) | **734 passed** (100 files) |
| `tsc --noEmit` after | clean | clean |

So the fix is correct on the version we have and unblocks the one we want, in both directions.

Repo gate: `ruff check` / `ruff format --check` clean, `dependabot.yml` parses.

**Test lanes affected**

- [ ] `unit` / `adapters` / `topology` / `integration` / `e2e` — untouched
- [x] `frontend` — the five previously-failing tests are the coverage

## User-facing impact

- [x] No user-visible change

The `CSS.escape` path is a scroll-into-view effect that already worked in browsers; nothing
about the rendered console changes. The config change alters only how future dependency PRs
are proposed.

## Documentation

- [x] No documentation change needed

## Dependencies

- [x] No dependency changes — this PR changes no installed version. It makes #9 mergeable and
      re-shapes how #8/#10/#11 will be re-proposed.

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] Frontend typecheck + tests pass (on both jsdom versions)
- [x] No secrets, credentials, tokens, keys, internal hostnames or customer data in the diff
- [x] No references to internal-only systems

Closes #8
Closes #10
Closes #11
