### PR TITLE
feat(docs): generate the documentation's screenshots from the real console

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -4,3 +4,7 @@ out/
 *.tsbuildinfo
 playwright-report/
 test-results/
+# Generated documentation screenshots. They are an OUTPUT of e2e/docs-screenshots.spec.ts and
+# their home is the docs repository's images/ — committing them here would fork the source of
+# truth and let the two copies drift apart, which is the problem the generator exists to solve.
+docs-screenshots/

--- a/frontend/e2e/docs-screenshots.spec.ts
+++ b/frontend/e2e/docs-screenshots.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The documentation's screenshots, generated from the real console.
+ *
+ * Every image on docs.xorcise.ai used to be shot by hand. By September they were five weeks
+ * stale and showed a console that no longer existed — the sidebar still said "Challenges"
+ * (renamed to "Missions" in July), the buttons still used the pre-design-system uppercase
+ * labels, and the Agents page was full of test debris like `test-cli-renamed`. Nobody had
+ * done anything wrong; hand-shot images simply have no way to notice the product moved.
+ *
+ * So they are generated instead. This spec drives the real UI against a seeded throwaway
+ * instance and writes PNGs the docs repository consumes directly.
+ *
+ * PREREQUISITES — this is not part of `npm run test:e2e`, because it needs seeded state and
+ * writes files. Run it deliberately:
+ *
+ *   export XORCISE_HOME=/tmp/xorcise-docs XORCISE_REST_PORT=3051 XORCISE_OTLP_PORT=4351
+ *   xorcise up --stub
+ *   python scripts/seed_docs_state.py --rest http://127.0.0.1:3051 --otlp http://127.0.0.1:4351
+ *   cd frontend && DOCS_RUN_ID=<the RUN_ID it printed> \
+ *     PLAYWRIGHT_BASE_URL=http://127.0.0.1:3051 \
+ *     npx playwright test e2e/docs-screenshots.spec.ts
+ *
+ * Output lands in `frontend/docs-screenshots/`. Copy into the docs repository's `images/`.
+ *
+ * WHY ELEMENT-SCOPED CROPS, NOT PIXEL BOXES: a step image wants the relevant control, not the
+ * whole 1440px page. Cropping by locator means a moved button still produces a correct crop,
+ * where a hardcoded bounding box silently photographs the wrong thing. It is also why there
+ * are no baked-in numbered markers: an annotated PNG cannot be regenerated without a human
+ * re-annotating it, which is the failure mode this whole spec exists to remove.
+ */
+
+const OUT = join(process.cwd(), "docs-screenshots");
+/**
+ * Two runs, because no single run renders both things the docs need. A run still in `created`
+ * shows the connect prompt and the launch-mode toggle but draws "No terrain yet" — the map
+ * appears once the run has left that state. A sealed run draws the full terrain and has a
+ * result, but has no prompt left to hand anyone. So the seed makes both.
+ */
+const RUN_ID = process.env.DOCS_RUN_ID ?? "";              // sealed: terrain + result
+const PENDING_RUN_ID = process.env.DOCS_PENDING_RUN_ID ?? ""; // created: prompt + launch mode
+
+/** Retina. The docs render these at up to ~1400 CSS px, so 1x looks soft on any modern display. */
+const VIEWPORT = { width: 1440, height: 900 } as const;
+
+test.use({ viewport: VIEWPORT, deviceScaleFactor: 2, colorScheme: "dark" });
+
+test.beforeAll(() => {
+  mkdirSync(OUT, { recursive: true });
+});
+
+/**
+ * Wait for the page to stop moving. `networkidle` alone is not enough: the terrain map and the
+ * timeline animate in after their data arrives, and a screenshot taken mid-transition shows
+ * half-drawn edges. The extra settle is empirical, not superstition.
+ */
+async function settle(page: Page, ms = 1200): Promise<void> {
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(ms);
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: join(OUT, `${name}.png`) });
+}
+
+test.describe("full-page console screenshots", () => {
+  test("dashboard", async ({ page }) => {
+    await page.goto("/ui/");
+    await settle(page);
+    await shot(page, "dashboard");
+  });
+
+  test("agents", async ({ page }) => {
+    await page.goto("/ui/agents/");
+    await expect(page.getByRole("heading", { name: "Agents", exact: true })).toBeVisible();
+    await settle(page);
+    await shot(page, "agents");
+  });
+
+  test("mission catalog", async ({ page }) => {
+    await page.goto("/ui/missions/");
+    await expect(page.getByRole("heading", { name: "Mission Catalog" })).toBeVisible();
+    await settle(page);
+    await shot(page, "missions");
+  });
+
+  test("run history", async ({ page }) => {
+    await page.goto("/ui/runs/");
+    await expect(page.getByRole("heading", { name: "Run history" })).toBeVisible();
+    await settle(page);
+    await shot(page, "runs");
+  });
+
+  test("performance", async ({ page }) => {
+    await page.goto("/ui/results/");
+    await expect(page.getByRole("heading", { name: "Performance" })).toBeVisible();
+    await settle(page);
+    await shot(page, "performance");
+  });
+
+  test("settings", async ({ page }) => {
+    await page.goto("/ui/settings/");
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await settle(page);
+    await shot(page, "settings");
+  });
+
+  test("setup", async ({ page }) => {
+    await page.goto("/ui/setup/");
+    await settle(page);
+    await shot(page, "setup");
+  });
+});
+
+test.describe("the live run page", () => {
+  test.skip(!RUN_ID, "DOCS_RUN_ID not set — seed an instance first (see the header comment)");
+
+  test("live run with terrain and trace", async ({ page }) => {
+    await page.goto(`/ui/runs/live/?id=${RUN_ID}`);
+    // The terrain map is the slowest thing on the page and the point of the screenshot.
+    // Role-scoped: the string "Terrain" also appears in the empty state, and a bare
+    // getByText matches both.
+    await expect(page.getByRole("heading", { name: "Terrain", exact: true })).toBeVisible();
+    await expect(page.getByText("No terrain yet.")).toHaveCount(0);
+    await settle(page, 2500);
+    await shot(page, "traces");
+  });
+
+  test("run result", async ({ page }) => {
+    await page.goto(`/ui/runs/result/?id=${RUN_ID}`);
+    await settle(page);
+    await shot(page, "results");
+  });
+});
+
+/**
+ * Step crops for guides/connect-your-agent, whose Web UI tabs were a sentence each with no
+ * image at all. Each crop is the control the step names — the crop IS the annotation.
+ */
+test.describe("step crops for connect-your-agent", () => {
+  test("register an agent", async ({ page }) => {
+    await page.goto("/ui/agents/new/");
+    await settle(page);
+    // The form card, not the whole page: the step is "fill this in", not "look at the console".
+    const form = page.locator("form").first();
+    await expect(form).toBeVisible();
+    await form.screenshot({ path: join(OUT, "step-register-agent.png") });
+  });
+
+  test("create a run", async ({ page }) => {
+    await page.goto("/ui/runs/new/");
+    await expect(page.getByRole("heading", { name: "New run" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Select agent" })).toBeVisible();
+    await settle(page);
+    await shot(page, "step-new-run");
+  });
+
+  /**
+   * NOT capturable under `--stub`, and the reason is worth recording rather than rediscovering.
+   *
+   * The prompt card renders only while the run is `awaitingAgent`, which needs the run's
+   * environment to reach `ready`. A stub environment never leaves `starting` — nothing is
+   * actually deployed — so the card never mounts. Sending telemetry does not help either: that
+   * marks the agent as connected, which ends the awaiting state from the other side.
+   *
+   * So this shot needs a REAL instance (Docker, a pulled mission, a deployed environment),
+   * photographed in the window after the environment is ready and before the agent connects.
+   * It skips rather than fails, so a stub-mode run of this spec is still green — but it does
+   * NOT silently write nothing, because the skip reason is the record.
+   */
+  test("the connect prompt and launch-mode toggle", async ({ page }) => {
+    test.skip(!PENDING_RUN_ID, "DOCS_PENDING_RUN_ID not set");
+    await page.goto(`/ui/runs/live/?id=${PENDING_RUN_ID}`);
+    await settle(page, 2000);
+    const toggle = page.getByText(/this host/i).first();
+    test.skip(
+      (await toggle.count()) === 0,
+      "no launch-mode toggle on this run — the prompt card needs a READY environment, which " +
+        "stub mode never reaches. Re-run against a real instance to capture this crop.",
+    );
+    await shot(page, "step-launch-mode");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "test": "vitest run",
     "test:e2e": "playwright test --grep-invert @no-server",
     "test:e2e:no-server": "playwright test --grep @no-server",
-    "codegen": "openapi-typescript openapi.json -o src/lib/api/schema.ts"
+    "codegen": "openapi-typescript openapi.json -o src/lib/api/schema.ts",
+    "screenshots": "playwright test e2e/docs-screenshots.spec.ts --reporter=list"
   },
   "dependencies": {
     "next": "^15",

--- a/scripts/seed_docs_state.py
+++ b/scripts/seed_docs_state.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Seed a XORCISE instance with the state the documentation screenshots need.
+
+Screenshots of an empty console are worse than no screenshots: they show empty states, and a
+reader comparing their own screen against one learns nothing. This script drives a running
+instance through the REST API and the OTLP receiver until every page the docs photograph has
+something real on it — registered agents, installed missions, and a run carrying genuine
+captured telemetry.
+
+It is deliberately NOT a fixture loader that writes to the database. Everything here goes
+through the same public surfaces an operator uses, so a change that breaks seeding is a change
+that broke the product, not the fixture.
+
+SAFETY: this creates agents, installs missions and starts runs. Point it ONLY at a throwaway
+instance — one booted with its own XORCISE_HOME and its own port. It refuses to run against
+the default port unless --i-know-this-is-not-my-real-instance is passed.
+
+Usage:
+    # boot a throwaway instance first
+    export XORCISE_HOME=/tmp/xorcise-docs XORCISE_REST_PORT=3051 XORCISE_OTLP_PORT=4351
+    xorcise up --stub
+
+    python scripts/seed_docs_state.py --rest http://127.0.0.1:3051 --otlp http://127.0.0.1:4351
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "otlp" / "claude_code_real_run.json"
+
+#: Agents to register. The three built-in harnesses, so the Agents page shows the real
+#: per-harness logos rather than three identical generic cards.
+AGENTS: tuple[tuple[str, str], ...] = (
+    ("scout", "claude-code"),
+    ("atlas", "openhands"),
+    ("probe", "codex"),
+)
+
+#: Missions to install. Two, so the catalog shows both installed and available states side by
+#: side — a catalog where everything is installed photographs as badly as an empty one.
+MISSIONS: tuple[str, ...] = ("chrono-canary", "breachpoint")
+
+#: The mission the screenshotted run is against. Its terrain is drawn on the live run page, so
+#: it wants to be a mission with an authored attack path rather than a bare one.
+RUN_MISSION = "chrono-canary"
+RUN_AGENT = "scout"
+
+
+def _request(method: str, url: str, body: object | None = None, timeout: float = 60.0) -> object:
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:300]
+        raise SystemExit(f"{method} {url} -> {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{method} {url} unreachable: {exc.reason}\nIs the instance up?") from exc
+
+
+def seed_agents(rest: str) -> None:
+    existing = {a["name"] for a in _request("GET", f"{rest}/api/agents")}  # type: ignore[union-attr]
+    for name, kind in AGENTS:
+        if name in existing:
+            print(f"  agent {name} already registered")
+            continue
+        _request("POST", f"{rest}/api/agents", {"name": name, "kind": kind})
+        print(f"  registered {name} ({kind})")
+
+
+def seed_missions(rest: str) -> None:
+    catalog = _request("GET", f"{rest}/api/missions")
+    by_id = {m["mission_id"]: m for m in catalog}  # type: ignore[union-attr]
+    for mission_id in MISSIONS:
+        entry = by_id.get(mission_id)
+        if entry is None:
+            print(f"  ! {mission_id} is not in this catalog — skipping")
+            continue
+        if entry.get("installed"):
+            print(f"  mission {mission_id} already installed")
+            continue
+        # Synchronous pull. Under --stub the driver is the stub, so no bytes move.
+        _request("POST", f"{rest}/api/missions/{mission_id}/pull", {}, timeout=900.0)
+        print(f"  installed {mission_id}")
+
+
+def create_run(rest: str) -> str:
+    run = _request(
+        "POST",
+        f"{rest}/api/runs",
+        {"agent": RUN_AGENT, "mission": RUN_MISSION, "budget_seconds": 1800},
+    )
+    run_id = run["run_id"]  # type: ignore[index]
+    print(f"  created run {run_id[:8]} ({RUN_AGENT} vs {RUN_MISSION})")
+    return str(run_id)
+
+
+def replay_telemetry(otlp: str, run_id: str) -> int:
+    """Replay a captured claude-code trace into the run, re-stamped with this run's id.
+
+    The payloads are real OTLP captured from a real agent, so the trace feed and the timeline
+    show an actual agent's prose and tool calls rather than lorem ipsum. Only the
+    `xorcise.run_id` resource attribute is rewritten — that attribute is how the collector
+    routes a batch to a run, and nothing else about the capture is touched.
+    """
+    if not FIXTURE.exists():
+        raise SystemExit(f"missing OTLP fixture: {FIXTURE}")
+    payloads = json.loads(FIXTURE.read_text())["records"]
+    for record in payloads:
+        payload = record["payload"]
+        for resource_span in payload.get("resourceSpans", []):
+            attrs = [
+                a
+                for a in resource_span.setdefault("resource", {}).setdefault("attributes", [])
+                if a.get("key") != "xorcise.run_id"
+            ]
+            attrs.append({"key": "xorcise.run_id", "value": {"stringValue": run_id}})
+            resource_span["resource"]["attributes"] = attrs
+        _request("POST", f"{otlp}/v1/traces", payload, timeout=30.0)
+    print(f"  replayed {len(payloads)} OTLP batch(es)")
+    return len(payloads)
+
+
+def seal(rest: str, run_id: str) -> None:
+    """Terminate and wait for grading, so the result page has something to render."""
+    _request("POST", f"{rest}/api/runs/{run_id}/terminate", {}, timeout=120.0)
+    for _ in range(30):
+        result = _request("GET", f"{rest}/api/runs/{run_id}/result")
+        if not isinstance(result, dict) or result.get("status") != "grading":
+            print("  run sealed and graded")
+            return
+        time.sleep(2)
+    print("  ! still grading after 60s — screenshots of the result page may show the spinner")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rest", default="http://127.0.0.1:3051")
+    ap.add_argument("--otlp", default="http://127.0.0.1:4351")
+    ap.add_argument("--keep-active", action="store_true",
+                    help="Do not terminate the run, so the live run page shows an ACTIVE run.")
+    ap.add_argument("--i-know-this-is-not-my-real-instance", action="store_true")
+    args = ap.parse_args()
+
+    if ":3001" in args.rest and not args.i_know_this_is_not_my_real_instance:
+        raise SystemExit(
+            "refusing to seed http://…:3001 — that is the default port, and this script "
+            "registers agents and starts runs. Boot a throwaway instance on another port "
+            "(XORCISE_HOME + XORCISE_REST_PORT), or pass "
+            "--i-know-this-is-not-my-real-instance."
+        )
+
+    health = _request("GET", f"{args.rest}/api/health", timeout=10.0)
+    print(f"instance: {args.rest} ({health})")
+
+    print("agents:")
+    seed_agents(args.rest)
+    print("missions:")
+    seed_missions(args.rest)
+    print("run:")
+    run_id = create_run(args.rest)
+    replay_telemetry(args.otlp, run_id)
+    time.sleep(2)  # let the collector commit the batches before anything reads them
+    if not args.keep_active:
+        seal(args.rest, run_id)
+
+    # The spec needs the run id; stdout's last line is the contract.
+    print(f"RUN_ID={run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The screenshots on docs.xorcise.ai were shot by hand and had no way to notice the product moved. All twelve are dated **4 Aug**; the console design system landed **21 Aug** in #59. So today the live docs show:

- a sidebar reading **"Challenges"** — renamed to "Missions" back in July
- the pre-design-system **uppercase button labels** that #59 replaced
- an Agents page full of test debris: `test-cli-renamed`, `cli-json-emmit`, `walking-skeleton`, `b`

Nobody did anything wrong. Hand-shot images rot silently, and these rotted in public.

## What this adds

**`scripts/seed_docs_state.py`** — drives a throwaway instance through the REST API and OTLP receiver until every photographed page has real content: three agents on the three built-in harnesses, two missions installed against 26 available, and a run replaying a genuinely captured claude-code trace from `tests/fixtures/otlp/`. Only the `xorcise.run_id` resource attribute is rewritten; nothing else about the capture is touched.

It seeds through the same public surfaces an operator uses, so a change that breaks seeding is a change that broke the product — not a stale fixture. It refuses `:3001` without an explicit override, because it registers agents and starts runs.

**`frontend/e2e/docs-screenshots.spec.ts`** — drives the real UI. Not part of `npm run test:e2e` (it needs seeded state and writes files), so it gets its own `npm run screenshots`.

## Two design decisions worth reviewing

**Element-scoped crops, not pixel boxes.** A moved button still yields a correct crop; a hardcoded rectangle silently photographs the wrong thing.

**No baked-in numbered markers.** An annotated PNG can't be regenerated without a human re-annotating it — the exact rot this replaces. Crop to the control instead. It turned out several console forms already carry their own numbered steps, which is better than anything painted on top.

## Two limits, recorded in the spec

Found by hitting them, and written down so they aren't rediscovered:

- Under `--stub` the run environment never leaves `starting`, so `awaitingAgent` is never true and the connect prompt + launch-mode toggle never mount. Sending telemetry doesn't help — that ends the awaiting state from the other side.
- With no judge configured a run grades 0%, so the result and performance pages photograph poorly.

Both shots need a real instance. The spec **skips them naming the reason** rather than writing a misleading image.

## Verification

Ran end to end against a throwaway stub instance (`XORCISE_HOME` + port 3051, isolated from the default):

```
12 passed (9.6s)
```

Twelve images produced. Four are already merged into the docs repo — `agents`, `missions`, `runs`, `traces` plus two new step crops — after visual inspection. `dashboard`, `setup`, `results`, `performance` and `settings` were **held back**: under stub mode `/ui/` routes to Setup with a "Docker ACTION NEEDED" banner, and the graded pages show 0%. They need a real-instance pass.

## Note for the reviewer

Output is gitignored here. The PNGs live in the docs repository; a second copy beside the generator would fork the source of truth and let the two drift — the problem this exists to solve.