### PR TITLE
ci: run the Docker-heavy lanes on any PR that changes more than docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,18 +110,77 @@ jobs:
           fi
           uv run pytest "${args[@]}"
 
+  # Does this PR touch anything the Docker-heavy lanes could possibly exercise?
+  #
+  # Deliberately an INVERSE rule: heavy=true unless EVERY changed file is documentation. A list
+  # of paths that must trigger the lanes would have to be kept in sync with what
+  # tests/integration and tests/e2e import — which is most of src/xorcise/core — and a list like
+  # that desynchronises silently the first time someone adds a module. Skipping is the dangerous
+  # direction, so anything unrecognised runs them.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      heavy: ${{ steps.filter.outputs.heavy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Decide whether the heavy lanes are needed
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Fail SAFE: if the diff cannot be computed for any reason, run the lanes.
+          if ! files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA"); then
+            echo "could not diff $BASE_SHA..$HEAD_SHA — running the heavy lanes"
+            echo "heavy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          heavy=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              *.md|docs/*|LICENSE|.github/ISSUE_TEMPLATE/*|.github/*.md) ;;
+              *) heavy=true ;;
+            esac
+          done <<EOF
+          $files
+          EOF
+          echo "changed files:"
+          printf '%s\n' "$files" | sed 's/^/  /'
+          echo "heavy=$heavy"
+          echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
+
   # Docker-heavy lanes: real containers, Headscale, FIXED host ports (:3001, the tailnet) —
   # one matrix leg each so they never share a runner.
   #
-  # Not on every PR: a flaky required check teaches everyone to ignore CI, which is worse than
-  # catching a regression at merge. Runs on push-to-main, nightly, or a `full-ci` label —
-  # and `ci-ok` requires them whenever they do run.
+  # These used to run ONLY on push-to-main, nightly, or an opt-in `full-ci` label, to keep a
+  # potentially flaky required check off every PR. The cost of that showed up in #80/#81/#82: a
+  # three-PR stack rewriting `up`, `down`, `db upgrade` and the run-create gate went review-ready
+  # and green with these lanes never executed — two of the PRs asked for the label in their body
+  # and nobody applied it — and the first place they would have run was the merge commit on main.
+  #
+  # So they now run on any PR that changes something other than documentation (see `changes`).
+  # The label is kept as a manual override for a docs-only PR that still wants them. If this
+  # does turn out to be flaky in practice, narrow `changes`, do not go back to opt-in: a lane
+  # nobody remembers to ask for is a lane that does not run.
   test-heavy:
     name: test-heavy (${{ matrix.lane }})
     runs-on: ubuntu-latest
-    needs: smoke
+    needs: [smoke, changes]
     if: >-
       github.event_name == 'push' ||
+      needs.changes.outputs.heavy == 'true' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci')
     timeout-minutes: 45
     permissions:
@@ -404,7 +463,7 @@ jobs:
     name: ci-ok
     runs-on: ubuntu-latest
     if: always()
-    needs: [smoke, test, test-heavy, frontend, frontend-e2e, build-dist, lint-actions]
+    needs: [smoke, changes, test, test-heavy, frontend, frontend-e2e, build-dist, lint-actions]
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -419,6 +478,7 @@ jobs:
           LINT_ACTIONS: ${{ needs.lint-actions.result }}
           EVENT: ${{ github.event_name }}
           HAS_FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+          HEAVY_NEEDED: ${{ needs.changes.outputs.heavy }}
         run: |
           set -uo pipefail
           status=0
@@ -445,16 +505,18 @@ jobs:
           done
 
           # test-heavy is conditional. It MUST succeed whenever it was supposed to run;
-          # `skipped` is only acceptable on a pull request that did not ask for it.
+          # `skipped` is only acceptable on a documentation-only pull request that did not ask
+          # for it. This condition MIRRORS the `if:` on test-heavy — if the two ever disagree,
+          # the gate either demands a job that never ran or waves through one that should have.
           heavy_required=false
-          if [ "$EVENT" = "push" ] || [ "$HAS_FULL_CI" = "true" ]; then
+          if [ "$EVENT" = "push" ] || [ "$HAS_FULL_CI" = "true" ] || [ "$HEAVY_NEEDED" = "true" ]; then
             heavy_required=true
           fi
 
           if [ "$TEST_HEAVY" = "success" ]; then
             printf 'ok       %-14s %s\n' "test-heavy" "$TEST_HEAVY"
           elif [ "$TEST_HEAVY" = "skipped" ] && [ "$heavy_required" = "false" ]; then
-            printf 'ok       %-14s %s (not required for this event; add the "full-ci" label to run it)\n' \
+            printf 'ok       %-14s %s (documentation-only change; add the "full-ci" label to run it anyway)\n' \
               "test-heavy" "$TEST_HEAVY"
           else
             printf 'FAILED   %-14s %s (required=%s)\n' "test-heavy" "$TEST_HEAVY" "$heavy_required"


### PR DESCRIPTION
## What changed

`test-heavy` (the `integration` and `e2e` lanes) now runs on any PR that changes something other
than documentation, instead of only on push-to-main, nightly, or an opt-in `full-ci` label.

A new `changes` job makes the decision, and does it by an **inverse** rule: `heavy=true` unless
*every* changed file is documentation.

```yaml
case "$f" in
  *.md|docs/*|LICENSE|.github/ISSUE_TEMPLATE/*|.github/*.md) ;;
  *) heavy=true ;;
esac
```

`ci-ok`'s `heavy_required` is updated to mirror the same condition — the two have to agree, or
the gate either demands a job that never ran or waves through one that should have.

## Why

From #87. The cost of opt-in showed up in the #80/#81/#82 stack: three PRs rewriting `up`,
`down`, `db upgrade`, `serve`'s bind path and the run-create nesting gate — precisely the surface
these lanes cover — sat review-ready with a green `ci-ok` and the lanes never executed. #81 and
#82 both **asked for the label in their own PR body**; nobody applied it. The first place those
lanes would have run was the merge commit on `main`.

### Why an inverse rule rather than a path list

The obvious implementation is a list of paths that trigger the lanes. I started there and
rejected it: `tests/integration` and `tests/e2e` import `roles.boot.role_all`, `rest.run_create`,
`rest.run_terminate`, `otel.store`, `otel.ingest.embedded`, `runcontrol.store`, `runs.observed`,
`missions.runtime`, `headscale`, `runner.docker.build`, `contracts.*` and `config` — most of
`src/xorcise/core`. A list covering that has to be maintained by hand, and it desynchronises
**silently** the first time someone adds a module: the lanes just stop running for it, which is
the same failure this PR exists to fix.

(That is also the argument I made against the hand-maintained address set in `find_free_port`
during the #81 review. It would be poor form to fix one and introduce the other.)

So the rule fails safe: anything unrecognised runs the lanes, and a diff that cannot be computed
runs them too.

### The flakiness concern in the original comment

The code being replaced said: *"Not on every PR: a flaky required check teaches everyone to
ignore CI, which is worse than catching a regression at merge."* That is a real concern and I
did not want to wave it away.

The evidence available: across today's work these lanes ran on 9 separate PR heads plus every
push to `main` — #80, #81, #82 (twice each through rebases), #85, #84/#89, #9, #70, #13/#90 — and
passed every time, in ~20-40 s per lane. That is not proof of zero flake, but it is a much better
basis than the state where they almost never ran.

The comment in the workflow records what to do if that turns out to be optimistic: **narrow
`changes`, do not return to opt-in.** A lane nobody remembers to ask for is a lane that does not
run.

The `full-ci` label still works, now as a manual override for a docs-only PR that wants the lanes
anyway.

## Testing

The classification logic, extracted and run against the cases that matter:

| changed files | heavy | |
|---|---|---|
| `README.md` | `false` | docs only |
| `docs/guide.md` + `CHANGELOG.md` | `false` | several docs |
| `.github/ISSUE_TEMPLATE/bug.yml` | `false` | issue template |
| `src/xorcise/core/cli/commands/lifecycle.py` | `true` | the #82 change |
| `README.md` + `src/.../run_create.py` | `true` | mixed — must run |
| `frontend/src/.../replay-timeline.tsx` | `true` | frontend code |
| `uv.lock` | `true` | dependency bump |
| `.github/workflows/ci.yml` | `true` | the workflow itself |
| `tests/e2e/test_run_real.py` | `true` | an e2e test |
| *(empty diff)* | `false` | |

10/10 as intended. `zizmor .github/workflows/ci.yml` → *No findings to report*. YAML parses and the
job graph resolves (`test-heavy.needs: [smoke, changes]`, `ci-ok.needs` includes `changes`).

**This PR is its own test case:** it changes `.github/workflows/ci.yml`, so `changes` must emit
`heavy=true` and both heavy lanes must run below. If they are skipped, the change does not work
and should not be merged.

**Test lanes affected**

- [x] `integration`, `e2e` — when they run, not what they do
- [ ] everything else — untouched

## User-facing impact

- [x] No user-visible change (CI only)

## Documentation

- [x] No documentation change needed — the rationale lives in the workflow comments

## Dependencies

- [x] No dependency changes. No new third-party action either: the diff is computed with
      `git diff` under the existing pinned `actions/checkout`, rather than adding a filter
      action to a repo that pins every `uses:` by SHA and lints with zizmor.

## Checklist

- [x] `zizmor` passes on the changed workflow
- [x] No secrets, credentials, tokens, keys, internal hostnames or customer data in the diff
- [x] No references to internal-only systems

Refs #87
