### PR TITLE
ci: the changes job must run on every event, or it skips the heavy lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,10 @@ jobs:
   changes:
     name: changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Runs on EVERY event, deliberately. This job carried `if: github.event_name ==
+    # 'pull_request'` for one commit, and a skipped job skips everything that `needs` it
+    # whatever the dependant's own `if` says — so on push-to-main `test-heavy` was skipped and
+    # `ci-ok`, which requires it there, failed. Guard the event INSIDE the step instead.
     timeout-minutes: 5
     permissions:
       contents: read
@@ -136,10 +139,18 @@ jobs:
       - name: Decide whether the heavy lanes are needed
         id: filter
         env:
+          EVENT: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Anything that is not a pull request (push to main, and any future trigger) runs the
+          # lanes unconditionally — there is no "changed files" question to ask.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "event=$EVENT — the heavy lanes always run"
+            echo "heavy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Fail SAFE: if the diff cannot be computed for any reason, run the lanes.
           if ! files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA"); then
             echo "could not diff $BASE_SHA..$HEAD_SHA — running the heavy lanes"


### PR DESCRIPTION
## What broke

`main` is red at `c08dc18` (#91) with every actual test passing. `ci-ok` failed because:

```
changes:                      skipped
test-heavy (${{ matrix.lane }}): skipped
ci-ok:                        failure
```

#91 gave `changes` `if: github.event_name == 'pull_request'`. **A skipped job skips everything
that `needs` it, whatever the dependant's own `if` says** — so on push-to-main `changes` skipped,
`test-heavy` skipped with it, and `ci-ok` correctly failed because the heavy lanes are required
on push.

The red build is the smaller problem. The real one: for one commit the heavy lanes ran on PRs but
**stopped running on push-to-main entirely** — the exact coverage #91 was written to add, removed
from the place it already existed.

## The fix

`changes` runs on every event, and the event is guarded *inside* the step instead:

```yaml
if [ "$EVENT" != "pull_request" ]; then
  echo "event=$EVENT — the heavy lanes always run"
  echo "heavy=true" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

Nothing is skipped, so nothing downstream is skipped. A push (or any future trigger) gets
`heavy=true` without being asked a changed-files question it has no base ref to answer.

## How this got through

#91's body said *"This PR is its own test case."* That was true and insufficient: a pull request
can only ever exercise the `pull_request` path. The `push` path had no test until it ran on
`main`, which is precisely the failure mode #87 is about — I reproduced the issue I was fixing,
one layer up.

Both branches are now covered:

| event | changed files | heavy | |
|---|---|---|---|
| `push` | *(n/a)* | `true` | **the case that broke** |
| `push` | `README.md` | `true` | push always runs them |
| `schedule` | *(n/a)* | `true` | any future trigger |
| `pull_request` | `README.md` | `false` | docs only |
| `pull_request` | `src/.../db.py` | `true` | code |
| `pull_request` | `.github/workflows/ci.yml` | `true` | the workflow |
| `pull_request` | *(empty)* | `false` | |

7/7. `zizmor` clean, YAML parses, `test-heavy.needs: [smoke, changes]` intact.

This PR still cannot exercise the push path before merging — that is inherent. What it can do is
guarantee the push path no longer depends on a conditional job existing, which is the property
that failed. I will confirm `test-heavy` actually runs on the merge commit.

**Test lanes affected**

- [x] `integration`, `e2e` — restores them on push-to-main

## User-facing impact

- [x] No user-visible change (CI only)

## Checklist

- [x] `zizmor` passes on the changed workflow
- [x] No secrets or internal references in the diff

Refs #87
